### PR TITLE
fix(build): DR 参照削除で残った行頭ピリオドを直す

### DIFF
--- a/workflows/build.js
+++ b/workflows/build.js
@@ -737,8 +737,8 @@ const cleanup = (await agent(
 log(`Cleanup: ${cleanup.edits.length} edit(s), tests_pass=${cleanup.tests_pass}.`);
 
 // ---- Verify: deterministic selection checks (diff scope + T-NNN presence) ∥ conformance ----
-// Correctness checking compares against the plan's anchors, not a defect hunt
-//. Static analysis belongs to the edit-time gates hooks; heavy assurance
+// Correctness checking compares against the plan's anchors, not a defect hunt.
+// Static analysis belongs to the edit-time gates hooks; heavy assurance
 // is human-invoked /audit on the PR. Both checks fail open and surface on the PR.
 // conformance is the only LLM review; its findings go to a dedicated PR section.
 


### PR DESCRIPTION
## 何を変えたか

`workflows/build.js` の Verify セクション冒頭のコメントで、行頭に取り残されたピリオドを前行の文末へ戻した。

```
-// Correctness checking compares against the plan's anchors, not a defect hunt
-//. Static analysis belongs to the edit-time gates hooks; heavy assurance
+// Correctness checking compares against the plan's anchors, not a defect hunt.
+// Static analysis belongs to the edit-time gates hooks; heavy assurance
```

## なぜ

#301 で inline の `(DR-0085)` を落とした際、文末のピリオドだけが次行の行頭に残った。canonical の `.ja/workflows/build.js:711` は 1 文でつながっており、この崩れは英語側にのみ出ている。MIRROR.md の通り英語側は実行物であって意図の正ではないため、canonical への反映は不要。

## 検証

`node --test workflows/build/tests/*.test.js` が 50 件 pass。コメントのみの変更で挙動は変わらない。

https://claude.ai/code/session_019nFr2sMvsnBhVGvJfn9NpL