### PR TITLE
fix(hooks): fast-uri を 3.1.4 へ更新する (CVE-2026-13676)

### DIFF
--- a/hooks/textlint/bun.lock
+++ b/hooks/textlint/bun.lock
@@ -257,7 +257,7 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+    "fast-uri": ["fast-uri@3.1.4", "", {}, "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw=="],
 
     "fault": ["fault@1.0.4", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA=="],
 


### PR DESCRIPTION
## Summary

hooks/textlint の間接依存 fast-uri 3.1.0 に CVE-2026-13676 (Unicode ホスト名正規化の不備によるポリシーバイパス) があるため、修正版 3.1.4 へ更新する。

依存経路は textlint → ajv → fast-uri で、ajv の要求範囲 `^3.0.1` に 3.1.4 が収まるため、変更は bun.lock の 1 行のみ。直接依存への昇格も package-lock.json の追加もしない。

#275 (ボット生成) は npm の package-lock.json を追加する一方で bun.lock を更新しておらず、実インストール版が 3.1.0 のまま残るため、本 PR で置き換える。

## Verification

- `bun install` が lock 追加変更なしで完了
- `node_modules/fast-uri` が 3.1.4
- `bunx textlint --stdin` でルール込みの lint が動作

Closes #275 の代替。

https://claude.ai/code/session_01QP8kgVY1zSnYQjs6m6Mqfn