### PR TITLE
chore(build): ADR-0085 の manual acceptance gate を退役する

### DIFF
--- a/.ja/skills/dr/tests/script-contract.test.js
+++ b/.ja/skills/dr/tests/script-contract.test.js
@@ -72,8 +72,6 @@ test("live な指示と規約に旧称 ADR が残っていない", () => {
   for (const [lang, [path, declaration]] of Object.entries(fowler)) {
     assert.match(readFileSync(path, "utf8"), declaration, `${lang}: 除外の根拠を本文が宣言する`);
   }
-  // build の manual acceptance を通す環境変数名。prose ではなく knob なので改名しない。
-  const ENV_KNOB = /ADR0085_MANUAL_ACCEPTANCE/g;
   // when_to_use は利用者が打つ語の一覧。旧称で呼ぶ人に届かせるため ADR も並べておく。
   const TRIGGERS = /^when_to_use:.*$/gm;
   const scanned = [];
@@ -87,7 +85,7 @@ test("live な指示と規約に旧称 ADR が残っていない", () => {
         const rel = full.slice(join(root, prefix).length + 1);
         if (EXEMPT.includes(rel) || rel.includes("__pycache__")) continue;
         scanned.push(rel);
-        const text = readFileSync(full, "utf8").replace(ENV_KNOB, "").replace(TRIGGERS, "");
+        const text = readFileSync(full, "utf8").replace(TRIGGERS, "");
         assert.doesNotMatch(text, /\bADRs?\b/, `${prefix || "en"}: ${rel} に旧称 ADR が残る`);
       }
     }

--- a/.ja/workflows/build/tests/build.behavior.test.js
+++ b/.ja/workflows/build/tests/build.behavior.test.js
@@ -1080,15 +1080,3 @@ test("translate-tail の訳 id が入力と一致しないなら英語原文で 
   );
   assert.ok(!shipCalls[0].prompt.includes("only one"), "id 不一致の訳は採用されない");
 });
-
-test("実環境で Plan 節付き issue が Load → Revalidate → Branch → Code → Cleanup → Verify と進む (manual acceptance、done 前必須)", () => {
-  // harness green だけで完了にしないための manual gate。実際に build workflow を
-  // Plan 節付きの実 issue で起動し、phase log が
-  // Load → Revalidate → Branch → Code → Cleanup → Verify の順に出て PR tail に /audit 案内が載ることを
-  // 確認したら ADR0085_MANUAL_ACCEPTANCE=pass を付けてテストを実行する。
-  assert.equal(
-    process.env.ADR0085_MANUAL_ACCEPTANCE,
-    "pass",
-    "manual acceptance 未実施。実 issue で build workflow を起動して確認後、ADR0085_MANUAL_ACCEPTANCE=pass で再実行する",
-  );
-});

--- a/docs/wiki/pre-existing-failure-disclosure.md
+++ b/docs/wiki/pre-existing-failure-disclosure.md
@@ -11,10 +11,6 @@ PR の verify でテストが失敗したとき、その PR の変更に起因�
 3. 意図的な gate (env 変数や手動受け入れ待ち) は、gate であることと解除条件を書く
 4. 変更起因の失敗と件数を分けて書く
 
-## 参照コード
-
-- `workflows/build/tests/build.behavior.test.js` の `ADR0085_MANUAL_ACCEPTANCE` gate (env 未設定のとき意図的に fail するテスト)
-
 ## 根拠
 
 - #167 #178 #179 #180 変更起因でない fail を verify 節で切り分ける運用の初出

--- a/skills/dr/tests/script-contract.test.js
+++ b/skills/dr/tests/script-contract.test.js
@@ -72,8 +72,6 @@ test("live な指示と規約に旧称 ADR が残っていない", () => {
   for (const [lang, [path, declaration]] of Object.entries(fowler)) {
     assert.match(readFileSync(path, "utf8"), declaration, `${lang}: 除外の根拠を本文が宣言する`);
   }
-  // build の manual acceptance を通す環境変数名。prose ではなく knob なので改名しない。
-  const ENV_KNOB = /ADR0085_MANUAL_ACCEPTANCE/g;
   // when_to_use は利用者が打つ語の一覧。旧称で呼ぶ人に届かせるため ADR も並べておく。
   const TRIGGERS = /^when_to_use:.*$/gm;
   const scanned = [];
@@ -87,7 +85,7 @@ test("live な指示と規約に旧称 ADR が残っていない", () => {
         const rel = full.slice(join(root, prefix).length + 1);
         if (EXEMPT.includes(rel) || rel.includes("__pycache__")) continue;
         scanned.push(rel);
-        const text = readFileSync(full, "utf8").replace(ENV_KNOB, "").replace(TRIGGERS, "");
+        const text = readFileSync(full, "utf8").replace(TRIGGERS, "");
         assert.doesNotMatch(text, /\bADRs?\b/, `${prefix || "en"}: ${rel} に旧称 ADR が残る`);
       }
     }

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -1080,15 +1080,3 @@ test("translate-tail の訳 id が入力と一致しないなら英語原文で 
   );
   assert.ok(!shipCalls[0].prompt.includes("only one"), "id 不一致の訳は採用されない");
 });
-
-test("実環境で Plan 節付き issue が Load → Revalidate → Branch → Code → Cleanup → Verify と進む (manual acceptance、done 前必須)", () => {
-  // harness green だけで完了にしないための manual gate。実際に build workflow を
-  // Plan 節付きの実 issue で起動し、phase log が
-  // Load → Revalidate → Branch → Code → Cleanup → Verify の順に出て PR tail に /audit 案内が載ることを
-  // 確認したら ADR0085_MANUAL_ACCEPTANCE=pass を付けてテストを実行する。
-  assert.equal(
-    process.env.ADR0085_MANUAL_ACCEPTANCE,
-    "pass",
-    "manual acceptance 未実施。実 issue で build workflow を起動して確認後、ADR0085_MANUAL_ACCEPTANCE=pass で再実行する",
-  );
-});


### PR DESCRIPTION
## What & Why

Closes #229

実 build での受け入れを実施しない判断に伴い、その受け入れを要求するテストを削除する。gate を残すと env 未設定の `bun test` が恒久的に赤のまま残り、変更起因の失敗と見分けがつかなくなる。

受け入れの相乗り先として #229 が挙げていた候補 (#227 / #225 / #215) はクローズ済みで、#217 は Plan 節を持たない。現存する Plan 節あり issue は #216 のみで、その Plan は tested unit が 2 つあるのに `seam: true` の記載が無く Load 段で止まる。ADR-0089 で Plan 節なし側の観察も実行不能になった。

## Changes

- `workflows/build/tests/build.behavior.test.js` (+ `.ja`): manual acceptance gate のテストを削除
- `skills/dr/tests/script-contract.test.js` (+ `.ja`): 旧称スキャンの `ENV_KNOB` 除外を削除。対象文字列が消えたため
- `docs/wiki/pre-existing-failure-disclosure.md`: 参照コード節を削除。根拠の履歴 (#220 / #226) は事実として残す

## How to Test

`bun test ./workflows ./.ja/workflows ./skills ./agents ./hooks` で 202 pass / 0 fail。env 変数なしで緑になる。

## Trade-off

build を実環境で一度も通していない事実を見張る仕組みが無くなる。ADR-0085 の Load 経路は ADR-0089 でさらに変わっており、実走確認は未実施のまま残る。

https://claude.ai/code/session_016vhTCQg6dsgUPguDyzcLPu