### PR TITLE
fix(audit): ROUTING に無いキーを引く classify の分岐を削除する

### DIFF
--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -209,7 +209,6 @@ const classify = (p) => {
   if (e === ".rs") return ROUTING["*.rs"];
   if (e === ".py") return ROUTING["*.py"];
   if (e === ".md") return ROUTING["*.md"];
-  if (e === ".yaml" || e === ".yml" || e === ".json") return ROUTING["*.yaml,*.json"];
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -210,7 +210,6 @@ const classify = (p) => {
   if (e === ".rs") return ROUTING["*.rs"];
   if (e === ".py") return ROUTING["*.py"];
   if (e === ".md") return ROUTING["*.md"];
-  if (e === ".yaml" || e === ".yml" || e === ".json") return ROUTING["*.yaml,*.json"];
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };

--- a/workflows/audit/tests/audit.routing.test.js
+++ b/workflows/audit/tests/audit.routing.test.js
@@ -1,0 +1,58 @@
+// classify() が返す reviewer 一覧は assert しない。ROUTING の中身を固定すると
+// 表の編集ごとに落ちる change detector になるため。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const auditJs = join(here, "..", "..", "audit.js");
+
+// Challenge 以降の stub は置かない。reviewer label に undefined を返すと findings が
+// 空になり、assignments を持つ早期 return に落ちるため。
+const routeOnlyStub = (files) => (prompt, opts) => {
+  if (opts && opts.label === "route") {
+    return { files: files.map((path) => ({ path, churn: 0 })) };
+  }
+  return undefined;
+};
+
+const runRoute = async (files) => {
+  const { result } = await runWorkflow(auditJs, {
+    args: { skipPreflight: true },
+    stubs: { agent: routeOnlyStub(files) },
+  });
+  return result;
+};
+
+const unassigned = (result, files) => {
+  const assigned = new Set(result.assignments.flatMap((a) => a.files));
+  return files.filter((p) => !assigned.has(p));
+};
+
+test("yaml と yml と json を含む diff で audit が Route 段を通過し 3 ファイルとも assignments に載る", async () => {
+  const files = ["config.yaml", "ci.yml", "package.json"];
+
+  const result = await runRoute(files);
+
+  assert.deepEqual(unassigned(result, files), [], "assignments から漏れたファイルは無い");
+});
+
+test("classify がソース上で分岐する全拡張子について、そのファイルが assignments のいずれかに載る", async () => {
+  // 拡張子はテスト側に列挙しない。classify に分岐が増えたとき追随できないため。
+  // `[".yaml", ".yml"].includes(e)` のような形で分岐を足すとこの抽出からは漏れる。
+  const source = readFileSync(auditJs, "utf8");
+  const extensions = [...source.matchAll(/\be === "(\.[a-z0-9]+)"/g)].map((m) => m[1]);
+  assert.notEqual(extensions.length, 0, "audit.js から拡張子の分岐を抽出できる");
+
+  // `.yaml` のような先頭ドットだけのパスは使わない。ext() が "" を返し、分岐を
+  // 通らないまま ROUTING.default に落ちるため。stem に test を含めないのは
+  // classify 先頭の test 判定に吸われるため。
+  const files = extensions.map((e, i) => `src/sample-${i}${e}`);
+
+  const result = await runRoute(files);
+
+  assert.deepEqual(unassigned(result, files), [], "assignments から漏れたファイルは無い");
+});


### PR DESCRIPTION
## What & Why

yaml/yml/json を含む diff の audit が Route 段でクラッシュしていた。classify() が ROUTING に無いキー `"*.yaml,*.json"` を引いて undefined を返し、`for (const r of classify(f.path))` が TypeError を投げるため、reviewer が 1 体も起動しない。commit 658e1eec が reviewer-encapsulation と reviewer-document の retire に伴って ROUTING の該当行を削除したとき、classify() 側の参照行が残ったのが原因。

## Review focus

- 見てほしいのは `workflows/audit/tests/audit.routing.test.js` の T-002。拡張子一覧を audit.js のソースから抽出する形が、将来 classify に分岐が増えたとき本当に追随するか
- `.ja/workflows/audit.js` と `workflows/audit.js` の削除行は同一なので流し読みでよい
- migration とロールバックの risk は無い。分岐 1 行の削除で、revert すれば元の挙動に戻る

## Changes

- classify() の yaml/yml/json 分岐を削除し、default 行 (duplication, reuse, efficiency) へ合流させた
- 回帰テスト 2 本を追加した。1 本は yaml/yml/json が assignments に載ることを固定し、もう 1 本は classify がソース上で分岐する全拡張子を同じ観点で押さえる

## Scope

- Not included: FOCUS.quality の readability と causation がどの ROUTING 行にも無く dispatch されない件。同じ形の desync だが #276 の backlog candidates に記録して別扱いにした
- Not included: retire 済み reviewer-encapsulation が `agents/_lib/finding-schema.md` に残っている件も同じく backlog

## Design Decisions

- キーを復活させず参照行を削除した。658e1eec のコミットメッセージが「\*.yaml,\*.json 経路は削除し default へ」と意図を書いており、参照先の reviewer 2 体も `agents/` から削除済みで復活先が無い
- ROUTING のキーから拡張子を導出して if 連鎖を廃止する案は採らなかった。`.yml` はどのキーにも現れず test と default は特殊行なのでパースと特殊ケースが残り、同クラスの FOCUS↔ROUTING desync は 1 件も解けないため
- テストは reviewer 一覧そのものを assert しない。ROUTING の中身を固定すると表の編集ごとに落ちる change detector になるため、assignments に載るかどうかだけを見ている

## How to Test

1. リポジトリルートで `node --test workflows/tests/` を実行する
2. 110 tests/110 pass/0 fail になる (このブランチの前は 108 pass)
3. `git checkout main -- workflows/audit.js` で実装だけ修正前に戻して同じコマンドを実行すると、追加した 2 本が `TypeError: classify is not a function or its return value is not iterable` で落ちる。確認後は `git checkout HEAD -- workflows/audit.js` で戻す

## Related

- Closes #276
