### PR TITLE
feat(audit): finding ごとの verdict を記録して刈られた経路を追えるようにする

### DIFF
--- a/.ja/skills/census/scripts/list-source-files.py
+++ b/.ja/skills/census/scripts/list-source-files.py
@@ -1,7 +1,7 @@
-"""List source files in a tree, largest first.
+"""ツリー内のソースファイルを行数降順で一覧する。
 
 Usage: list-source-files.py <repo-root>
-Output: "<lines> <path>" per line, sorted descending.
+Output: 1 行 1 ファイルで "<行数> <パス>" を降順出力。
 """
 import os
 import sys

--- a/.ja/skills/dr/scripts/dr_common.py
+++ b/.ja/skills/dr/scripts/dr_common.py
@@ -1,4 +1,4 @@
-"""Shared helpers for the dr skill scripts."""
+"""dr skill のスクリプトが共有するヘルパー。"""
 
 import os
 import re
@@ -33,7 +33,7 @@ def resolve_dr_dir(arg=None):
 
 
 def guard_skill_dir(dr_dir, hint):
-    """Reject the skill-definition directory itself as a Decision Record archive."""
+    """skill 定義ディレクトリ自体を Decision Record の置き場として受け付けない。"""
     if (dr_dir / "SKILL.md").is_file():
         fail(
             f"Error: {dr_dir} contains SKILL.md (skill-definition directory,"
@@ -43,11 +43,11 @@ def guard_skill_dir(dr_dir, hint):
 
 
 def split_frontmatter(text):
-    """(frontmatter lines, body lines).
+    """(frontmatter の行, body の行) を返す。
 
-    Frontmatter only when the file opens with a --- line and has a closing ---
-    line. A --- elsewhere (e.g. a body horizontal rule) is never a delimiter, and
-    an unclosed opening --- yields no frontmatter.
+    frontmatter と見なすのは、ファイルが --- の行で始まり、閉じる --- の行を持つ
+    ときだけ。それ以外の位置にある --- (body の水平線など) は区切りにしない。
+    開いたまま閉じない --- は frontmatter 無しとして扱う。
     """
     lines = text.splitlines()
     fence = re.compile(r"^---[ \t]*$")

--- a/.ja/skills/dr/scripts/pre-check.py
+++ b/.ja/skills/dr/scripts/pre-check.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Usage: pre-check.py "DR Title"
 
-stdout: JSON with status, number, filename, slug, date, dr_dir, similar_drs
-stderr: validation failures with exit 1
+stdout: status, number, filename, slug, date, dr_dir, similar_drs を持つ JSON
+stderr: 検証に落ちた内容。exit 1
 """
 
 import json
@@ -15,7 +15,7 @@ from dr_common import fail, guard_skill_dir, resolve_dr_dir
 
 
 def similarity(title_a, title_b):
-    """Shared distinct words between the titles, divided by title_a's word count."""
+    """2 つのタイトルで共通する語の異なり数を、title_a の語数で割った値。"""
     words_a = title_a.lower().split()
     if not words_a:
         return 0.0

--- a/.ja/skills/dr/scripts/update-index.py
+++ b/.ja/skills/dr/scripts/update-index.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Usage: update-index.py [dr-directory]
 
-Regenerates <dr-dir>/README.md from the Decision Record files.
-stdout: path to the updated index file
-stderr: directory not found etc. with exit 1
+Decision Record のファイル群から <dr-dir>/README.md を再生成する。
+stdout: 更新した index ファイルのパス
+stderr: ディレクトリ不在などの失敗内容。exit 1
 """
 
 import os

--- a/.ja/workflows/assert/worktree.py
+++ b/.ja/workflows/assert/worktree.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
 """Usage:
-  worktree.py <session-id>             Create a fresh assert worktree
-  worktree.py --cleanup <session-id>   Remove the assert worktree and its branch
+  worktree.py <session-id>             assert worktree を新規作成する
+  worktree.py --cleanup <session-id>   assert worktree とその branch を削除する
 
-The branch and path are derived from the session id so creation and cleanup
-never drift: branch = assert-<id>, path = .claude/worktrees/assert-<id>. git runs
-from the process cwd (the repo root), so the path is relative to it.
+branch と path は session id から導出するため、作成と cleanup が drift しない。
+branch = assert-<id>、path = .claude/worktrees/assert-<id>。git はプロセスの cwd
+(repo root) から実行するため、path はそこからの相対。
 
-Create removes any stale worktree and branch first, then adds a fresh one from
-HEAD.
+作成はまず古い worktree と branch を除去し、続けて HEAD から新規に add する。
 
 stdout (create):  JSON {branch, path, status: "created"}
 stdout (cleanup): JSON {branch, path, status: "removed"}
-On create failure: JSON {branch, path, status: "error", reason, stderr}, exit 1
-(env failure, references/phase-4.md § Bootstrap Failure Handling). Cleanup
-is best-effort: stale-state removals are ignored and it never fails the run.
+作成失敗時: JSON {branch, path, status: "error", reason, stderr}、exit 1
+(env failure、references/phase-4.md § Bootstrap Failure Handling)。cleanup は
+best-effort で、古い状態の除去失敗は無視し run を失敗させない。
 """
 
 import json
@@ -34,13 +33,13 @@ def paths(session_id):
 
 
 def _remove(branch, path, runner):
-    """Best-effort removal of a worktree and its branch. Errors are ignored."""
+    """worktree とその branch を best-effort で除去する。エラーは無視する。"""
     runner(["git", "worktree", "remove", path, "--force"])
     runner(["git", "branch", "-D", branch])
 
 
 def create(session_id, runner=_real_runner):
-    """Remove any stale worktree, then create a fresh one. Return the result dict."""
+    """古い worktree を除去してから新規作成する。結果 dict を返す。"""
     branch, path = paths(session_id)
     _remove(branch, path, runner)
     rc, stderr = runner(["git", "worktree", "add", "-b", branch, path, "HEAD"])
@@ -56,7 +55,7 @@ def create(session_id, runner=_real_runner):
 
 
 def cleanup(session_id, runner=_real_runner):
-    """Remove the worktree and branch. Return the result dict (never errors)."""
+    """worktree と branch を除去する。結果 dict を返す (エラーにはならない)。"""
     branch, path = paths(session_id)
     _remove(branch, path, runner)
     return {"branch": branch, "path": path, "status": "removed"}

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -63,21 +63,27 @@ const bundled = (rel) =>
 //
 // payload は prompt に埋め込む形でしか agent に渡せず、agent が書き写す途中で要約すると
 // record だけが痩せる。実測では findings の summary が長い run で raw_findings 44 件が 2 件に
-// なり、tally との矛盾に気づくまで検出できなかった。書き出した record を読み返させて件数を
-// 返させ、script 側で期待値と照合する。
+// なった。件数を agent に自己申告させると切り詰めた当人が報告することになるので、stdin を
+// 受けた snapshot.py が数えた値 (stdout の counts) を持ち帰らせ、script 側で照合する。
 const SNAPSHOT_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["path", "raw_findings_count", "findings_count"],
+  required: ["path", "counts"],
   properties: {
-    path: { type: "string", description: "snapshot.py が stdout に出力したパス" },
-    raw_findings_count: {
-      type: "integer",
-      description: "書き出した record を読み返した raw_findings の要素数。payload の値ではない",
-    },
-    findings_count: {
-      type: "integer",
-      description: "書き出した record を読み返した findings の要素数。payload の値ではない",
+    path: { type: "string", description: "snapshot.py の stdout JSON の path をそのまま" },
+    counts: {
+      type: "object",
+      additionalProperties: false,
+      required: ["raw_findings", "findings", "skipped", "needs_context", "zero_reviewer_files"],
+      description:
+        "snapshot.py の stdout JSON の counts をそのまま。自分で数え直さず、値を書き換えない",
+      properties: {
+        raw_findings: { type: "integer" },
+        findings: { type: "integer" },
+        skipped: { type: "integer" },
+        needs_context: { type: "integer" },
+        zero_reviewer_files: { type: "integer" },
+      },
     },
   },
 };
@@ -115,11 +121,11 @@ const writeSnapshot = async ({
         `\`python3 ${bundled("workflows/audit/snapshot.py")} < <tempfile>\` を 1 回実行する。` +
         `スクリプトが timestamp・branch・prior snapshot との delta ` +
         `(file + message でマッチした resolved / new / carried) を解決し、` +
-        `$HOME/.claude/history/ に記録を書いて出力パスを stdout に返す。` +
+        `$HOME/.claude/history/ に記録を書き、{path, counts} の JSON 1 行を stdout に返す。` +
         `payload は一字一句そのまま書く。要約・省略・整形・再生成はしない。長さを理由に切り詰めない。` +
         `コードの review や finding の変更はしない。他の方法でファイルを書かない。` +
-        `書き終えたら出力パスの record を読み返し、raw_findings と findings の実際の要素数を返す。` +
-        `payload に書いてある数ではなく、ディスク上の record を数えた値を返す。Payload は次のとおり。\n${payload}`,
+        `stdout の JSON をそのまま path と counts として返す。counts は自分で数え直さず、値を書き換えない。` +
+        `Payload は次のとおり。\n${payload}`,
     ),
     {
       agentType: "general-purpose",
@@ -131,21 +137,29 @@ const writeSnapshot = async ({
       schema: SNAPSHOT_SCHEMA,
     },
   );
-  // 照合は script が持つ。agent 自身に「切り詰めていないか」を判定させると、切り詰めた当人が
-  // 自己申告することになる。
-  const expected = { raw: rawFindings.length, findings: findings.length };
+  // 照合は script が持つ。突き合わせる相手は snapshot.py が数えた counts で、agent の
+  // 申告ではない。agent は書き写す当人なので、自分が削った分を自分で報告することになる。
+  const expected = {
+    raw_findings: rawFindings.length,
+    findings: findings.length,
+    skipped: skipped.length,
+    needs_context: needsContext ? needsContext.length : 0,
+    zero_reviewer_files: zeroReviewerFiles ? zeroReviewerFiles.length : 0,
+  };
   if (!written) {
     log(`Snapshot: agent が結果を返さなかった。record が書かれたかは未確認。`);
     return { written: false, truncated: null, expected };
   }
-  const actual = { raw: written.raw_findings_count, findings: written.findings_count };
-  const truncated = actual.raw !== expected.raw || actual.findings !== expected.findings;
-  if (truncated) {
+  const actual = written.counts;
+  const lost = Object.keys(expected).filter((k) => actual[k] !== expected[k]);
+  if (lost.length) {
     log(
-      `Snapshot truncated: raw_findings ${actual.raw}/${expected.raw}、findings ${actual.findings}/${expected.findings}。record は刈り率の計測に使えない。`,
+      `Snapshot truncated: ${lost
+        .map((k) => `${k} ${actual[k]}/${expected[k]}`)
+        .join("、")}。record は刈り率の計測に使えない。`,
     );
   }
-  return { written: true, path: written.path, truncated, expected, actual };
+  return { written: true, path: written.path, truncated: lost.length > 0, lost, expected, actual };
 };
 
 // /audit の routing 表。react-pattern は JSX を含む拡張子 (jsx / tsx) にだけ付け、素の js の

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -58,7 +58,20 @@ const bundled = (rel) =>
 // timestamp・branch・prior snapshot との delta 計算は audit/snapshot.py が行う。agent は
 // payload を一時ファイルに書いてそのスクリプトを 1 回叩くだけで、disk への副作用が目的、
 // 戻り値は使わない。
-const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped, challengeRan }) => {
+// snapshot.py の build_record は payload を dict() でそのまま通すので、ここで払い出した
+// キーがそのまま record の項目になる。返り値にしか無い項目は record から読めないため、
+// 刈り率と 0 reviewer のファイルは payload 側にも渡す。tally は challengeRan が false の
+// とき undefined を渡し、JSON.stringify にキーごと落とさせる。fail-open した run が件数を
+// 持つと、全件 confirmed だった run と record 上で見分けがつかなくなる。
+const writeSnapshot = async ({
+  preFlight,
+  rawFindings,
+  findings,
+  skipped,
+  challengeRan,
+  tally,
+  zeroReviewerFiles,
+}) => {
   phase("Snapshot");
   const payload = JSON.stringify({
     scope: scope || "HEAD",
@@ -68,6 +81,8 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped, challe
     findings,
     skipped,
     challenge_ran: challengeRan,
+    tally,
+    zero_reviewer_files: zeroReviewerFiles,
   });
   await agent(
     anchor(
@@ -478,7 +493,14 @@ const skipped = units
   }));
 
 if (!findings.length) {
-  await writeSnapshot({ preFlight, rawFindings, findings: [], skipped, challengeRan: false });
+  await writeSnapshot({
+    preFlight,
+    rawFindings,
+    findings: [],
+    skipped,
+    challengeRan: false,
+    zeroReviewerFiles,
+  });
   return {
     findings: [],
     assignments,
@@ -592,6 +614,16 @@ for (const f of rawFindings) {
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
+// challenge_ran は「challenge が実際に verdicts を返した run」と fail-open した run
+// (challenged が null / undefined → verdictById が空 → 全 finding が no_verdict 経由で
+// confirmed に落ちる) を区別する。tally は triage の件数を運び、呼び出し元が survivors /
+// needsContext / noVerdict から再計算せずに読めるようにする。
+const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
+const tally = {
+  survived: survivors.length,
+  needs_context: needsContext.length,
+  no_verdict: noVerdict,
+};
 
 phase("Integrate");
 // membership は上の triage ループで既に決まっている。Integrate への入力は survivors のみで、
@@ -636,11 +668,15 @@ await writeSnapshot({
   findings: finalFindings,
   skipped,
   challengeRan,
+  tally: challengeRan ? tally : undefined,
+  zeroReviewerFiles,
 });
 return {
   findings: finalFindings,
   survivors,
   needs_context: needsContext,
+  challenge_ran: challengeRan,
+  tally,
   assignments,
   skipped,
   zero_reviewer_files: zeroReviewerFiles,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -444,17 +444,59 @@ if (!findings.length) {
 // ---- Challenge ∥ Verify -> Integrate。reviewer -> aggregate は禁止 ----
 // 同じ findings に独立した 2 pass を並行で当て、Integrate が固定規則で reconcile する。
 const findingsJson = JSON.stringify(findings);
+// workflows/polish.js の VERDICTS_SCHEMA (id/verdict/severity/why) の形を踏襲する。
+// severity の enum はこのファイル自身の FINDINGS_SCHEMA (critical/high/medium/low) に
+// 合わせ、polish の P1/P2/P3 は使わない。2 つの workflow は severity の物差しが異なるため。
+const VERDICTS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["verdicts"],
+  properties: {
+    verdicts: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "verdict"],
+        properties: {
+          id: { type: "string" },
+          verdict: {
+            type: "string",
+            enum: ["confirmed", "disputed", "downgraded", "needs_context"],
+          },
+          severity: {
+            type: "string",
+            enum: ["critical", "high", "medium", "low"],
+          },
+          why: { type: "string" },
+        },
+      },
+    },
+  },
+};
+// critic への入力は rawFindings (R-N id の出どころ) から reviewer フィールドを外したもの。
+// どの reviewer が挙げた finding かで challenge の verdict が偏らないようにする。
+const challengeInput = rawFindings.map((f) => ({
+  id: f.id,
+  file: f.file,
+  line: f.line,
+  severity: f.severity,
+  summary: f.message,
+}));
 const [challenged, verified] = await parallel([
   () =>
     agent(
       anchor(
-        `critic-audit として、これらの finding を challenge し false positive を刈る。finding は事実ではなく、立証されるべき主張として扱う。各 finding は file:line で参照する。Findings は次のとおり。\n${findingsJson}`,
+        `critic-audit として、これらの finding を challenge し false positive を刈る。finding は事実ではなく、立証されるべき主張として扱う。各 finding は id で参照する。\n` +
+          `verdict の判定基準は次のとおり。confirmed = 実在し severity も妥当 / disputed = false positive / downgraded = 実在するが severity が過大 (下げた値を severity に入れる) / needs_context = コードだけでは判定できず人間の文脈が要る。\n` +
+          `Findings は次のとおり。\n${JSON.stringify(challengeInput)}`,
       ),
       {
         agentType: "critic-audit",
         phase: "Challenge",
         label: "challenge",
         model: "sonnet",
+        schema: VERDICTS_SCHEMA,
         // judge 段は難易度軸で xhigh を選ぶ (docs の "the hardest coding and agentic tasks")。
         // 所要時間は数分で long-horizon の基準には届かないが、finding を退ける判断の質が
         // false positive を左右するので token でなく精度側に振る。
@@ -476,12 +518,40 @@ const [challenged, verified] = await parallel([
     ),
 ]);
 
+// ---- Triage: survivor 判定はスクリプトが持ち、critic は verdict を返すだけ ----
+// verdict 側でなく finding 側を回すことで、challenge agent が verdict を付け忘れた
+// finding も取りこぼさない。confirmed 扱いで survivors に残し no_verdict として計上する。
+// challenge agent が丸ごと失敗した場合 (verdict 一覧が空) も全件が同じ no_verdict 経路を
+// 通るので、fail-open が呼び出し元から劣化と分かる形で残る。
+const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
+const survivors = [];
+const needsContext = [];
+let noVerdict = 0;
+for (const f of rawFindings) {
+  const v = verdictById.get(f.id);
+  if (!v) {
+    noVerdict++;
+    survivors.push({ ...f });
+    continue;
+  }
+  if (v.verdict === "disputed") continue;
+  if (v.verdict === "needs_context") {
+    needsContext.push({ ...f, why: v.why || "" });
+    continue;
+  }
+  const severity = v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
+  survivors.push({ ...f, severity });
+}
+log(
+  `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
+);
+
 phase("Integrate");
 const integrated = await agent(
   anchor(
     `enhancer-integration として、同じ findings に対する独立した 2 つの pass を file:line で突き合わせ、cross-domain の root cause と severity 順のリストに reconcile する。\n` +
       `Membership 規則。どの finding を残すかは challenge pass が決める。challenge pass が false positive として刈った finding は、verification pass が evidence を見つけていても刈られたままにする。verification pass の役割は survivor に実行経路の evidence と severity を与えることだけで、刈られた finding を復活させない。\n` +
-      `Challenge pass (membership / false positive の刈り込み) は次のとおり。\n${challenged}\n\n` +
+      `Challenge pass (membership / false positive の刈り込み) は次のとおり。\n${JSON.stringify(challenged)}\n\n` +
       `Verification pass (実行経路の evidence + severity) は次のとおり。\n${verified}`,
   ),
   {
@@ -501,4 +571,10 @@ await writeSnapshot({
   findings: finalFindings,
   skipped,
 });
-return { findings: finalFindings, assignments, skipped };
+return {
+  findings: finalFindings,
+  survivors,
+  needs_context: needsContext,
+  assignments,
+  skipped,
+};

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -176,11 +176,9 @@ const FOCUS = {
   security: ["security", "silence"],
   performance: ["react-pattern", "efficiency", "progressive"],
   quality: [
-    "readability",
     "design",
     "react-pattern",
     "rust",
-    "causation",
     "resilience",
     "duplication",
     "reuse",
@@ -188,10 +186,18 @@ const FOCUS = {
     "operations",
     "prompt",
     "silence",
+    "coverage",
   ],
   a11y: ["accessibility", "progressive"],
   all: null,
 };
+
+// agents/reviewers/に定義はあるが ROUTING に行を持たない reviewer。/audit の
+// fan-out ではなく skill から直接呼ばれるときだけ走るので、glob 表の行を持たず
+// FOCUS の外に置く。audit.routing.test.js の T-014 が agents/reviewers/の
+// 定義すべてが ROUTING かここのどちらかに載ることを検証するため、この配列は
+// 定義が到達不能になることへの防御柵になる。
+const SKILL_ONLY_REVIEWERS = ["causation", "readability", "conformance"];
 
 const ext = (p) => {
   const base = p.slice(p.lastIndexOf("/") + 1);
@@ -212,6 +218,17 @@ const classify = (p) => {
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };
+// T-014 (audit.routing.test.js) のランタイム側の鏡。reviewer 名が ROUTING と
+// SKILL_ONLY_REVIEWERS の両方に載ることは無いはず。テストは test 実行時にしか
+// 検知しないが、この check は実際の run のたびに同じ drift を検知する。
+const routingSkillOnlyOverlap = [...new Set(Object.values(ROUTING).flat())].filter((r) =>
+  SKILL_ONLY_REVIEWERS.includes(r),
+);
+if (routingSkillOnlyOverlap.length) {
+  log(
+    `Config drift: ROUTING と SKILL_ONLY_REVIEWERS の両方に載っている: ${routingSkillOnlyOverlap.join(", ")}。`,
+  );
+}
 
 const FINDINGS_SCHEMA = {
   type: "object",
@@ -336,15 +353,24 @@ if (!files.length) {
   return {
     findings: [],
     skipped: [],
+    zero_reviewer_files: [],
     why: "指定 scope に audit 対象のファイルが無い。",
   };
 }
 
 const focusSet = FOCUS[focus] === undefined ? null : FOCUS[focus];
 const assign = {};
+// classify() が返す reviewer が focus との積集合で全て落ちたファイルは 0 件になる。
+// これはファイルが無言で audit から外れる劣化なので、WORKFLOWS.md の粒度に沿って
+// 捨てず file path 単位で記録する。
+const zeroReviewerFiles = [];
 for (const f of files) {
-  for (const r of classify(f.path)) {
-    if (focusSet && !focusSet.includes(r)) continue;
+  const reviewers = classify(f.path).filter((r) => !focusSet || focusSet.includes(r));
+  if (!reviewers.length) {
+    zeroReviewerFiles.push({ path: f.path });
+    continue;
+  }
+  for (const r of reviewers) {
     (assign[r] = assign[r] || []).push(f.path);
   }
 }
@@ -352,6 +378,14 @@ const assignments = Object.entries(assign).map(([reviewer, fs]) => ({
   reviewer,
   files: fs,
 }));
+
+if (zeroReviewerFiles.length) {
+  log(
+    `0 reviewer になったファイル [focus=${focus}]: ${zeroReviewerFiles.length} - ${zeroReviewerFiles
+      .map((f) => f.path)
+      .join(", ")}`,
+  );
+}
 
 // 対話版の /audit は 30 ファイルを超えると scope を絞るよう prompt を出す。headless では
 // prompt を出せないため、warn だけして続行する。
@@ -444,7 +478,7 @@ const skipped = units
 
 if (!findings.length) {
   await writeSnapshot({ preFlight, rawFindings, findings: [], skipped });
-  return { findings: [], assignments, skipped };
+  return { findings: [], assignments, skipped, zero_reviewer_files: zeroReviewerFiles };
 }
 
 // ---- Challenge ∥ Verify -> Integrate。reviewer -> aggregate は禁止 ----
@@ -597,4 +631,5 @@ return {
   needs_context: needsContext,
   assignments,
   skipped,
+  zero_reviewer_files: zeroReviewerFiles,
 };

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -61,10 +61,9 @@ const bundled = (rel) =>
 // payload のキーは snapshot.py の build_record がそのまま record の項目にする。返り値に
 // しか無い項目は record から読めないので、record で読ませたいものはここへ渡す。
 //
-// payload は prompt に埋め込む形でしか agent に渡せず、agent が書き写す途中で要約すると
-// record だけが痩せる。実測では findings の summary が長い run で raw_findings 44 件が 2 件に
-// なった。件数を agent に自己申告させると切り詰めた当人が報告することになるので、stdin を
-// 受けた snapshot.py が数えた値 (stdout の counts) を持ち帰らせ、script 側で照合する。
+// payload は prompt に埋め込む形でしか agent に渡せず、書き写す途中で要約されると record
+// だけが痩せる。件数を agent に自己申告させると切り詰めた当人が報告することになるので、
+// stdin を受けた snapshot.py が数えた値を持ち帰らせる。
 const SNAPSHOT_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -131,8 +130,8 @@ const writeSnapshot = async ({
       agentType: "general-purpose",
       phase: "Snapshot",
       label: "snapshot",
-      // haiku では長い payload の書き写しが途中で要約に変わる。実測で raw_findings 44 件が
-      // 2 件になった。判断を求める段ではないが、書き写す長さが model 選択を決める。
+      // haiku では長い payload の書き写しが途中で要約に変わる。判断を求める段ではないが、
+      // 書き写す長さが model 選択を決める。
       model: "sonnet",
       schema: SNAPSHOT_SCHEMA,
     },
@@ -268,12 +267,6 @@ const FOCUS = {
   all: null,
 };
 
-// agents/reviewers/に定義はあるが ROUTING に行を持たない reviewer。/audit の
-// fan-out ではなく skill から直接呼ばれるときだけ走るので、glob 表の行を持たず
-// FOCUS の外に置く。ここに名前が無い定義は誰からも呼ばれないまま残るため、この配列が
-// 到達不能な定義への防御柵になる。
-const SKILL_ONLY_REVIEWERS = ["causation", "readability", "conformance"];
-
 const ext = (p) => {
   const base = p.slice(p.lastIndexOf("/") + 1);
   const dot = base.lastIndexOf(".");
@@ -293,22 +286,9 @@ const classify = (p) => {
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };
-// T-014 (audit.routing.test.js) のランタイム側の鏡。reviewer 名が ROUTING と
-// SKILL_ONLY_REVIEWERS の両方に載ることは無いはず。テストは test 実行時にしか
-// 検知しないが、この check は実際の run のたびに同じ drift を検知する。
-const routingSkillOnlyOverlap = [...new Set(Object.values(ROUTING).flat())].filter((r) =>
-  SKILL_ONLY_REVIEWERS.includes(r),
-);
-if (routingSkillOnlyOverlap.length) {
-  log(
-    `Config drift: ROUTING と SKILL_ONLY_REVIEWERS の両方に載っている: ${routingSkillOnlyOverlap.join(", ")}。`,
-  );
-}
-
 // source_ids を返すのは Integrate だけ。共有 schema に optional で置くと Integrate が省いても
-// validation を通り、R-N の追跡が run ごとに切れる (実測で 1 run 落ち、id は summary の散文へ
-// 流れた)。reviewer 用は property ごと持たないので、reviewer が id を捏造して返せば
-// additionalProperties: false が弾く。
+// validation を通り、R-N の追跡が run ごとに切れる。reviewer 用は property ごと持たないので、
+// reviewer が id を捏造して返せば additionalProperties: false が弾く。
 const findingsSchema = ({ withSourceIds = false } = {}) => ({
   type: "object",
   additionalProperties: false,
@@ -447,9 +427,8 @@ if (!files.length) {
 
 const focusSet = FOCUS[focus] === undefined ? null : FOCUS[focus];
 const assign = {};
-// classify() が返す reviewer が focus との積集合で全て落ちたファイルは 0 件になる。
-// これはファイルが無言で audit から外れる劣化なので、WORKFLOWS.md の粒度に沿って
-// 捨てず file path 単位で記録する。
+// classify() が返す reviewer が focus との積集合で全て落ちたファイルは、無言で audit の
+// 対象から外れる。どのファイルが外れたかを後から読めるよう path 単位で残す。
 const zeroReviewerFiles = [];
 for (const f of files) {
   const reviewers = classify(f.path).filter((r) => !focusSet || focusSet.includes(r));
@@ -618,9 +597,7 @@ const VERDICTS_SCHEMA = {
     },
   },
 };
-// critic-audit への challenge input と Integrate への survivors input は同じ射影
-// (rawFindings の message フィールドを summary に改名) を必要とする。ヘルパーを 1 つに
-// して、呼び出し 2 箇所で形が乖離しないようにする。
+// 呼び出し 2 箇所で形が乖離しないよう、射影を 1 箇所に置く。
 const toCriticRef = (f) => ({
   id: f.id,
   file: f.file,
@@ -667,10 +644,9 @@ const [challenged, verified] = await parallel([
 ]);
 
 // ---- Triage: survivor 判定はスクリプトが持ち、critic は verdict を返すだけ ----
-// verdict 側でなく finding 側を回すことで、challenge agent が verdict を付け忘れた
-// finding も取りこぼさない。confirmed 扱いで survivors に残し no_verdict として計上する。
-// challenge agent が丸ごと失敗した場合 (verdict 一覧が空) も全件が同じ no_verdict 経路を
-// 通るので、fail-open が呼び出し元から劣化と分かる形で残る。
+// verdict 側でなく finding 側を回す。verdict を付け忘れた finding が黙って消えず、
+// confirmed 扱いで no_verdict に計上される。challenge が丸ごと失敗した run も全件が
+// 同じ経路を通るので、劣化が件数として残る。
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
@@ -731,10 +707,8 @@ const integrated = await agent(
   },
 );
 
-// Integrate が返さなかったときのフォールバック先は triage 済みの survivors (各自が R-N id を
-// 持ったまま) であって、triage 前の findings 配列ではない。その配列は rawFindings への id 付与
-// より前の状態なので、そこへ落とすと challenge triage が disputed と判定した finding を黙って
-// 呼び戻すことになる。
+// フォールバック先を triage 前の findings にすると、id が付く前の配列に落ちるので、
+// challenge が disputed と判定した finding を黙って呼び戻すことになる。
 const finalFindings = (integrated && integrated.findings) || survivorsInput;
 const snapshot = await writeSnapshot({
   preFlight,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -58,7 +58,7 @@ const bundled = (rel) =>
 // timestamp・branch・prior snapshot との delta 計算は audit/snapshot.py が行う。agent は
 // payload を一時ファイルに書いてそのスクリプトを 1 回叩くだけで、disk への副作用が目的、
 // 戻り値は使わない。
-const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
+const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped, challengeRan }) => {
   phase("Snapshot");
   const payload = JSON.stringify({
     scope: scope || "HEAD",
@@ -67,6 +67,7 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
     raw_findings: rawFindings,
     findings,
     skipped,
+    challenge_ran: challengeRan,
   });
   await agent(
     anchor(
@@ -477,8 +478,14 @@ const skipped = units
   }));
 
 if (!findings.length) {
-  await writeSnapshot({ preFlight, rawFindings, findings: [], skipped });
-  return { findings: [], assignments, skipped, zero_reviewer_files: zeroReviewerFiles };
+  await writeSnapshot({ preFlight, rawFindings, findings: [], skipped, challengeRan: false });
+  return {
+    findings: [],
+    assignments,
+    skipped,
+    zero_reviewer_files: zeroReviewerFiles,
+    challenge_ran: false,
+  };
 }
 
 // ---- Challenge ∥ Verify -> Integrate。reviewer -> aggregate は禁止 ----
@@ -618,12 +625,17 @@ const integrated = await agent(
   },
 );
 
-const finalFindings = (integrated && integrated.findings) || findings;
+// Integrate-absent fallback must stay the triaged survivors (each still carrying its
+// own R-N id), never the pre-triage findings array: that array predates the id
+// assignment in rawFindings, so falling back to it would silently readmit findings
+// the challenge triage already disputed.
+const finalFindings = (integrated && integrated.findings) || survivorsInput;
 await writeSnapshot({
   preFlight,
   rawFindings,
   findings: finalFindings,
   skipped,
+  challengeRan,
 });
 return {
   findings: finalFindings,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -71,6 +71,7 @@ const writeSnapshot = async ({
   challengeRan,
   verifyRan,
   tally,
+  needsContext,
   zeroReviewerFiles,
 }) => {
   phase("Snapshot");
@@ -84,6 +85,7 @@ const writeSnapshot = async ({
     challenge_ran: challengeRan,
     verify_ran: verifyRan,
     tally,
+    needs_context: needsContext,
     zero_reviewer_files: zeroReviewerFiles,
   });
   await agent(
@@ -606,6 +608,11 @@ const needsContext = [];
 let noVerdict = 0;
 for (const f of rawFindings) {
   const v = verdictById.get(f.id);
+  // verdict は rawFindings 自身に書き戻す。survivors と needsContext へ振り分けるだけだと、
+  // disputed で落ちた id はどちらにも入らず record から消え、reviewer 別の生存率を測れない。
+  // rawFindings は snapshot payload にそのまま載るので、ここが finding ごとの verdict の
+  // 置き場になる。
+  f.verdict = v ? v.verdict : "no_verdict";
   if (!v) {
     noVerdict++;
     survivors.push({ ...f });
@@ -662,10 +669,10 @@ const integrated = await agent(
   },
 );
 
-// Integrate-absent fallback must stay the triaged survivors (each still carrying its
-// own R-N id), never the pre-triage findings array: that array predates the id
-// assignment in rawFindings, so falling back to it would silently readmit findings
-// the challenge triage already disputed.
+// Integrate が返さなかったときのフォールバック先は triage 済みの survivors (各自が R-N id を
+// 持ったまま) であって、triage 前の findings 配列ではない。その配列は rawFindings への id 付与
+// より前の状態なので、そこへ落とすと challenge triage が disputed と判定した finding を黙って
+// 呼び戻すことになる。
 const finalFindings = (integrated && integrated.findings) || survivorsInput;
 await writeSnapshot({
   preFlight,
@@ -675,6 +682,7 @@ await writeSnapshot({
   challengeRan,
   verifyRan,
   tally: challengeRan ? tally : undefined,
+  needsContext,
   zeroReviewerFiles,
 });
 return {

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -547,15 +547,19 @@ const VERDICTS_SCHEMA = {
     },
   },
 };
-// critic への入力は rawFindings (R-N id の出どころ) から reviewer フィールドを外したもの。
-// どの reviewer が挙げた finding かで challenge の verdict が偏らないようにする。
-const challengeInput = rawFindings.map((f) => ({
+// critic-audit への challenge input と Integrate への survivors input は同じ射影
+// (rawFindings の message フィールドを summary に改名) を必要とする。ヘルパーを 1 つに
+// して、呼び出し 2 箇所で形が乖離しないようにする。
+const toCriticRef = (f) => ({
   id: f.id,
   file: f.file,
   line: f.line,
   severity: f.severity,
   summary: f.message,
-}));
+});
+// critic への入力は rawFindings (R-N id の出どころ) から reviewer フィールドを外したもの。
+// どの reviewer が挙げた finding かで challenge の verdict が偏らないようにする。
+const challengeInput = rawFindings.map(toCriticRef);
 const [challenged, verified] = await parallel([
   () =>
     agent(
@@ -640,13 +644,7 @@ phase("Integrate");
 log(
   `verify pass の出力: ${verified ? "あり" : "なし"}。参考情報にとどめ、Integrate には渡さない。`,
 );
-const survivorsInput = survivors.map((s) => ({
-  id: s.id,
-  file: s.file,
-  line: s.line,
-  severity: s.severity,
-  summary: s.message,
-}));
+const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
   anchor(
     `enhancer-integration として、challenge triage を生き残った survivors を file:line で突き合わせ、cross-domain の root cause と severity 順のリストに reconcile する。\n` +

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -58,11 +58,8 @@ const bundled = (rel) =>
 // timestamp・branch・prior snapshot との delta 計算は audit/snapshot.py が行う。agent は
 // payload を一時ファイルに書いてそのスクリプトを 1 回叩くだけで、disk への副作用が目的、
 // 戻り値は使わない。
-// snapshot.py の build_record は payload を dict() でそのまま通すので、ここで払い出した
-// キーがそのまま record の項目になる。返り値にしか無い項目は record から読めないため、
-// 刈り率と 0 reviewer のファイルは payload 側にも渡す。tally は challengeRan が false の
-// とき undefined を渡し、JSON.stringify にキーごと落とさせる。fail-open した run が件数を
-// 持つと、全件 confirmed だった run と record 上で見分けがつかなくなる。
+// payload のキーは snapshot.py の build_record がそのまま record の項目にする。返り値に
+// しか無い項目は record から読めないので、record で読ませたいものはここへ渡す。
 const writeSnapshot = async ({
   preFlight,
   rawFindings,
@@ -85,7 +82,9 @@ const writeSnapshot = async ({
     challenge_ran: challengeRan,
     verify_ran: verifyRan,
     tally,
-    needs_context: needsContext,
+    // 同じ finding は raw_findings 側に verdict つきで載る。ここは raw_findings から
+    // 導けない why だけの側表にする。
+    needs_context: needsContext && needsContext.map(({ id, why }) => ({ id, why })),
     zero_reviewer_files: zeroReviewerFiles,
   });
   await agent(
@@ -214,9 +213,8 @@ const FOCUS = {
 
 // agents/reviewers/に定義はあるが ROUTING に行を持たない reviewer。/audit の
 // fan-out ではなく skill から直接呼ばれるときだけ走るので、glob 表の行を持たず
-// FOCUS の外に置く。audit.routing.test.js の T-014 が agents/reviewers/の
-// 定義すべてが ROUTING かここのどちらかに載ることを検証するため、この配列は
-// 定義が到達不能になることへの防御柵になる。
+// FOCUS の外に置く。ここに名前が無い定義は誰からも呼ばれないまま残るため、この配列が
+// 到達不能な定義への防御柵になる。
 const SKILL_ONLY_REVIEWERS = ["causation", "readability", "conformance"];
 
 const ext = (p) => {
@@ -517,7 +515,8 @@ if (!findings.length) {
 }
 
 // ---- Challenge ∥ Verify -> Integrate。reviewer -> aggregate は禁止 ----
-// 同じ findings に独立した 2 pass を並行で当て、Integrate が固定規則で reconcile する。
+// 同じ findings に独立した 2 pass を並行で当てる。membership を決めるのは Challenge の
+// verdict だけで、Verify の evidence は Integrate に届かない。
 const findingsJson = JSON.stringify(findings);
 // workflows/polish.js の VERDICTS_SCHEMA (id/verdict/severity/why) の形を踏襲する。
 // severity の enum はこのファイル自身の FINDINGS_SCHEMA (critical/high/medium/low) に
@@ -608,10 +607,8 @@ const needsContext = [];
 let noVerdict = 0;
 for (const f of rawFindings) {
   const v = verdictById.get(f.id);
-  // verdict は rawFindings 自身に書き戻す。survivors と needsContext へ振り分けるだけだと、
-  // disputed で落ちた id はどちらにも入らず record から消え、reviewer 別の生存率を測れない。
-  // rawFindings は snapshot payload にそのまま載るので、ここが finding ごとの verdict の
-  // 置き場になる。
+  // disputed の id は survivors にも needsContext にも入らない。書き戻さなければ record から
+  // 消え、reviewer 別の生存率を測れなくなる。
   f.verdict = v ? v.verdict : "no_verdict";
   if (!v) {
     noVerdict++;
@@ -629,12 +626,9 @@ for (const f of rawFindings) {
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
-// challenge_ran は「challenge が実際に verdicts を返した run」と fail-open した run
-// (challenged が null / undefined → verdictById が空 → 全 finding が no_verdict 経由で
-// confirmed に落ちる) を区別する。tally は triage の件数を運び、呼び出し元が survivors /
-// needsContext / noVerdict から再計算せずに読めるようにする。
-// verify pass は自由記述のテキストを返すので、schema の形ではなく中身の有無で判定する。
-// 出力を Integrate に転送しない以上、走ったかどうかは record からしか読めない。
+// challenge_ran は「verdicts を返した run」と fail-open した run (verdictById が空になり、
+// 全 finding が no_verdict 経由で confirmed に落ちる) を区別する。verify は自由記述の
+// テキストを返すため、schema の形ではなく中身の有無で判定する。
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
 const verifyRan = !!String(verified || "").trim();
 const tally = {
@@ -644,12 +638,10 @@ const tally = {
 };
 
 phase("Integrate");
-// membership は上の triage ループで既に決まっている。Integrate への入力は survivors のみで、
-// findings / challenge / verify の全体を渡さない。よって challenge pass が確定した finding を
-// Integrate が再び刈ることはできない。verification pass (実行経路の evidence) は走らせ続けるが、
-// その evidence は参考情報にとどめ、ここには転送しない。
+// 入力を survivors だけに絞ることで、challenge pass が確定した finding を Integrate が
+// 再び刈る経路自体をなくす。
 log(
-  `verify pass の出力: ${verified ? "あり" : "なし"}。参考情報にとどめ、Integrate には渡さない。`,
+  `verify pass の出力: ${verifyRan ? "あり" : "なし"}。参考情報にとどめ、Integrate には渡さない。`,
 );
 const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
@@ -681,6 +673,8 @@ await writeSnapshot({
   skipped,
   challengeRan,
   verifyRan,
+  // fail-open した run は degraded 印だけを残し件数を書かない、が plan の contract。
+  // undefined を渡すと JSON.stringify がキーごと落とす。
   tally: challengeRan ? tally : undefined,
   needsContext,
   zeroReviewerFiles,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -69,6 +69,7 @@ const writeSnapshot = async ({
   findings,
   skipped,
   challengeRan,
+  verifyRan,
   tally,
   zeroReviewerFiles,
 }) => {
@@ -81,6 +82,7 @@ const writeSnapshot = async ({
     findings,
     skipped,
     challenge_ran: challengeRan,
+    verify_ran: verifyRan,
     tally,
     zero_reviewer_files: zeroReviewerFiles,
   });
@@ -499,6 +501,7 @@ if (!findings.length) {
     findings: [],
     skipped,
     challengeRan: false,
+    verifyRan: false,
     zeroReviewerFiles,
   });
   return {
@@ -507,6 +510,7 @@ if (!findings.length) {
     skipped,
     zero_reviewer_files: zeroReviewerFiles,
     challenge_ran: false,
+    verify_ran: false,
   };
 }
 
@@ -618,7 +622,10 @@ log(
 // (challenged が null / undefined → verdictById が空 → 全 finding が no_verdict 経由で
 // confirmed に落ちる) を区別する。tally は triage の件数を運び、呼び出し元が survivors /
 // needsContext / noVerdict から再計算せずに読めるようにする。
+// verify pass は自由記述のテキストを返すので、schema の形ではなく中身の有無で判定する。
+// 出力を Integrate に転送しない以上、走ったかどうかは record からしか読めない。
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
+const verifyRan = !!String(verified || "").trim();
 const tally = {
   survived: survivors.length,
   needs_context: needsContext.length,
@@ -668,6 +675,7 @@ await writeSnapshot({
   findings: finalFindings,
   skipped,
   challengeRan,
+  verifyRan,
   tally: challengeRan ? tally : undefined,
   zeroReviewerFiles,
 });
@@ -676,6 +684,7 @@ return {
   survivors,
   needs_context: needsContext,
   challenge_ran: challengeRan,
+  verify_ran: verifyRan,
   tally,
   assignments,
   skipped,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -667,6 +667,10 @@ for (const f of rawFindings) {
     continue;
   }
   const severity = v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
+  // 下げ先は別フィールドに書く。f.severity を上書きすると reviewer が付けた元の値が消え、
+  // 「reviewer が severity を過大に付けるか」を測れなくなる。survivors は下げ後だけを持ち、
+  // Integrate が merge した後は finding 単位で追えない。
+  if (severity !== f.severity) f.downgraded_to = severity;
   survivors.push({ ...f, severity });
 }
 log(

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -125,7 +125,9 @@ const writeSnapshot = async ({
       agentType: "general-purpose",
       phase: "Snapshot",
       label: "snapshot",
-      model: "haiku",
+      // haiku では長い payload の書き写しが途中で要約に変わる。実測で raw_findings 44 件が
+      // 2 件になった。判断を求める段ではないが、書き写す長さが model 選択を決める。
+      model: "sonnet",
       schema: SNAPSHOT_SCHEMA,
     },
   );

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -232,6 +232,12 @@ const FINDINGS_SCHEMA = {
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
+          source_ids: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "R-N ids of the raw findings this finding absorbed (Integrate output only)",
+          },
         },
       },
     },
@@ -547,12 +553,26 @@ log(
 );
 
 phase("Integrate");
+// membership は上の triage ループで既に決まっている。Integrate への入力は survivors のみで、
+// findings / challenge / verify の全体を渡さない。よって challenge pass が確定した finding を
+// Integrate が再び刈ることはできない。verification pass (実行経路の evidence) は走らせ続けるが、
+// その evidence は参考情報にとどめ、ここには転送しない。
+log(
+  `verify pass の出力: ${verified ? "あり" : "なし"}。参考情報にとどめ、Integrate には渡さない。`,
+);
+const survivorsInput = survivors.map((s) => ({
+  id: s.id,
+  file: s.file,
+  line: s.line,
+  severity: s.severity,
+  summary: s.message,
+}));
 const integrated = await agent(
   anchor(
-    `enhancer-integration として、同じ findings に対する独立した 2 つの pass を file:line で突き合わせ、cross-domain の root cause と severity 順のリストに reconcile する。\n` +
-      `Membership 規則。どの finding を残すかは challenge pass が決める。challenge pass が false positive として刈った finding は、verification pass が evidence を見つけていても刈られたままにする。verification pass の役割は survivor に実行経路の evidence と severity を与えることだけで、刈られた finding を復活させない。\n` +
-      `Challenge pass (membership / false positive の刈り込み) は次のとおり。\n${JSON.stringify(challenged)}\n\n` +
-      `Verification pass (実行経路の evidence + severity) は次のとおり。\n${verified}`,
+    `enhancer-integration として、challenge triage を生き残った survivors を file:line で突き合わせ、cross-domain の root cause と severity 順のリストに reconcile する。\n` +
+      `Membership は既に確定している。以下の survivors はすべて challenge pass を通過済みなので、再び刈ったり disputed 扱いにしたり drop したりしない。merge と並べ替えだけを行う。\n` +
+      `返す finding には、吸収した survivor の id (R-N) を source_ids に全件残す。複数の survivor を統合した root cause なら、その全 id を source_ids に持つ。\n` +
+      `Survivors は次のとおり。\n${JSON.stringify(survivorsInput)}`,
   ),
   {
     agentType: "enhancer-integration",

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -60,6 +60,28 @@ const bundled = (rel) =>
 // 戻り値は使わない。
 // payload のキーは snapshot.py の build_record がそのまま record の項目にする。返り値に
 // しか無い項目は record から読めないので、record で読ませたいものはここへ渡す。
+//
+// payload は prompt に埋め込む形でしか agent に渡せず、agent が書き写す途中で要約すると
+// record だけが痩せる。実測では findings の summary が長い run で raw_findings 44 件が 2 件に
+// なり、tally との矛盾に気づくまで検出できなかった。書き出した record を読み返させて件数を
+// 返させ、script 側で期待値と照合する。
+const SNAPSHOT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["path", "raw_findings_count", "findings_count"],
+  properties: {
+    path: { type: "string", description: "snapshot.py が stdout に出力したパス" },
+    raw_findings_count: {
+      type: "integer",
+      description: "書き出した record を読み返した raw_findings の要素数。payload の値ではない",
+    },
+    findings_count: {
+      type: "integer",
+      description: "書き出した record を読み返した findings の要素数。payload の値ではない",
+    },
+  },
+};
+
 const writeSnapshot = async ({
   preFlight,
   rawFindings,
@@ -87,22 +109,41 @@ const writeSnapshot = async ({
     needs_context: needsContext && needsContext.map(({ id, why }) => ({ id, why })),
     zero_reviewer_files: zeroReviewerFiles,
   });
-  await agent(
+  const written = await agent(
     anchor(
       `あなたは audit の Snapshot 段階を担当する。次の JSON payload を一時ファイルに書き、` +
         `\`python3 ${bundled("workflows/audit/snapshot.py")} < <tempfile>\` を 1 回実行する。` +
         `スクリプトが timestamp・branch・prior snapshot との delta ` +
         `(file + message でマッチした resolved / new / carried) を解決し、` +
         `$HOME/.claude/history/ に記録を書いて出力パスを stdout に返す。` +
-        `コードの review や finding の変更はしない。他の方法でファイルを書かない。Payload は次のとおり。\n${payload}`,
+        `payload は一字一句そのまま書く。要約・省略・整形・再生成はしない。長さを理由に切り詰めない。` +
+        `コードの review や finding の変更はしない。他の方法でファイルを書かない。` +
+        `書き終えたら出力パスの record を読み返し、raw_findings と findings の実際の要素数を返す。` +
+        `payload に書いてある数ではなく、ディスク上の record を数えた値を返す。Payload は次のとおり。\n${payload}`,
     ),
     {
       agentType: "general-purpose",
       phase: "Snapshot",
       label: "snapshot",
       model: "haiku",
+      schema: SNAPSHOT_SCHEMA,
     },
   );
+  // 照合は script が持つ。agent 自身に「切り詰めていないか」を判定させると、切り詰めた当人が
+  // 自己申告することになる。
+  const expected = { raw: rawFindings.length, findings: findings.length };
+  if (!written) {
+    log(`Snapshot: agent が結果を返さなかった。record が書かれたかは未確認。`);
+    return { written: false, truncated: null, expected };
+  }
+  const actual = { raw: written.raw_findings_count, findings: written.findings_count };
+  const truncated = actual.raw !== expected.raw || actual.findings !== expected.findings;
+  if (truncated) {
+    log(
+      `Snapshot truncated: raw_findings ${actual.raw}/${expected.raw}、findings ${actual.findings}/${expected.findings}。record は刈り率の計測に使えない。`,
+    );
+  }
+  return { written: true, path: written.path, truncated, expected, actual };
 };
 
 // /audit の routing 表。react-pattern は JSX を含む拡張子 (jsx / tsx) にだけ付け、素の js の
@@ -507,7 +548,7 @@ const skipped = units
   }));
 
 if (!findings.length) {
-  await writeSnapshot({
+  const emptySnapshot = await writeSnapshot({
     preFlight,
     rawFindings,
     findings: [],
@@ -517,6 +558,7 @@ if (!findings.length) {
     zeroReviewerFiles,
   });
   return {
+    snapshot: emptySnapshot,
     findings: [],
     assignments,
     skipped,
@@ -678,7 +720,7 @@ const integrated = await agent(
 // より前の状態なので、そこへ落とすと challenge triage が disputed と判定した finding を黙って
 // 呼び戻すことになる。
 const finalFindings = (integrated && integrated.findings) || survivorsInput;
-await writeSnapshot({
+const snapshot = await writeSnapshot({
   preFlight,
   rawFindings,
   findings: finalFindings,
@@ -692,6 +734,7 @@ await writeSnapshot({
   zeroReviewerFiles,
 });
 return {
+  snapshot,
   findings: finalFindings,
   survivors,
   needs_context: needsContext,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -248,7 +248,11 @@ if (routingSkillOnlyOverlap.length) {
   );
 }
 
-const FINDINGS_SCHEMA = {
+// source_ids を返すのは Integrate だけ。共有 schema に optional で置くと Integrate が省いても
+// validation を通り、R-N の追跡が run ごとに切れる (実測で 1 run 落ち、id は summary の散文へ
+// 流れた)。reviewer 用は property ごと持たないので、reviewer が id を捏造して返せば
+// additionalProperties: false が弾く。
+const findingsSchema = ({ withSourceIds = false } = {}) => ({
   type: "object",
   additionalProperties: false,
   required: ["findings"],
@@ -258,7 +262,9 @@ const FINDINGS_SCHEMA = {
       items: {
         type: "object",
         additionalProperties: false,
-        required: ["file", "line", "severity", "summary"],
+        required: withSourceIds
+          ? ["file", "line", "severity", "summary", "source_ids"]
+          : ["file", "line", "severity", "summary"],
         properties: {
           file: { type: "string" },
           line: { type: "string" },
@@ -267,17 +273,23 @@ const FINDINGS_SCHEMA = {
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
-          source_ids: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              "R-N ids of the raw findings this finding absorbed (Integrate output only)",
-          },
+          ...(withSourceIds
+            ? {
+                source_ids: {
+                  type: "array",
+                  items: { type: "string" },
+                  description: "この finding が吸収した raw finding の R-N id を全件",
+                },
+              }
+            : {}),
         },
       },
     },
   },
-};
+});
+
+const FINDINGS_SCHEMA = findingsSchema();
+const INTEGRATED_SCHEMA = findingsSchema({ withSourceIds: true });
 
 const ROUTE_SCHEMA = {
   type: "object",
@@ -657,7 +669,7 @@ const integrated = await agent(
     label: "integrate",
     model: "opus",
     effort: "high",
-    schema: FINDINGS_SCHEMA,
+    schema: INTEGRATED_SCHEMA,
   },
 );
 

--- a/.ja/workflows/audit/snapshot.py
+++ b/.ja/workflows/audit/snapshot.py
@@ -1,25 +1,24 @@
 """Usage: snapshot.py   (audit payload JSON on stdin)
 
-Record one audit run to $HOME/.claude/history/ and compute the
-resolved/new/carried delta against the most recent prior snapshot.
+audit の 1 実行を $HOME/.claude/history/ に記録し、直近の prior snapshot に
+対する resolved/new/carried の delta を計算する。
 
 stdin:  JSON {scope, focus, pre_flight, raw_findings[], findings[], skipped[],
         challenge_ran, verify_ran, tally, needs_context[], zero_reviewer_files[]}
-        each raw_findings entry carries at least {file, message}, plus {id, reviewer,
-        verdict} once the triage pass has run.
-        Every key is copied to the record verbatim; absent keys stay absent. An absent
-        tally means the run failed open, which challenge_ran / verify_ran state directly.
-stdout: one line of JSON, {path, counts}. counts holds the element count of each
-        array this process serialized, so the caller compares against a figure it
-        did not obtain from the agent that transcribed the payload.
-exit 0 on success. exit 1 on an unparseable payload (nothing written).
+        各 raw_findings entry は最低限 {file, message} を持ち、triage を通った後は
+        {id, reviewer, verdict} も持つ。
+        キーは record にそのまま写す。無いキーは無いまま。tally が無い run は
+        fail-open したことを意味し、それは challenge_ran / verify_ran が直接示す。
+stdout: {path, counts} の JSON 1 行。counts はこのプロセスが serialize した各配列の
+        要素数なので、呼び出し元は payload を書き写した agent 由来でない数字と
+        照合できる。
+exit 0 は成功。exit 1 は payload が parse 不能 (何も書かない)。
 
-Resolved fields (shell / prior snapshot), added to the record:
-  branch        git rev-parse --abbrev-ref HEAD (falls back to "unknown")
+record に追加される解決済みフィールド (シェル / prior snapshot 由来):
+  branch        git rev-parse --abbrev-ref HEAD ("unknown" にフォールバック)
   generated_at  UTC ISO-8601
-  delta         {resolved, new, carried} counts vs the most recent prior
-                audit-*.json, matched on (file, message); first run -> all 0 with
-                note "first run".
+  delta         直近の audit-*.json に対する {resolved, new, carried} カウント。
+                (file, message) で照合。初回は全て 0 + note "first run"。
 """
 
 import glob
@@ -44,10 +43,10 @@ def finding_key(f):
 
 
 def compute_delta(current_raw, prior_raw):
-    """resolved = in prior only, new = in current only, carried = in both.
+    """resolved = prior のみ、new = current のみ、carried = 両方に存在。
 
-    prior_raw is None when no prior snapshot exists; the caller records a
-    "first run" note in that case.
+    prior snapshot が無いとき prior_raw は None。その場合は "first run" note を
+    記録する。
     """
     if prior_raw is None:
         return {"resolved": 0, "new": 0, "carried": 0, "note": "first run"}
@@ -61,14 +60,13 @@ def compute_delta(current_raw, prior_raw):
 
 
 def contradicts_own_tally(data):
-    """True when the record holds fewer raw_findings than its own tally accounts for.
+    """record の raw_findings が自身の tally より少ないとき True。
 
-    raw_findings is survived + needs_context + disputed, so a record carrying a
-    tally satisfies len(raw_findings) >= survived + needs_context. A record that
-    fails this lost entries after the tally was computed: the payload reaches the
-    writer through an LLM prompt, and summarizing while transcribing thins the
-    arrays without touching the counts. Records without a tally are left alone;
-    there is nothing to check them against.
+    raw_findings は survived + needs_context + disputed なので、tally を持つ
+    record では len(raw_findings) >= survived + needs_context が成り立つ。これを
+    満たさない record は tally を計算した後に要素を失っている。payload は LLM の
+    prompt を経由して書き手に届くため、書き写す途中で要約されると件数はそのまま
+    に配列だけが痩せる。tally を持たない record は照合する相手が無いので対象外。
     """
     tally = data.get("tally")
     raw = data.get("raw_findings")
@@ -76,23 +74,23 @@ def contradicts_own_tally(data):
         return False
     survived = tally.get("survived", 0)
     needs_context = tally.get("needs_context", 0)
-    # The operands are checked before they are added. A prior carrying "survived": "21"
-    # would raise on the addition, and latest_prior_raw only catches OSError / ValueError,
-    # so main() would die and write no record at all -- for exactly the malformed prior
-    # this function exists to step over.
+    # 加算する前に両オペランドの型を見る。prior の tally が "survived": "21" だと
+    # 加算が TypeError を投げ、latest_prior_raw が拾うのは OSError と ValueError
+    # だけなので main() ごと落ちて record が 1 つも書かれない。この関数がまたぐ
+    # べき壊れた prior で、まさにそれが起きる。
     if not isinstance(survived, int) or not isinstance(needs_context, int):
         return False
     return len(raw) < survived + needs_context
 
 
 def latest_prior_raw(history_dir):
-    """raw_findings of the most recent usable prior audit-*.json, or None.
+    """baseline に使える直近の prior audit-*.json の raw_findings。無ければ None。
 
-    Sorted by filename; the name embeds a UTC timestamp so lexical order is
-    chronological. A prior file that is unreadable, lacks raw_findings, or
-    contradicts its own tally is skipped rather than aborting the run. Taking a
-    thinned record as the baseline reports its missing entries as new on the next
-    run and as resolved on the run after, so the delta stays wrong twice.
+    ファイル名でソートする。名前に UTC timestamp が入るため辞書順が時系列に
+    なる。読めない、raw_findings を欠く、自身の tally と矛盾する prior ファイルは
+    run を中断せずスキップする。痩せた record を baseline に取ると、失われた
+    要素が次の run で new、その次の run で resolved と報告され、delta が 2 回
+    続けて狂う。
     """
     priors = sorted(glob.glob(str(history_dir / "audit-*.json")), reverse=True)
     for path in priors:
@@ -134,11 +132,10 @@ COUNTED_ARRAYS = (
 
 
 def counted_arrays(record):
-    """Element count per array the record carries, for the caller to compare against.
+    """record が持つ配列ごとの要素数。呼び出し元はこれと照合する。
 
-    An absent key counts 0 rather than being omitted, so the caller reads the
-    same key set every run and a dropped array is a count mismatch instead of a
-    missing field.
+    無いキーは省かず 0 と数える。呼び出し元が毎回同じキー集合を読めるので、
+    配列が丸ごと落ちた場合もフィールドの欠落でなく件数の不一致として出る。
     """
     return {
         key: len(record[key]) if isinstance(record.get(key), list) else 0
@@ -180,8 +177,8 @@ def main():
     out_path = HISTORY_DIR / f"audit-{now.strftime('%Y-%m-%d-%H%M%S')}.json"
     with open(out_path, "w") as fh:
         json.dump(record, fh, ensure_ascii=False, indent=2)
-    # The counts come from what this process serialized, so the caller compares
-    # against them instead of against a figure the agent reports about itself.
+    # counts はこのプロセスが serialize した内容から取る。呼び出し元は agent が
+    # 自分について報告した数字ではなく、この値と照合する。
     print(json.dumps({"path": str(out_path), "counts": counted_arrays(record)}))
 
 

--- a/.ja/workflows/audit/snapshot.py
+++ b/.ja/workflows/audit/snapshot.py
@@ -3,9 +3,15 @@
 Record one audit run to $HOME/.claude/history/ and compute the
 resolved/new/carried delta against the most recent prior snapshot.
 
-stdin:  JSON {scope, focus, pre_flight, raw_findings[], findings[], skipped[]}
-        each raw_findings entry carries at least {file, message}.
-stdout: the path of the JSON record written.
+stdin:  JSON {scope, focus, pre_flight, raw_findings[], findings[], skipped[],
+        challenge_ran, verify_ran, tally, needs_context[], zero_reviewer_files[]}
+        each raw_findings entry carries at least {file, message}, plus {id, reviewer,
+        verdict} once the triage pass has run.
+        Every key is copied to the record verbatim; absent keys stay absent. An absent
+        tally means the run failed open, which challenge_ran / verify_ran state directly.
+stdout: one line of JSON, {path, counts}. counts holds the element count of each
+        array this process serialized, so the caller compares against a figure it
+        did not obtain from the agent that transcribed the payload.
 exit 0 on success. exit 1 on an unparseable payload (nothing written).
 
 Resolved fields (shell / prior snapshot), added to the record:
@@ -54,12 +60,39 @@ def compute_delta(current_raw, prior_raw):
     }
 
 
+def contradicts_own_tally(data):
+    """True when the record holds fewer raw_findings than its own tally accounts for.
+
+    raw_findings is survived + needs_context + disputed, so a record carrying a
+    tally satisfies len(raw_findings) >= survived + needs_context. A record that
+    fails this lost entries after the tally was computed -- the payload reaches
+    the writer through an LLM prompt, and one that summarizes while transcribing
+    thins the arrays without touching the counts. Records without a tally are
+    left alone; there is nothing to check them against.
+    """
+    tally = data.get("tally")
+    raw = data.get("raw_findings")
+    if not isinstance(tally, dict) or not isinstance(raw, list):
+        return False
+    survived = tally.get("survived", 0)
+    needs_context = tally.get("needs_context", 0)
+    # The operands are checked before they are added. A prior carrying "survived": "21"
+    # would raise on the addition, and latest_prior_raw only catches OSError / ValueError,
+    # so main() would die and write no record at all -- for exactly the malformed prior
+    # this function exists to step over.
+    if not isinstance(survived, int) or not isinstance(needs_context, int):
+        return False
+    return len(raw) < survived + needs_context
+
+
 def latest_prior_raw(history_dir):
-    """raw_findings of the most recent prior audit-*.json, or None if none exists.
+    """raw_findings of the most recent usable prior audit-*.json, or None.
 
     Sorted by filename; the name embeds a UTC timestamp so lexical order is
-    chronological. A prior file that is unreadable or lacks raw_findings is
-    skipped rather than aborting the run.
+    chronological. A prior file that is unreadable, lacks raw_findings, or
+    contradicts its own tally is skipped rather than aborting the run. Taking a
+    thinned record as the baseline reports its missing entries as new on the next
+    run and as resolved on the run after, so the delta stays wrong twice.
     """
     priors = sorted(glob.glob(str(history_dir / "audit-*.json")), reverse=True)
     for path in priors:
@@ -67,6 +100,8 @@ def latest_prior_raw(history_dir):
             with open(path) as fh:
                 data = json.load(fh)
         except (OSError, ValueError):
+            continue
+        if contradicts_own_tally(data):
             continue
         raw = data.get("raw_findings")
         if isinstance(raw, list):
@@ -87,6 +122,28 @@ def git_branch():
         return branch or "unknown"
     except (OSError, subprocess.SubprocessError):
         return "unknown"
+
+
+COUNTED_ARRAYS = (
+    "raw_findings",
+    "findings",
+    "skipped",
+    "needs_context",
+    "zero_reviewer_files",
+)
+
+
+def counted_arrays(record):
+    """Element count per array the record carries, for the caller to compare against.
+
+    An absent key counts 0 rather than being omitted, so the caller reads the
+    same key set every run and a dropped array is a count mismatch instead of a
+    missing field.
+    """
+    return {
+        key: len(record[key]) if isinstance(record.get(key), list) else 0
+        for key in COUNTED_ARRAYS
+    }
 
 
 def build_record(payload, branch, generated_at, delta):
@@ -123,7 +180,9 @@ def main():
     out_path = HISTORY_DIR / f"audit-{now.strftime('%Y-%m-%d-%H%M%S')}.json"
     with open(out_path, "w") as fh:
         json.dump(record, fh, ensure_ascii=False, indent=2)
-    print(str(out_path))
+    # The counts come from what this process serialized, so the caller compares
+    # against them instead of against a figure the agent reports about itself.
+    print(json.dumps({"path": str(out_path), "counts": counted_arrays(record)}))
 
 
 if __name__ == "__main__":

--- a/.ja/workflows/audit/snapshot.py
+++ b/.ja/workflows/audit/snapshot.py
@@ -65,10 +65,10 @@ def contradicts_own_tally(data):
 
     raw_findings is survived + needs_context + disputed, so a record carrying a
     tally satisfies len(raw_findings) >= survived + needs_context. A record that
-    fails this lost entries after the tally was computed -- the payload reaches
-    the writer through an LLM prompt, and one that summarizes while transcribing
-    thins the arrays without touching the counts. Records without a tally are
-    left alone; there is nothing to check them against.
+    fails this lost entries after the tally was computed: the payload reaches the
+    writer through an LLM prompt, and summarizing while transcribing thins the
+    arrays without touching the counts. Records without a tally are left alone;
+    there is nothing to check them against.
     """
     tally = data.get("tally")
     raw = data.get("raw_findings")

--- a/.ja/workflows/build/verify-tests.py
+++ b/.ja/workflows/build/verify-tests.py
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
 """Usage: verify-tests.py   (test-presence checks JSON on stdin)
 
-Deterministically verify that each plan test statement (T-NNN name) occurs
-verbatim in one of its unit's files. code.js instructs the implementation to use
-the scenario name verbatim as the test name, so a literal fixed-string search is
-a presence check for "this planned test was actually written".
+plan の各 test 文 (T-NNN の name) が、その unit のファイルのいずれかに原文のまま
+現れることを決定的に検証する。code.js は実装に対し、シナリオ名をそのまま test 名に
+使うよう指示する。よって固定文字列の検索が「計画した test が実際に書かれたか」の
+存在確認になる。
 
-stdin:  JSON array of {files, names} — one entry per plan unit. files are
-        repo-root-relative paths (the unit's own files, tests included); names
-        are the unit's T-NNN statements.
-stdout: JSON {results: [{name, found}]}, names flattened in input order.
-          found = some listed file is a regular readable file containing the
-                  name's bytes literally (not regex)
-exit 0 on a completed run (read the verdict from JSON). exit 1 on usage / parse
-error -- fail-closed: a malformed payload is never silently treated as "all
-statements present". The surfacing decision (found=false -> PR) stays in build.js.
+stdin:  {files, names} の JSON 配列。plan の unit ごとに 1 要素。files は repo root
+        からの相対パス (その unit 自身のファイル。test を含む)。names はその unit の
+        T-NNN 文。
+stdout: JSON {results: [{name, found}]}。names は入力順に平坦化する。
+          found = 列挙されたファイルのいずれかが読める通常ファイルで、name のバイト列を
+                  そのまま (正規表現でなく) 含む
+完走したら exit 0 (判定は JSON から読む)。usage と parse の失敗は exit 1。fail-closed に
+する。壊れた payload を「全ての文が存在する」と黙って扱わないため。found=false を
+どう surface するかの判断は build.js が持つ。
 """
 
 import json
@@ -23,7 +23,7 @@ from pathlib import Path
 
 
 def read_bytes(root, path):
-    """The file's bytes, or empty on a missing / unreadable file (fail-closed)."""
+    """ファイルのバイト列。存在しない / 読めないときは空を返す (fail-closed)。"""
     target = root / path
     if not target.is_file():
         return b""
@@ -34,7 +34,7 @@ def read_bytes(root, path):
 
 
 def run(checks, root=Path(".")):
-    """Verify every unit's names against its own files, preserving input order."""
+    """各 unit の names をその unit 自身のファイルに照合する。入力順を保つ。"""
     results = []
     for entry in checks:
         if not isinstance(entry, dict):

--- a/docs/decisions/0095-move-audit-membership-rule-from-agent-to-script.md
+++ b/docs/decisions/0095-move-audit-membership-rule-from-agent-to-script.md
@@ -1,0 +1,56 @@
+---
+status: "accepted"
+date: "2026-08-02"
+decision-makers: thkt
+---
+
+# DR-0095: audit の membership 判定を enhancer-integration の Phase 2 から script の triage に移す
+
+## Context and Problem Statement
+
+`agents/enhancers/enhancer-integration.md` は Phase 2 (Reconciliation、`agents/enhancers/enhancer-integration.md:68-79`) で challenger (critic-audit) と verifier (critic-evidence) の出力を finding_id で突き合わせ、6 段の優先順位表で confirmed/disputed/needs_review/needs_context を判定する設計だった。Input セクション (`agents/enhancers/enhancer-integration.md:20-62`) はこの判定に使う `challenges` 配列 (finding_id/verdict/reasoning/evidence) と `verifications` 配列 (finding_id/verdict/budget_exhausted/evidence) を受け取る形を文書化している。
+
+Issue #298 の実測では、raw findings 79 件が final 13 件、34 件が 8 件、12 件が 3 件に減り 75-85% が消えていた (#298 記載の当時の行番号基準)。finding に id が無いため、この刈りの主因が Challenge か Integrate かを追跡できなかった。#298 の U-001 で `workflows/audit.js` に R-N id 付きの script 側 triage ループを実装し (`workflows/audit.js:566-602`)、challenger の verdict のみで survivors/needs_context/no_verdict を決定するようにした。U-003 でさらに Integrate への入力を `survivorsInput` (`workflows/audit.js:612-618`、id/file/line/severity/summary のみ) に絞り、prompt に「Membership is already decided ... Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes」(`workflows/audit.js:622`) を明記した。verifier (critic-evidence) の出力は `verified` として実行されるが Integrate には渡らず、`log()` で informational とだけ記録される (`workflows/audit.js:604-611`)。
+
+この結果、enhancer-integration.md が文書化する Phase 1 (Receive) と Phase 2 (Reconciliation) は、`/audit` 経由の呼び出しでは実行されなくなった。Integrate に渡る `survivorsInput` は verdict/reasoning/evidence/budget_exhausted のいずれのフィールドも持たず、`challenges`/`verifications` という配列名も付かないため、Phase 2 が要求する突き合わせの対象そのものが入力に存在しない。enhancer-integration.md 自体は #298 のスコープ外 (Issue の Scope 節が挙げる「reviewer roster の retire と統合」は Backlog candidates 行き) として無改修のまま残り、この乖離はコードを読まないと分からない。
+
+## Decision Drivers
+
+- membership (survivor 判定) を script が 1 箇所で決定論的に持つほうが `workflows/polish.js` の triage ループと同型になり、判定基準が prompt の解釈に依存しない
+- verifier の出力を Integrate に転送し Phase 2 の優先順位表で再判定させると、script の triage 結果と Phase 2 の判定が食い違う二重刈りのリスクが生まれる。#298 の Approach 節はこのリスクを名指しし、Manual verification 節も「二重刈りは prompt 文言でしか止められず、文言の存在を T-NNN で固定すると言い換えのたびに落ちる change detector になる」としてテストでなくコードレビューで確認する方針を取っている
+- `agents/enhancers/enhancer-integration.md` の改修 (Phase 2 の削除や Input 定義の更新) は #298 の Scope 外。Backlog candidates が挙げる「reviewer roster の retire と統合の判断」の一部であり、単独 Issue の中で改修すると影響範囲が #298 の枠を超える
+- 判定は外部から観測できる形だけで行う方針 (#298 Testing Decisions) により、prompt 文言を固定する test は置かない。Phase 2 が不使用になったこと自体は unit test でなく DR で記録する対象になる
+
+## Considered Options
+
+- Option A: `agents/enhancers/enhancer-integration.md` は無改修のまま残し、`workflows/audit.js` 側で Integrate への入力を triage 済みの survivors のみに絞り、再刈り禁止を prompt に明記する。Phase 2 が `/audit` 経由では実行されなくなる副作用を本 DR に記録する
+- Option B: `agents/enhancers/enhancer-integration.md` を改修し、Phase 2 (Reconciliation) と Input セクションの `challenges`/`verifications` 形を削除して、Phase 3 (Integration) 相当の統合専任 agent として定義し直す
+- Option C: script 側の triage を実装せず、Phase 2 の優先順位表に membership 判定を委ね続ける。Integrate には challenger と verifier の生の出力をそのまま転送する
+
+## Decision Outcome
+
+Option A を採用する。#298 の Scope は `workflows/audit.js` と `workflows/audit/tests/` に限定されており、`agents/enhancers/enhancer-integration.md` の改修は reviewer roster 全体の retire/統合判断と地続きで、単独では判断しきれない。script 側に triage を持たせる変更 (U-001, U-003) だけで #298 の Acceptance Criteria (verdict が snapshot に載る、R-N id が source_ids まで追える) を満たせるため、enhancer-integration.md には触れずに Integrate への入力を絞る形で二重刈りを止めた。
+
+### Consequences
+
+- Good, because membership 判定が `workflows/audit.js` の triage ループ 1 箇所に決定論的に集約され、`workflows/polish.js` と同型のパターンになる。判定基準の変更は script の 1 ファイルを読めば追える
+- Good, because `agents/enhancers/enhancer-integration.md` を無改修のまま残せるため、#298 の作業が reviewer roster 全体の設計判断に波及しない
+- Bad, because `agents/enhancers/enhancer-integration.md` の Phase 1 (Receive) と Phase 2 (Reconciliation)、その Input セクションが定義する `challenges`/`verifications` 形は、`/audit` 経由の呼び出しでは実行されない仕様になる。ファイルだけを読む人は、Integrate が challenger と verifier を突き合わせて needs_review 等を判定すると誤解する
+- Bad, because Phase 2 の優先順位表が持っていた「challenger は disputed だが verifier が verified を返した」ケースの回収経路 (needs_review) が `/audit` の出力から失われる。verifier (critic-evidence) は実行されるが、その判定は `log()` の 1 行に残るのみで最終 findings に一切影響しない
+- Bad, because enhancer-integration.md と audit.js の呼び出し形の乖離は自動テストで検出できない (#298 Testing Decisions が明記する方針)。コードレビューでの目視確認と本 DR が唯一の記録になる
+
+### Confirmation
+
+`workflows/audit.js` の Integrate 呼び出し prompt (`workflows/audit.js:619-625`) が「Membership is already decided」を含み、渡す入力 `survivorsInput` (`workflows/audit.js:612-618`) が id/file/line/severity/summary のみで verdict/reasoning/evidence を持たないことをコードレビューで確認する。`agents/enhancers/enhancer-integration.md` が無改修であることは `git diff main...HEAD -- agents/enhancers/enhancer-integration.md` が空であることで確認できる。
+
+## More Information
+
+- 上流の Issue は #298。本 DR は #298 の Plan の U-006 にあたり、triage の実装自体は U-001 (script 側 triage ループ) と U-003 (Integrate 入力の survivors 限定と再刈り禁止 prompt) が担う
+- enhancer-integration.md の Phase 2 削除や reviewer roster 全体の retire/統合判断は、#298 の Backlog candidates に挙げた別判断として持ち越す
+- 関連する既存 DR は DR-0035 (audit/verify の convergence signal と reconciliation の置き場所)。DR-0035 は `/verify` 側の reconciliation を enhancer-evidence に割り当てる判断をしており、`/audit` 側の enhancer-integration.md にも同型の Phase 2 (Reconciliation) が独立して存在する (`agents/enhancers/enhancer-evidence.md:70-82` と `agents/enhancers/enhancer-integration.md:68-79`)。両者の分岐の経緯は本 DR の調査範囲外である
+- `docs/decisions/` は `.ja` ミラー対象外 (`.ja/docs/decisions/` は存在しない)。本 DR に対応する日本語ミラーの追補は不要
+
+### Reassessment Triggers
+
+- enhancer-integration.md の他の呼び出し元 (現状は `/audit` 以外に存在しない) が Phase 2 の Input 形をそのまま必要とする実装が現れたとき、Phase 2 を維持したまま呼び出し形を揃える判断が優勢になりうる
+- verifier (critic-evidence) の execution-path evidence を membership 判定に使わないことが false negative (本来 disputed の finding が survivors に残る、または本来 confirmed の finding が消える) として実害化したとき、needs_review 相当の回収経路を script 側 triage に作り直す検討が要る

--- a/docs/decisions/0095-move-audit-membership-rule-from-agent-to-script.md
+++ b/docs/decisions/0095-move-audit-membership-rule-from-agent-to-script.md
@@ -10,7 +10,7 @@ decision-makers: thkt
 
 `agents/enhancers/enhancer-integration.md` は Phase 2 (Reconciliation、`agents/enhancers/enhancer-integration.md:68-79`) で challenger (critic-audit) と verifier (critic-evidence) の出力を finding_id で突き合わせ、6 段の優先順位表で confirmed/disputed/needs_review/needs_context を判定する設計だった。Input セクション (`agents/enhancers/enhancer-integration.md:20-62`) はこの判定に使う `challenges` 配列 (finding_id/verdict/reasoning/evidence) と `verifications` 配列 (finding_id/verdict/budget_exhausted/evidence) を受け取る形を文書化している。
 
-Issue #298 の実測では、raw findings 79 件が final 13 件、34 件が 8 件、12 件が 3 件に減り 75-85% が消えていた (#298 記載の当時の行番号基準)。finding に id が無いため、この刈りの主因が Challenge か Integrate かを追跡できなかった。#298 の U-001 で `workflows/audit.js` に R-N id 付きの script 側 triage ループを実装し (`workflows/audit.js:566-602`)、challenger の verdict のみで survivors/needs_context/no_verdict を決定するようにした。U-003 でさらに Integrate への入力を `survivorsInput` (`workflows/audit.js:612-618`、id/file/line/severity/summary のみ) に絞り、prompt に「Membership is already decided ... Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes」(`workflows/audit.js:622`) を明記した。verifier (critic-evidence) の出力は `verified` として実行されるが Integrate には渡らず、`log()` で informational とだけ記録される (`workflows/audit.js:604-611`)。
+Issue #298 の実測では、raw findings 79 件が final 13 件、34 件が 8 件、12 件が 3 件に減り 75-85% が消えていた (#298 記載の当時の行番号基準)。finding に id が無いため、この刈りの主因が Challenge か Integrate かを追跡できなかった。#298 の U-001 で `workflows/audit.js` に R-N id 付きの script 側 triage ループ (`rawFindings` を回して `verdictById` を引く箇所) を実装し、challenger の verdict のみで survivors/needs_context/no_verdict を決定するようにした。U-003 でさらに Integrate への入力を `survivorsInput` (`toCriticRef` による id/file/line/severity/summary のみの射影) に絞り、prompt に「Membership is already decided ... Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes」を明記した。verifier (critic-evidence) の出力は `verified` として実行されるが Integrate には渡らず、`log()` で informational とだけ記録される。
 
 この結果、enhancer-integration.md が文書化する Phase 1 (Receive) と Phase 2 (Reconciliation) は、`/audit` 経由の呼び出しでは実行されなくなった。Integrate に渡る `survivorsInput` は verdict/reasoning/evidence/budget_exhausted のいずれのフィールドも持たず、`challenges`/`verifications` という配列名も付かないため、Phase 2 が要求する突き合わせの対象そのものが入力に存在しない。enhancer-integration.md 自体は #298 のスコープ外 (Issue の Scope 節が挙げる「reviewer roster の retire と統合」は Backlog candidates 行き) として無改修のまま残り、この乖離はコードを読まないと分からない。
 
@@ -41,7 +41,7 @@ Option A を採用する。#298 の Scope は `workflows/audit.js` と `workflow
 
 ### Confirmation
 
-`workflows/audit.js` の Integrate 呼び出し prompt (`workflows/audit.js:619-625`) が「Membership is already decided」を含み、渡す入力 `survivorsInput` (`workflows/audit.js:612-618`) が id/file/line/severity/summary のみで verdict/reasoning/evidence を持たないことをコードレビューで確認する。`agents/enhancers/enhancer-integration.md` が無改修であることは `git diff main...HEAD -- agents/enhancers/enhancer-integration.md` が空であることで確認できる。
+`workflows/audit.js` の Integrate 呼び出し prompt が「Membership is already decided」を含み、渡す入力 `survivorsInput` が id/file/line/severity/summary のみで verdict/reasoning/evidence を持たないことをコードレビューで確認する。`agents/enhancers/enhancer-integration.md` が無改修であることは `git diff main...HEAD -- agents/enhancers/enhancer-integration.md` が空であることで確認できる。
 
 ## More Information
 

--- a/hooks/ja-prose-guard.sh
+++ b/hooks/ja-prose-guard.sh
@@ -1,0 +1,78 @@
+#!/bin/zsh
+# PostToolUse hook: warn when a .ja/ source file carries prose with no Japanese in it.
+#
+# .ja/ is canonical and its prose (comments / docstrings) is written in Japanese, while
+# code structure and identifiers stay identical to the English side. Agents default to
+# writing comments in English, so a full-file Write silently replaces existing Japanese
+# prose. That regression has landed 4 times, twice inside commits that claimed to be
+# mechanical style-only changes, and a diff review does not catch it.
+#
+# Warns, never blocks: a file whose comments are legitimately all identifiers or proper
+# nouns has no Japanese to find, and that is not a defect.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/japanese-detect.sh"
+
+input=$(cat)
+
+# Fast-exit before forking jq: only .ja/ paths can trigger this.
+case "$input" in
+  *.ja/*) ;;
+  *) exit 0 ;;
+esac
+
+read -r tool_name file_path < <(printf '%s' "$input" | jq -r '[.tool_name // "", .tool_input.file_path // ""] | @tsv' 2>/dev/null) || true
+
+case "$tool_name" in
+  Write|Edit|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+[[ -z "$file_path" ]] && exit 0
+[[ ! -f "$file_path" ]] && exit 0
+
+# Path must be under a .ja/ directory, not merely contain the string.
+case "$file_path" in
+  */.ja/*) ;;
+  *) exit 0 ;;
+esac
+
+# Extensions whose prose the mirror convention translates. Markdown is covered by
+# textlint; this guard is for source files where comments are the only prose.
+case "$file_path" in
+  *.py|*.js|*.ts|*.sh) ;;
+  *) exit 0 ;;
+esac
+
+# Prose lines only: line comments, block-comment bodies, and Python docstring delimiters.
+# Counting the whole file would pass on any file holding a Japanese string literal.
+prose=$(LC_ALL=en_US.UTF-8 grep -E '^\s*(#|//|\*|"""|'"'''"')' "$file_path" 2>/dev/null || true)
+
+# No prose at all means nothing to translate (a pure-code identical copy).
+[[ -z "$prose" ]] && exit 0
+
+# Shebang and coding lines are not prose.
+prose=$(printf '%s\n' "$prose" | grep -v -E '^#!|^# -\*- coding' || true)
+[[ -z "$prose" ]] && exit 0
+
+# Threshold 1: a single Japanese character anywhere in the prose clears this guard. The
+# target is a wholesale replacement, not partial drift.
+if printf '%s' "$prose" | has_japanese 1; then
+  exit 0
+fi
+
+prose_lines=$(printf '%s\n' "$prose" | grep -c . || true)
+
+# stdout の JSON で返す。exit 0 の stderr は誰にも表示されないので、警告がそこに
+# 出るだけでは退行を止められない。systemMessage が人間に、additionalContext が
+# 書き換えた本人に届く。
+msg=".ja/ は canonical で prose は日本語 (MIRROR.md)。$file_path のコメント / docstring ${prose_lines} 行に日本語が 1 文字もない。英語で書き直していないか確認する。過去訳は git log --oneline -- \"$file_path\" から取れる。"
+
+jq -n --arg m "$msg" '{
+  systemMessage: $m,
+  hookSpecificOutput: {
+    hookEventName: "PostToolUse",
+    additionalContext: $m
+  }
+}'
+exit 0

--- a/hooks/ja-prose-guard.sh
+++ b/hooks/ja-prose-guard.sh
@@ -44,16 +44,48 @@ case "$file_path" in
   *) exit 0 ;;
 esac
 
-# Prose lines only: line comments, block-comment bodies, and Python docstring delimiters.
-# Counting the whole file would pass on any file holding a Japanese string literal.
-prose=$(LC_ALL=en_US.UTF-8 grep -E '^\s*(#|//|\*|"""|'"'''"')' "$file_path" 2>/dev/null || true)
+# Prose only, never code or string literals. Counting the whole file would pass on any
+# file holding a Japanese string literal; matching comment-looking lines would both miss a
+# docstring's body (its 2nd line onward starts with neither # nor ") and catch Markdown
+# headings inside a generated-text literal.
+case "$file_path" in
+  *.py)
+    # Python has an exact answer available, so take it: ast for docstrings, tokenize for
+    # comments. A regex cannot tell `# heading` inside a triple-quoted template from a
+    # real comment.
+    prose=$(python3 - "$file_path" <<'PY' 2>/dev/null || true
+import ast, io, sys, tokenize
+
+path = sys.argv[1]
+src = open(path, encoding="utf-8").read()
+out = []
+try:
+    tree = ast.parse(src)
+except SyntaxError:
+    sys.exit(0)
+for node in ast.walk(tree):
+    if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+        doc = ast.get_docstring(node)
+        if doc:
+            out.append(doc)
+try:
+    for tok in tokenize.generate_tokens(io.StringIO(src).readline):
+        if tok.type == tokenize.COMMENT and not tok.string.startswith("#!"):
+            out.append(tok.string)
+except (tokenize.TokenError, IndentationError):
+    pass
+print("\n".join(out))
+PY
+    )
+    ;;
+  *)
+    prose=$(LC_ALL=en_US.UTF-8 grep -E '^\s*(#|//|\*)' "$file_path" 2>/dev/null || true)
+    prose=$(printf '%s\n' "$prose" | grep -v -E '^#!|^# -\*- coding' || true)
+    ;;
+esac
 
 # No prose at all means nothing to translate (a pure-code identical copy).
-[[ -z "$prose" ]] && exit 0
-
-# Shebang and coding lines are not prose.
-prose=$(printf '%s\n' "$prose" | grep -v -E '^#!|^# -\*- coding' || true)
-[[ -z "$prose" ]] && exit 0
+[[ -z "${prose//[[:space:]]/}" ]] && exit 0
 
 # Threshold 1: a single Japanese character anywhere in the prose clears this guard. The
 # target is a wholesale replacement, not partial drift.

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -250,7 +250,11 @@ if (routingSkillOnlyOverlap.length) {
   );
 }
 
-const FINDINGS_SCHEMA = {
+// Only Integrate returns source_ids. Kept optional on the shared schema, an Integrate run
+// that omits it still passes validation and R-N tracking breaks per run (measured: one run
+// dropped it and put the ids in the summary prose instead). The reviewer variant lacks the
+// property entirely, so additionalProperties: false rejects a reviewer that invents ids.
+const findingsSchema = ({ withSourceIds = false } = {}) => ({
   type: "object",
   additionalProperties: false,
   required: ["findings"],
@@ -260,7 +264,9 @@ const FINDINGS_SCHEMA = {
       items: {
         type: "object",
         additionalProperties: false,
-        required: ["file", "line", "severity", "summary"],
+        required: withSourceIds
+          ? ["file", "line", "severity", "summary", "source_ids"]
+          : ["file", "line", "severity", "summary"],
         properties: {
           file: { type: "string" },
           line: { type: "string" },
@@ -269,17 +275,23 @@ const FINDINGS_SCHEMA = {
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
-          source_ids: {
-            type: "array",
-            items: { type: "string" },
-            description:
-              "R-N ids of the raw findings this finding absorbed (Integrate output only)",
-          },
+          ...(withSourceIds
+            ? {
+                source_ids: {
+                  type: "array",
+                  items: { type: "string" },
+                  description: "every R-N id of the raw findings this finding absorbed",
+                },
+              }
+            : {}),
         },
       },
     },
   },
-};
+});
+
+const FINDINGS_SCHEMA = findingsSchema();
+const INTEGRATED_SCHEMA = findingsSchema({ withSourceIds: true });
 
 const ROUTE_SCHEMA = {
   type: "object",
@@ -662,7 +674,7 @@ const integrated = await agent(
     label: "integrate",
     model: "opus",
     effort: "high",
-    schema: FINDINGS_SCHEMA,
+    schema: INTEGRATED_SCHEMA,
   },
 );
 

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -59,12 +59,9 @@ const bundled = (rel) =>
 // audit/snapshot.py resolves the timestamp, branch, and the delta against the
 // prior snapshot. The agent only writes the payload to a temp file and runs the
 // script once; the disk side-effect is the goal, its result is not consumed.
-// snapshot.py's build_record passes the payload straight through via dict(), so the keys
-// emitted here become the record's own fields. Anything that lives only on the return value
-// cannot be read back from the record, so the cull counts and the zero-reviewer files go into
-// the payload too. tally is passed as undefined when challengeRan is false, letting
-// JSON.stringify drop the key entirely: a fail-open run carrying counts would be
-// indistinguishable in the record from a run that confirmed every finding.
+// snapshot.py's build_record turns the payload keys into the record's fields verbatim.
+// Anything that lives only on the return value cannot be read back from the record, so
+// whatever a reader must find there has to be passed here.
 const writeSnapshot = async ({
   preFlight,
   rawFindings,
@@ -87,7 +84,9 @@ const writeSnapshot = async ({
     challenge_ran: challengeRan,
     verify_ran: verifyRan,
     tally,
-    needs_context: needsContext,
+    // The same findings already appear in raw_findings carrying their verdict. This side
+    // table holds only why, which raw_findings cannot supply.
+    needs_context: needsContext && needsContext.map(({ id, why }) => ({ id, why })),
     zero_reviewer_files: zeroReviewerFiles,
   });
   await agent(
@@ -216,9 +215,8 @@ const FOCUS = {
 
 // Reviewers with an agents/reviewers/ definition but no ROUTING row: they run
 // only when a skill invokes them directly, not through /audit's fan-out, so
-// they carry no glob-table row and sit outside FOCUS. audit.routing.test.js's
-// T-014 enforces that every agents/reviewers/ definition lands in ROUTING or
-// here, so this list is the fence against a definition going unreachable.
+// they carry no glob-table row and sit outside FOCUS. A definition named in neither
+// place is left with no caller, so this list is the fence against that.
 const SKILL_ONLY_REVIEWERS = ["causation", "readability", "conformance"];
 
 const ext = (p) => {
@@ -521,8 +519,8 @@ if (!findings.length) {
 }
 
 // ---- Challenge ∥ Verify -> Integrate (reviewer -> aggregate is forbidden) ----
-// Two independent passes over the same findings run concurrently; Integrate
-// reconciles them with a fixed rule.
+// Two independent passes over the same findings run concurrently. Only Challenge's
+// verdicts decide membership; Verify's evidence never reaches Integrate.
 const findingsJson = JSON.stringify(findings);
 // Mirrors workflows/polish.js's VERDICTS_SCHEMA shape (id/verdict/severity/why); the
 // severity enum tracks this file's own FINDINGS_SCHEMA (critical/high/medium/low) rather
@@ -614,10 +612,8 @@ const needsContext = [];
 let noVerdict = 0;
 for (const f of rawFindings) {
   const v = verdictById.get(f.id);
-  // The verdict is written back onto rawFindings itself. Sorting findings into survivors
-  // and needsContext alone leaves a disputed id in neither, so it vanishes from the record
-  // and per-reviewer survival rates cannot be measured. rawFindings goes into the snapshot
-  // payload as is, which makes this the place a per-finding verdict lives.
+  // A disputed id enters neither survivors nor needsContext. Without the write-back it
+  // vanishes from the record and per-reviewer survival rates cannot be measured.
   f.verdict = v ? v.verdict : "no_verdict";
   if (!v) {
     noVerdict++;
@@ -635,13 +631,9 @@ for (const f of rawFindings) {
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
-// challenge_ran distinguishes "challenge actually returned verdicts" from the fail-open
-// path (challenged is null/undefined -> verdictById is empty -> every finding defaults to
-// confirmed via no_verdict); tally carries the triage counts for callers who want them
-// without re-deriving from survivors / needsContext / noVerdict.
-// The verify pass returns free-form text, so it is judged by whether content came back
-// rather than by a schema shape. Its output is never forwarded to Integrate, which leaves
-// the record as the only place a reader can tell whether the pass ran at all.
+// challenge_ran separates a run that returned verdicts from the fail-open path (an empty
+// verdictById drops every finding to confirmed via no_verdict). verify returns free-form
+// text, so it is judged by whether content came back rather than by a schema shape.
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
 const verifyRan = !!String(verified || "").trim();
 const tally = {
@@ -651,12 +643,10 @@ const tally = {
 };
 
 phase("Integrate");
-// Membership is already decided by the triage loop above: Integrate's input is survivors
-// only, never the full findings / challenge / verify payload, so it has no way to re-cull
-// a finding the challenge pass already confirmed. The verification pass still runs (for its
-// execution-path evidence), but that evidence stays informational and is not forwarded here.
+// Narrowing the input to survivors removes the path by which Integrate could re-cull a
+// finding the challenge pass already confirmed.
 log(
-  `verify pass returned ${verified ? "output" : "no output"}; kept informational, not forwarded to Integrate.`,
+  `verify pass returned ${verifyRan ? "output" : "no output"}; kept informational, not forwarded to Integrate.`,
 );
 const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
@@ -688,6 +678,8 @@ await writeSnapshot({
   skipped,
   challengeRan,
   verifyRan,
+  // The plan's contract: a fail-open run keeps the degraded mark and writes no counts.
+  // Passing undefined makes JSON.stringify drop the key.
   tally: challengeRan ? tally : undefined,
   needsContext,
   zeroReviewerFiles,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -552,16 +552,20 @@ const VERDICTS_SCHEMA = {
     },
   },
 };
-// The critic's input is rawFindings (the source of the R-N ids triage keys off of) with
-// the reviewer field left out, so the challenge verdict cannot be biased by which
-// reviewer raised the finding.
-const challengeInput = rawFindings.map((f) => ({
+// Both critic-audit's challenge input and Integrate's survivors input need the same
+// projection (rawFindings' message field renamed to summary); one helper keeps the shape
+// from drifting between the two call sites.
+const toCriticRef = (f) => ({
   id: f.id,
   file: f.file,
   line: f.line,
   severity: f.severity,
   summary: f.message,
-}));
+});
+// The critic's input is rawFindings (the source of the R-N ids triage keys off of) with
+// the reviewer field left out, so the challenge verdict cannot be biased by which
+// reviewer raised the finding.
+const challengeInput = rawFindings.map(toCriticRef);
 const [challenged, verified] = await parallel([
   () =>
     agent(
@@ -647,13 +651,7 @@ phase("Integrate");
 log(
   `verify pass returned ${verified ? "output" : "no output"}; kept informational, not forwarded to Integrate.`,
 );
-const survivorsInput = survivors.map((s) => ({
-  id: s.id,
-  file: s.file,
-  line: s.line,
-  severity: s.severity,
-  summary: s.message,
-}));
+const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
   anchor(
     `enhancer-integration. Reconcile these survivors of the challenge triage, matched by file:line, into cross-domain root causes and a severity-ordered list.\n` +

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -447,17 +447,60 @@ if (!findings.length) {
 // Two independent passes over the same findings run concurrently; Integrate
 // reconciles them with a fixed rule.
 const findingsJson = JSON.stringify(findings);
+// Mirrors workflows/polish.js's VERDICTS_SCHEMA shape (id/verdict/severity/why); the
+// severity enum tracks this file's own FINDINGS_SCHEMA (critical/high/medium/low) rather
+// than polish's P1/P2/P3, since the two workflows score severity on different scales.
+const VERDICTS_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["verdicts"],
+  properties: {
+    verdicts: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "verdict"],
+        properties: {
+          id: { type: "string" },
+          verdict: {
+            type: "string",
+            enum: ["confirmed", "disputed", "downgraded", "needs_context"],
+          },
+          severity: {
+            type: "string",
+            enum: ["critical", "high", "medium", "low"],
+          },
+          why: { type: "string" },
+        },
+      },
+    },
+  },
+};
+// The critic's input is rawFindings (the source of the R-N ids triage keys off of) with
+// the reviewer field left out, so the challenge verdict cannot be biased by which
+// reviewer raised the finding.
+const challengeInput = rawFindings.map((f) => ({
+  id: f.id,
+  file: f.file,
+  line: f.line,
+  severity: f.severity,
+  summary: f.message,
+}));
 const [challenged, verified] = await parallel([
   () =>
     agent(
       anchor(
-        `critic-audit. Challenge these findings to prune false positives. Each finding is a position to be argued, not a fact. Reference each finding by its file:line. The findings are as follows.\n${findingsJson}`,
+        `critic-audit. Challenge these findings to prune false positives. Each finding is a position to be argued, not a fact. Reference each finding by its id.\n` +
+          `The verdict criteria are as follows. confirmed = real and the severity holds / disputed = false positive / downgraded = real but severity inflated (put the lowered severity in severity) / needs_context = undecidable from code alone, needs human context.\n` +
+          `The findings are as follows.\n${JSON.stringify(challengeInput)}`,
       ),
       {
         agentType: "critic-audit",
         phase: "Challenge",
         label: "challenge",
         model: "sonnet",
+        schema: VERDICTS_SCHEMA,
         // Judge stages take xhigh on the difficulty criterion (the docs' "the hardest coding
         // and agentic tasks"). They run for minutes, short of the long-horizon threshold, but
         // the quality of rejecting a finding drives false positives, so spend on accuracy.
@@ -479,12 +522,40 @@ const [challenged, verified] = await parallel([
     ),
 ]);
 
+// ---- Triage: script owns survivor determination, the critic only returns verdicts ----
+// Loop the finding side (not the verdict side) so a finding the challenge agent dropped
+// a verdict for is not silently lost; it defaults to confirmed and is counted as
+// no_verdict, the same fail-open shape a total challenge-agent failure takes (an empty
+// verdict list leaves every finding no_verdict).
+const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
+const survivors = [];
+const needsContext = [];
+let noVerdict = 0;
+for (const f of rawFindings) {
+  const v = verdictById.get(f.id);
+  if (!v) {
+    noVerdict++;
+    survivors.push({ ...f });
+    continue;
+  }
+  if (v.verdict === "disputed") continue;
+  if (v.verdict === "needs_context") {
+    needsContext.push({ ...f, why: v.why || "" });
+    continue;
+  }
+  const severity = v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
+  survivors.push({ ...f, severity });
+}
+log(
+  `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
+);
+
 phase("Integrate");
 const integrated = await agent(
   anchor(
     `enhancer-integration. Reconcile two independent passes over the same findings, matched by file:line, into cross-domain root causes and a severity-ordered list.\n` +
       `Membership rule: the challenge pass decides which findings survive. A finding the challenge pass pruned as a false positive stays pruned even if the verification pass found evidence for it. The verification pass only supplies execution-path evidence and severity for the survivors; it never revives a pruned finding.\n` +
-      `The challenge pass (membership / false-positive pruning) is as follows.\n${challenged}\n\n` +
+      `The challenge pass (membership / false-positive pruning) is as follows.\n${JSON.stringify(challenged)}\n\n` +
       `The verification pass (execution-path evidence + severity) is as follows.\n${verified}`,
   ),
   {
@@ -504,4 +575,10 @@ await writeSnapshot({
   findings: finalFindings,
   skipped,
 });
-return { findings: finalFindings, assignments, skipped };
+return {
+  findings: finalFindings,
+  survivors,
+  needs_context: needsContext,
+  assignments,
+  skipped,
+};

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -59,7 +59,7 @@ const bundled = (rel) =>
 // audit/snapshot.py resolves the timestamp, branch, and the delta against the
 // prior snapshot. The agent only writes the payload to a temp file and runs the
 // script once; the disk side-effect is the goal, its result is not consumed.
-const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
+const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped, challengeRan }) => {
   phase("Snapshot");
   const payload = JSON.stringify({
     scope: scope || "HEAD",
@@ -68,6 +68,7 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped }) => {
     raw_findings: rawFindings,
     findings,
     skipped,
+    challenge_ran: challengeRan,
   });
   await agent(
     anchor(
@@ -480,8 +481,14 @@ const skipped = units
   }));
 
 if (!findings.length) {
-  await writeSnapshot({ preFlight, rawFindings, findings: [], skipped });
-  return { findings: [], assignments, skipped, zero_reviewer_files: zeroReviewerFiles };
+  await writeSnapshot({ preFlight, rawFindings, findings: [], skipped, challengeRan: false });
+  return {
+    findings: [],
+    assignments,
+    skipped,
+    zero_reviewer_files: zeroReviewerFiles,
+    challenge_ran: false,
+  };
 }
 
 // ---- Challenge ∥ Verify -> Integrate (reviewer -> aggregate is forbidden) ----
@@ -633,12 +640,17 @@ const integrated = await agent(
   },
 );
 
-const finalFindings = (integrated && integrated.findings) || findings;
+// Integrate-absent fallback must stay the triaged survivors (each still carrying its
+// own R-N id), never the pre-triage findings array: that array predates the id
+// assignment in rawFindings, so falling back to it would silently readmit findings
+// the challenge triage already disputed.
+const finalFindings = (integrated && integrated.findings) || survivorsInput;
 await writeSnapshot({
   preFlight,
   rawFindings,
   findings: finalFindings,
   skipped,
+  challengeRan,
 });
 return {
   findings: finalFindings,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -590,6 +590,16 @@ for (const f of rawFindings) {
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
+// challenge_ran distinguishes "challenge actually returned verdicts" from the fail-open
+// path (challenged is null/undefined -> verdictById is empty -> every finding defaults to
+// confirmed via no_verdict); tally carries the triage counts for callers who want them
+// without re-deriving from survivors / needsContext / noVerdict.
+const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
+const tally = {
+  survived: survivors.length,
+  needs_context: needsContext.length,
+  no_verdict: noVerdict,
+};
 
 phase("Integrate");
 // Membership is already decided by the triage loop above: Integrate's input is survivors
@@ -634,6 +644,8 @@ return {
   findings: finalFindings,
   survivors,
   needs_context: needsContext,
+  challenge_ran: challengeRan,
+  tally,
   assignments,
   skipped,
   zero_reviewer_files: zeroReviewerFiles,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -676,6 +676,11 @@ for (const f of rawFindings) {
     continue;
   }
   const severity = v.verdict === "downgraded" && v.severity ? v.severity : f.severity;
+  // The lowered value goes in its own field. Overwriting f.severity would erase what the
+  // reviewer assigned, and with it any measure of whether reviewers inflate severity.
+  // survivors carry only the lowered value, and after Integrate merges there is no
+  // per-finding severity left to read.
+  if (severity !== f.severity) f.downgraded_to = severity;
   survivors.push({ ...f, severity });
 }
 log(

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -233,6 +233,12 @@ const FINDINGS_SCHEMA = {
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
+          source_ids: {
+            type: "array",
+            items: { type: "string" },
+            description:
+              "R-N ids of the raw findings this finding absorbed (Integrate output only)",
+          },
         },
       },
     },
@@ -551,12 +557,26 @@ log(
 );
 
 phase("Integrate");
+// Membership is already decided by the triage loop above: Integrate's input is survivors
+// only, never the full findings / challenge / verify payload, so it has no way to re-cull
+// a finding the challenge pass already confirmed. The verification pass still runs (for its
+// execution-path evidence), but that evidence stays informational and is not forwarded here.
+log(
+  `verify pass returned ${verified ? "output" : "no output"}; kept informational, not forwarded to Integrate.`,
+);
+const survivorsInput = survivors.map((s) => ({
+  id: s.id,
+  file: s.file,
+  line: s.line,
+  severity: s.severity,
+  summary: s.message,
+}));
 const integrated = await agent(
   anchor(
-    `enhancer-integration. Reconcile two independent passes over the same findings, matched by file:line, into cross-domain root causes and a severity-ordered list.\n` +
-      `Membership rule: the challenge pass decides which findings survive. A finding the challenge pass pruned as a false positive stays pruned even if the verification pass found evidence for it. The verification pass only supplies execution-path evidence and severity for the survivors; it never revives a pruned finding.\n` +
-      `The challenge pass (membership / false-positive pruning) is as follows.\n${JSON.stringify(challenged)}\n\n` +
-      `The verification pass (execution-path evidence + severity) is as follows.\n${verified}`,
+    `enhancer-integration. Reconcile these survivors of the challenge triage, matched by file:line, into cross-domain root causes and a severity-ordered list.\n` +
+      `Membership is already decided: every survivor below already passed the challenge pass. Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes.\n` +
+      `Each finding you return must carry source_ids listing every survivor id (R-N) it absorbed, so a root cause merged from several survivors keeps all of their ids.\n` +
+      `The survivors are as follows.\n${JSON.stringify(survivorsInput)}`,
   ),
   {
     agentType: "enhancer-integration",

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -128,7 +128,10 @@ const writeSnapshot = async ({
       agentType: "general-purpose",
       phase: "Snapshot",
       label: "snapshot",
-      model: "haiku",
+      // On haiku, transcribing a long payload turns into summarizing partway through:
+      // measured, 44 raw_findings came out as 2. No judgment is asked of this stage, but
+      // the length of what it copies is what decides the model.
+      model: "sonnet",
       schema: SNAPSHOT_SCHEMA,
     },
   );

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -65,22 +65,28 @@ const bundled = (rel) =>
 //
 // The payload only reaches the agent embedded in a prompt, and an agent that summarizes
 // while transcribing leaves the record alone thinned out. Measured: a run whose findings
-// carried long summaries wrote 2 raw_findings where the payload held 44, and nothing caught
-// it until the count contradicted tally. Have the record read back and the counts returned,
-// then compare them here.
+// carried long summaries wrote 2 raw_findings where the payload held 44. Having the agent
+// report the counts would make the party that cut them the one reporting on it, so the
+// counts come from snapshot.py, which counted the stdin it received.
 const SNAPSHOT_SCHEMA = {
   type: "object",
   additionalProperties: false,
-  required: ["path", "raw_findings_count", "findings_count"],
+  required: ["path", "counts"],
   properties: {
-    path: { type: "string", description: "the path snapshot.py printed to stdout" },
-    raw_findings_count: {
-      type: "integer",
-      description: "raw_findings element count read back from the written record, not the payload",
-    },
-    findings_count: {
-      type: "integer",
-      description: "findings element count read back from the written record, not the payload",
+    path: { type: "string", description: "path from snapshot.py's stdout JSON, verbatim" },
+    counts: {
+      type: "object",
+      additionalProperties: false,
+      required: ["raw_findings", "findings", "skipped", "needs_context", "zero_reviewer_files"],
+      description:
+        "counts from snapshot.py's stdout JSON, verbatim. Do not recount and do not alter the values",
+      properties: {
+        raw_findings: { type: "integer" },
+        findings: { type: "integer" },
+        skipped: { type: "integer" },
+        needs_context: { type: "integer" },
+        zero_reviewer_files: { type: "integer" },
+      },
     },
   },
 };
@@ -118,11 +124,11 @@ const writeSnapshot = async ({
         `\`python3 ${bundled("workflows/audit/snapshot.py")} < <tempfile>\` once. ` +
         `The script resolves the timestamp, branch, and the delta against the ` +
         `prior snapshot (resolved / new / carried, matched on file + message), writes the record under ` +
-        `$HOME/.claude/history/, and prints the output path to stdout. ` +
+        `$HOME/.claude/history/, and prints one line of JSON, {path, counts}, to stdout. ` +
         `Write the payload verbatim. Do not summarize, omit, reformat, or regenerate it, and do not truncate it for length. ` +
         `Do not review code or change any finding. Do not write the file by any other means. ` +
-        `Once written, read the record back from the output path and return the actual element counts of raw_findings and findings. ` +
-        `Count what is on disk, not what the payload says. The payload is as follows.\n${payload}`,
+        `Return that stdout JSON as path and counts. Do not recount and do not alter the values. ` +
+        `The payload is as follows.\n${payload}`,
     ),
     {
       agentType: "general-purpose",
@@ -135,21 +141,30 @@ const writeSnapshot = async ({
       schema: SNAPSHOT_SCHEMA,
     },
   );
-  // The script owns the comparison. Asking the agent whether it truncated makes the party
-  // that truncated the one reporting on it.
-  const expected = { raw: rawFindings.length, findings: findings.length };
+  // The script owns the comparison, and what it compares against is the count snapshot.py
+  // took of its own stdin, not the agent's report. The agent is the party doing the
+  // transcribing, so it would be reporting on what it itself dropped.
+  const expected = {
+    raw_findings: rawFindings.length,
+    findings: findings.length,
+    skipped: skipped.length,
+    needs_context: needsContext ? needsContext.length : 0,
+    zero_reviewer_files: zeroReviewerFiles ? zeroReviewerFiles.length : 0,
+  };
   if (!written) {
     log(`Snapshot: the agent returned no result; whether a record was written is unverified.`);
     return { written: false, truncated: null, expected };
   }
-  const actual = { raw: written.raw_findings_count, findings: written.findings_count };
-  const truncated = actual.raw !== expected.raw || actual.findings !== expected.findings;
-  if (truncated) {
+  const actual = written.counts;
+  const lost = Object.keys(expected).filter((k) => actual[k] !== expected[k]);
+  if (lost.length) {
     log(
-      `Snapshot truncated: raw_findings ${actual.raw}/${expected.raw}, findings ${actual.findings}/${expected.findings}. The record cannot be used to measure cull rates.`,
+      `Snapshot truncated: ${lost
+        .map((k) => `${k} ${actual[k]}/${expected[k]}`)
+        .join(", ")}. The record cannot be used to measure cull rates.`,
     );
   }
-  return { written: true, path: written.path, truncated, expected, actual };
+  return { written: true, path: written.path, truncated: lost.length > 0, lost, expected, actual };
 };
 
 // /audit routing table. react-pattern only attaches to JSX files (jsx / tsx), so a

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -71,6 +71,7 @@ const writeSnapshot = async ({
   findings,
   skipped,
   challengeRan,
+  verifyRan,
   tally,
   zeroReviewerFiles,
 }) => {
@@ -83,6 +84,7 @@ const writeSnapshot = async ({
     findings,
     skipped,
     challenge_ran: challengeRan,
+    verify_ran: verifyRan,
     tally,
     zero_reviewer_files: zeroReviewerFiles,
   });
@@ -503,6 +505,7 @@ if (!findings.length) {
     findings: [],
     skipped,
     challengeRan: false,
+    verifyRan: false,
     zeroReviewerFiles,
   });
   return {
@@ -511,6 +514,7 @@ if (!findings.length) {
     skipped,
     zero_reviewer_files: zeroReviewerFiles,
     challenge_ran: false,
+    verify_ran: false,
   };
 }
 
@@ -624,7 +628,11 @@ log(
 // path (challenged is null/undefined -> verdictById is empty -> every finding defaults to
 // confirmed via no_verdict); tally carries the triage counts for callers who want them
 // without re-deriving from survivors / needsContext / noVerdict.
+// The verify pass returns free-form text, so it is judged by whether content came back
+// rather than by a schema shape. Its output is never forwarded to Integrate, which leaves
+// the record as the only place a reader can tell whether the pass ran at all.
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
+const verifyRan = !!String(verified || "").trim();
 const tally = {
   survived: survivors.length,
   needs_context: needsContext.length,
@@ -674,6 +682,7 @@ await writeSnapshot({
   findings: finalFindings,
   skipped,
   challengeRan,
+  verifyRan,
   tally: challengeRan ? tally : undefined,
   zeroReviewerFiles,
 });
@@ -682,6 +691,7 @@ return {
   survivors,
   needs_context: needsContext,
   challenge_ran: challengeRan,
+  verify_ran: verifyRan,
   tally,
   assignments,
   skipped,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -62,6 +62,29 @@ const bundled = (rel) =>
 // snapshot.py's build_record turns the payload keys into the record's fields verbatim.
 // Anything that lives only on the return value cannot be read back from the record, so
 // whatever a reader must find there has to be passed here.
+//
+// The payload only reaches the agent embedded in a prompt, and an agent that summarizes
+// while transcribing leaves the record alone thinned out. Measured: a run whose findings
+// carried long summaries wrote 2 raw_findings where the payload held 44, and nothing caught
+// it until the count contradicted tally. Have the record read back and the counts returned,
+// then compare them here.
+const SNAPSHOT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["path", "raw_findings_count", "findings_count"],
+  properties: {
+    path: { type: "string", description: "the path snapshot.py printed to stdout" },
+    raw_findings_count: {
+      type: "integer",
+      description: "raw_findings element count read back from the written record, not the payload",
+    },
+    findings_count: {
+      type: "integer",
+      description: "findings element count read back from the written record, not the payload",
+    },
+  },
+};
+
 const writeSnapshot = async ({
   preFlight,
   rawFindings,
@@ -89,22 +112,41 @@ const writeSnapshot = async ({
     needs_context: needsContext && needsContext.map(({ id, why }) => ({ id, why })),
     zero_reviewer_files: zeroReviewerFiles,
   });
-  await agent(
+  const written = await agent(
     anchor(
       `You are the snapshot stage of an audit. Write the following JSON payload to a temp file and run ` +
         `\`python3 ${bundled("workflows/audit/snapshot.py")} < <tempfile>\` once. ` +
         `The script resolves the timestamp, branch, and the delta against the ` +
         `prior snapshot (resolved / new / carried, matched on file + message), writes the record under ` +
         `$HOME/.claude/history/, and prints the output path to stdout. ` +
-        `Do not review code or change any finding. Do not write the file by any other means. The payload is as follows.\n${payload}`,
+        `Write the payload verbatim. Do not summarize, omit, reformat, or regenerate it, and do not truncate it for length. ` +
+        `Do not review code or change any finding. Do not write the file by any other means. ` +
+        `Once written, read the record back from the output path and return the actual element counts of raw_findings and findings. ` +
+        `Count what is on disk, not what the payload says. The payload is as follows.\n${payload}`,
     ),
     {
       agentType: "general-purpose",
       phase: "Snapshot",
       label: "snapshot",
       model: "haiku",
+      schema: SNAPSHOT_SCHEMA,
     },
   );
+  // The script owns the comparison. Asking the agent whether it truncated makes the party
+  // that truncated the one reporting on it.
+  const expected = { raw: rawFindings.length, findings: findings.length };
+  if (!written) {
+    log(`Snapshot: the agent returned no result; whether a record was written is unverified.`);
+    return { written: false, truncated: null, expected };
+  }
+  const actual = { raw: written.raw_findings_count, findings: written.findings_count };
+  const truncated = actual.raw !== expected.raw || actual.findings !== expected.findings;
+  if (truncated) {
+    log(
+      `Snapshot truncated: raw_findings ${actual.raw}/${expected.raw}, findings ${actual.findings}/${expected.findings}. The record cannot be used to measure cull rates.`,
+    );
+  }
+  return { written: true, path: written.path, truncated, expected, actual };
 };
 
 // /audit routing table. react-pattern only attaches to JSX files (jsx / tsx), so a
@@ -511,7 +553,7 @@ const skipped = units
   }));
 
 if (!findings.length) {
-  await writeSnapshot({
+  const emptySnapshot = await writeSnapshot({
     preFlight,
     rawFindings,
     findings: [],
@@ -521,6 +563,7 @@ if (!findings.length) {
     zeroReviewerFiles,
   });
   return {
+    snapshot: emptySnapshot,
     findings: [],
     assignments,
     skipped,
@@ -683,7 +726,7 @@ const integrated = await agent(
 // assignment in rawFindings, so falling back to it would silently readmit findings
 // the challenge triage already disputed.
 const finalFindings = (integrated && integrated.findings) || survivorsInput;
-await writeSnapshot({
+const snapshot = await writeSnapshot({
   preFlight,
   rawFindings,
   findings: finalFindings,
@@ -697,6 +740,7 @@ await writeSnapshot({
   zeroReviewerFiles,
 });
 return {
+  snapshot,
   findings: finalFindings,
   survivors,
   needs_context: needsContext,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -59,7 +59,21 @@ const bundled = (rel) =>
 // audit/snapshot.py resolves the timestamp, branch, and the delta against the
 // prior snapshot. The agent only writes the payload to a temp file and runs the
 // script once; the disk side-effect is the goal, its result is not consumed.
-const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped, challengeRan }) => {
+// snapshot.py's build_record passes the payload straight through via dict(), so the keys
+// emitted here become the record's own fields. Anything that lives only on the return value
+// cannot be read back from the record, so the cull counts and the zero-reviewer files go into
+// the payload too. tally is passed as undefined when challengeRan is false, letting
+// JSON.stringify drop the key entirely: a fail-open run carrying counts would be
+// indistinguishable in the record from a run that confirmed every finding.
+const writeSnapshot = async ({
+  preFlight,
+  rawFindings,
+  findings,
+  skipped,
+  challengeRan,
+  tally,
+  zeroReviewerFiles,
+}) => {
   phase("Snapshot");
   const payload = JSON.stringify({
     scope: scope || "HEAD",
@@ -69,6 +83,8 @@ const writeSnapshot = async ({ preFlight, rawFindings, findings, skipped, challe
     findings,
     skipped,
     challenge_ran: challengeRan,
+    tally,
+    zero_reviewer_files: zeroReviewerFiles,
   });
   await agent(
     anchor(
@@ -481,7 +497,14 @@ const skipped = units
   }));
 
 if (!findings.length) {
-  await writeSnapshot({ preFlight, rawFindings, findings: [], skipped, challengeRan: false });
+  await writeSnapshot({
+    preFlight,
+    rawFindings,
+    findings: [],
+    skipped,
+    challengeRan: false,
+    zeroReviewerFiles,
+  });
   return {
     findings: [],
     assignments,
@@ -651,6 +674,8 @@ await writeSnapshot({
   findings: finalFindings,
   skipped,
   challengeRan,
+  tally: challengeRan ? tally : undefined,
+  zeroReviewerFiles,
 });
 return {
   findings: finalFindings,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -63,11 +63,10 @@ const bundled = (rel) =>
 // Anything that lives only on the return value cannot be read back from the record, so
 // whatever a reader must find there has to be passed here.
 //
-// The payload only reaches the agent embedded in a prompt, and an agent that summarizes
-// while transcribing leaves the record alone thinned out. Measured: a run whose findings
-// carried long summaries wrote 2 raw_findings where the payload held 44. Having the agent
-// report the counts would make the party that cut them the one reporting on it, so the
-// counts come from snapshot.py, which counted the stdin it received.
+// The payload only reaches the agent embedded in a prompt, and summarizing while
+// transcribing leaves the record alone thinned out. Having the agent report the counts
+// would make the party that cut them the one reporting on it, so they come from
+// snapshot.py, which counted the stdin it received.
 const SNAPSHOT_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -134,9 +133,9 @@ const writeSnapshot = async ({
       agentType: "general-purpose",
       phase: "Snapshot",
       label: "snapshot",
-      // On haiku, transcribing a long payload turns into summarizing partway through:
-      // measured, 44 raw_findings came out as 2. No judgment is asked of this stage, but
-      // the length of what it copies is what decides the model.
+      // On haiku, transcribing a long payload turns into summarizing partway through.
+      // No judgment is asked of this stage, but the length of what it copies decides
+      // the model.
       model: "sonnet",
       schema: SNAPSHOT_SCHEMA,
     },
@@ -273,12 +272,6 @@ const FOCUS = {
   all: null,
 };
 
-// Reviewers with an agents/reviewers/ definition but no ROUTING row: they run
-// only when a skill invokes them directly, not through /audit's fan-out, so
-// they carry no glob-table row and sit outside FOCUS. A definition named in neither
-// place is left with no caller, so this list is the fence against that.
-const SKILL_ONLY_REVIEWERS = ["causation", "readability", "conformance"];
-
 const ext = (p) => {
   const base = p.slice(p.lastIndexOf("/") + 1);
   const dot = base.lastIndexOf(".");
@@ -298,22 +291,10 @@ const classify = (p) => {
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };
-// Runtime mirror of T-014 in audit.routing.test.js: a reviewer name should
-// never sit in both ROUTING and SKILL_ONLY_REVIEWERS. The test only catches
-// this at test time; this check catches the same drift on every actual run.
-const routingSkillOnlyOverlap = [...new Set(Object.values(ROUTING).flat())].filter((r) =>
-  SKILL_ONLY_REVIEWERS.includes(r),
-);
-if (routingSkillOnlyOverlap.length) {
-  log(
-    `Config drift: ROUTING and SKILL_ONLY_REVIEWERS both list ${routingSkillOnlyOverlap.join(", ")}.`,
-  );
-}
-
 // Only Integrate returns source_ids. Kept optional on the shared schema, an Integrate run
-// that omits it still passes validation and R-N tracking breaks per run (measured: one run
-// dropped it and put the ids in the summary prose instead). The reviewer variant lacks the
-// property entirely, so additionalProperties: false rejects a reviewer that invents ids.
+// that omits it still passes validation and R-N tracking breaks per run. The reviewer
+// variant lacks the property entirely, so additionalProperties: false rejects a reviewer
+// that invents ids.
 const findingsSchema = ({ withSourceIds = false } = {}) => ({
   type: "object",
   additionalProperties: false,
@@ -453,10 +434,8 @@ if (!files.length) {
 
 const focusSet = FOCUS[focus] === undefined ? null : FOCUS[focus];
 const assign = {};
-// A file whose classify() reviewers all fall outside the focus intersection
-// gets none: it is a degradation (the file is silently skipped, not audited),
-// so it is recorded here at file-path granularity per WORKFLOWS.md rather
-// than dropped.
+// A file whose classify() reviewers all fall outside the focus intersection drops out of
+// the audit silently. Keep it at file-path granularity so a reader can tell which fell out.
 const zeroReviewerFiles = [];
 for (const f of files) {
   const reviewers = classify(f.path).filter((r) => !focusSet || focusSet.includes(r));
@@ -625,9 +604,7 @@ const VERDICTS_SCHEMA = {
     },
   },
 };
-// Both critic-audit's challenge input and Integrate's survivors input need the same
-// projection (rawFindings' message field renamed to summary); one helper keeps the shape
-// from drifting between the two call sites.
+// One place for the projection, so the shape cannot drift between the two call sites.
 const toCriticRef = (f) => ({
   id: f.id,
   file: f.file,
@@ -675,10 +652,10 @@ const [challenged, verified] = await parallel([
 ]);
 
 // ---- Triage: script owns survivor determination, the critic only returns verdicts ----
-// Loop the finding side (not the verdict side) so a finding the challenge agent dropped
-// a verdict for is not silently lost; it defaults to confirmed and is counted as
-// no_verdict, the same fail-open shape a total challenge-agent failure takes (an empty
-// verdict list leaves every finding no_verdict).
+// Loop the finding side, not the verdict side. A finding the challenge agent dropped a
+// verdict for is not silently lost; it defaults to confirmed and lands in no_verdict.
+// A run where challenge failed entirely takes the same path, so the degradation survives
+// as a count.
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
@@ -739,10 +716,8 @@ const integrated = await agent(
   },
 );
 
-// Integrate-absent fallback must stay the triaged survivors (each still carrying its
-// own R-N id), never the pre-triage findings array: that array predates the id
-// assignment in rawFindings, so falling back to it would silently readmit findings
-// the challenge triage already disputed.
+// Falling back to the pre-triage findings array would land on the state before ids were
+// assigned, silently readmitting findings the challenge pass had disputed.
 const finalFindings = (integrated && integrated.findings) || survivorsInput;
 const snapshot = await writeSnapshot({
   preFlight,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -73,6 +73,7 @@ const writeSnapshot = async ({
   challengeRan,
   verifyRan,
   tally,
+  needsContext,
   zeroReviewerFiles,
 }) => {
   phase("Snapshot");
@@ -86,6 +87,7 @@ const writeSnapshot = async ({
     challenge_ran: challengeRan,
     verify_ran: verifyRan,
     tally,
+    needs_context: needsContext,
     zero_reviewer_files: zeroReviewerFiles,
   });
   await agent(
@@ -612,6 +614,11 @@ const needsContext = [];
 let noVerdict = 0;
 for (const f of rawFindings) {
   const v = verdictById.get(f.id);
+  // The verdict is written back onto rawFindings itself. Sorting findings into survivors
+  // and needsContext alone leaves a disputed id in neither, so it vanishes from the record
+  // and per-reviewer survival rates cannot be measured. rawFindings goes into the snapshot
+  // payload as is, which makes this the place a per-finding verdict lives.
+  f.verdict = v ? v.verdict : "no_verdict";
   if (!v) {
     noVerdict++;
     survivors.push({ ...f });
@@ -682,6 +689,7 @@ await writeSnapshot({
   challengeRan,
   verifyRan,
   tally: challengeRan ? tally : undefined,
+  needsContext,
   zeroReviewerFiles,
 });
 return {

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -177,11 +177,9 @@ const FOCUS = {
   security: ["security", "silence"],
   performance: ["react-pattern", "efficiency", "progressive"],
   quality: [
-    "readability",
     "design",
     "react-pattern",
     "rust",
-    "causation",
     "resilience",
     "duplication",
     "reuse",
@@ -189,10 +187,18 @@ const FOCUS = {
     "operations",
     "prompt",
     "silence",
+    "coverage",
   ],
   a11y: ["accessibility", "progressive"],
   all: null,
 };
+
+// Reviewers with an agents/reviewers/ definition but no ROUTING row: they run
+// only when a skill invokes them directly, not through /audit's fan-out, so
+// they carry no glob-table row and sit outside FOCUS. audit.routing.test.js's
+// T-014 enforces that every agents/reviewers/ definition lands in ROUTING or
+// here, so this list is the fence against a definition going unreachable.
+const SKILL_ONLY_REVIEWERS = ["causation", "readability", "conformance"];
 
 const ext = (p) => {
   const base = p.slice(p.lastIndexOf("/") + 1);
@@ -213,6 +219,17 @@ const classify = (p) => {
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };
+// Runtime mirror of T-014 in audit.routing.test.js: a reviewer name should
+// never sit in both ROUTING and SKILL_ONLY_REVIEWERS. The test only catches
+// this at test time; this check catches the same drift on every actual run.
+const routingSkillOnlyOverlap = [...new Set(Object.values(ROUTING).flat())].filter((r) =>
+  SKILL_ONLY_REVIEWERS.includes(r),
+);
+if (routingSkillOnlyOverlap.length) {
+  log(
+    `Config drift: ROUTING and SKILL_ONLY_REVIEWERS both list ${routingSkillOnlyOverlap.join(", ")}.`,
+  );
+}
 
 const FINDINGS_SCHEMA = {
   type: "object",
@@ -338,15 +355,25 @@ if (!files.length) {
   return {
     findings: [],
     skipped: [],
+    zero_reviewer_files: [],
     why: "No files to audit for the given scope.",
   };
 }
 
 const focusSet = FOCUS[focus] === undefined ? null : FOCUS[focus];
 const assign = {};
+// A file whose classify() reviewers all fall outside the focus intersection
+// gets none: it is a degradation (the file is silently skipped, not audited),
+// so it is recorded here at file-path granularity per WORKFLOWS.md rather
+// than dropped.
+const zeroReviewerFiles = [];
 for (const f of files) {
-  for (const r of classify(f.path)) {
-    if (focusSet && !focusSet.includes(r)) continue;
+  const reviewers = classify(f.path).filter((r) => !focusSet || focusSet.includes(r));
+  if (!reviewers.length) {
+    zeroReviewerFiles.push({ path: f.path });
+    continue;
+  }
+  for (const r of reviewers) {
     (assign[r] = assign[r] || []).push(f.path);
   }
 }
@@ -354,6 +381,14 @@ const assignments = Object.entries(assign).map(([reviewer, fs]) => ({
   reviewer,
   files: fs,
 }));
+
+if (zeroReviewerFiles.length) {
+  log(
+    `Zero-reviewer files [focus=${focus}]: ${zeroReviewerFiles.length} - ${zeroReviewerFiles
+      .map((f) => f.path)
+      .join(", ")}`,
+  );
+}
 
 // The interactive /audit prompts to narrow scope past 30 files; headless has
 // no prompt, so warn and continue.
@@ -446,7 +481,7 @@ const skipped = units
 
 if (!findings.length) {
   await writeSnapshot({ preFlight, rawFindings, findings: [], skipped });
-  return { findings: [], assignments, skipped };
+  return { findings: [], assignments, skipped, zero_reviewer_files: zeroReviewerFiles };
 }
 
 // ---- Challenge ∥ Verify -> Integrate (reviewer -> aggregate is forbidden) ----
@@ -601,4 +636,5 @@ return {
   needs_context: needsContext,
   assignments,
   skipped,
+  zero_reviewer_files: zeroReviewerFiles,
 };

--- a/workflows/audit/snapshot.py
+++ b/workflows/audit/snapshot.py
@@ -9,7 +9,9 @@ stdin:  JSON {scope, focus, pre_flight, raw_findings[], findings[], skipped[],
         verdict} once the triage pass has run.
         Every key is copied to the record verbatim; absent keys stay absent. An absent
         tally means the run failed open, which challenge_ran / verify_ran state directly.
-stdout: the path of the JSON record written.
+stdout: one line of JSON, {path, counts}. counts holds the element count of each
+        array this process serialized, so the caller compares against a figure it
+        did not obtain from the agent that transcribed the payload.
 exit 0 on success. exit 1 on an unparseable payload (nothing written).
 
 Resolved fields (shell / prior snapshot), added to the record:
@@ -72,10 +74,15 @@ def contradicts_own_tally(data):
     raw = data.get("raw_findings")
     if not isinstance(tally, dict) or not isinstance(raw, list):
         return False
-    accounted = tally.get("survived", 0) + tally.get("needs_context", 0)
-    if not isinstance(accounted, int):
+    survived = tally.get("survived", 0)
+    needs_context = tally.get("needs_context", 0)
+    # The operands are checked before they are added. A prior carrying "survived": "21"
+    # would raise on the addition, and latest_prior_raw only catches OSError / ValueError,
+    # so main() would die and write no record at all -- for exactly the malformed prior
+    # this function exists to step over.
+    if not isinstance(survived, int) or not isinstance(needs_context, int):
         return False
-    return len(raw) < accounted
+    return len(raw) < survived + needs_context
 
 
 def latest_prior_raw(history_dir):

--- a/workflows/audit/snapshot.py
+++ b/workflows/audit/snapshot.py
@@ -58,12 +58,34 @@ def compute_delta(current_raw, prior_raw):
     }
 
 
+def contradicts_own_tally(data):
+    """True when the record holds fewer raw_findings than its own tally accounts for.
+
+    raw_findings is survived + needs_context + disputed, so a record carrying a
+    tally satisfies len(raw_findings) >= survived + needs_context. A record that
+    fails this lost entries after the tally was computed -- the payload reaches
+    the writer through an LLM prompt, and one that summarizes while transcribing
+    thins the arrays without touching the counts. Records without a tally are
+    left alone; there is nothing to check them against.
+    """
+    tally = data.get("tally")
+    raw = data.get("raw_findings")
+    if not isinstance(tally, dict) or not isinstance(raw, list):
+        return False
+    accounted = tally.get("survived", 0) + tally.get("needs_context", 0)
+    if not isinstance(accounted, int):
+        return False
+    return len(raw) < accounted
+
+
 def latest_prior_raw(history_dir):
-    """raw_findings of the most recent prior audit-*.json, or None if none exists.
+    """raw_findings of the most recent usable prior audit-*.json, or None.
 
     Sorted by filename; the name embeds a UTC timestamp so lexical order is
-    chronological. A prior file that is unreadable or lacks raw_findings is
-    skipped rather than aborting the run.
+    chronological. A prior file that is unreadable, lacks raw_findings, or
+    contradicts its own tally is skipped rather than aborting the run. Taking a
+    thinned record as the baseline reports its missing entries as new on the next
+    run and as resolved on the run after, so the delta stays wrong twice.
     """
     priors = sorted(glob.glob(str(history_dir / "audit-*.json")), reverse=True)
     for path in priors:
@@ -71,6 +93,8 @@ def latest_prior_raw(history_dir):
             with open(path) as fh:
                 data = json.load(fh)
         except (OSError, ValueError):
+            continue
+        if contradicts_own_tally(data):
             continue
         raw = data.get("raw_findings")
         if isinstance(raw, list):
@@ -91,6 +115,28 @@ def git_branch():
         return branch or "unknown"
     except (OSError, subprocess.SubprocessError):
         return "unknown"
+
+
+COUNTED_ARRAYS = (
+    "raw_findings",
+    "findings",
+    "skipped",
+    "needs_context",
+    "zero_reviewer_files",
+)
+
+
+def counted_arrays(record):
+    """Element count per array the record carries, for the caller to compare against.
+
+    An absent key counts 0 rather than being omitted, so the caller reads the
+    same key set every run and a dropped array is a count mismatch instead of a
+    missing field.
+    """
+    return {
+        key: len(record[key]) if isinstance(record.get(key), list) else 0
+        for key in COUNTED_ARRAYS
+    }
 
 
 def build_record(payload, branch, generated_at, delta):
@@ -127,7 +173,9 @@ def main():
     out_path = HISTORY_DIR / f"audit-{now.strftime('%Y-%m-%d-%H%M%S')}.json"
     with open(out_path, "w") as fh:
         json.dump(record, fh, ensure_ascii=False, indent=2)
-    print(str(out_path))
+    # The counts come from what this process serialized, so the caller compares
+    # against them instead of against a figure the agent reports about itself.
+    print(json.dumps({"path": str(out_path), "counts": counted_arrays(record)}))
 
 
 if __name__ == "__main__":

--- a/workflows/audit/snapshot.py
+++ b/workflows/audit/snapshot.py
@@ -65,10 +65,10 @@ def contradicts_own_tally(data):
 
     raw_findings is survived + needs_context + disputed, so a record carrying a
     tally satisfies len(raw_findings) >= survived + needs_context. A record that
-    fails this lost entries after the tally was computed -- the payload reaches
-    the writer through an LLM prompt, and one that summarizes while transcribing
-    thins the arrays without touching the counts. Records without a tally are
-    left alone; there is nothing to check them against.
+    fails this lost entries after the tally was computed: the payload reaches the
+    writer through an LLM prompt, and summarizing while transcribing thins the
+    arrays without touching the counts. Records without a tally are left alone;
+    there is nothing to check them against.
     """
     tally = data.get("tally")
     raw = data.get("raw_findings")

--- a/workflows/audit/snapshot.py
+++ b/workflows/audit/snapshot.py
@@ -3,8 +3,12 @@
 Record one audit run to $HOME/.claude/history/ and compute the
 resolved/new/carried delta against the most recent prior snapshot.
 
-stdin:  JSON {scope, focus, pre_flight, raw_findings[], findings[], skipped[]}
-        each raw_findings entry carries at least {file, message}.
+stdin:  JSON {scope, focus, pre_flight, raw_findings[], findings[], skipped[],
+        challenge_ran, verify_ran, tally, needs_context[], zero_reviewer_files[]}
+        each raw_findings entry carries at least {file, message}, plus {id, reviewer,
+        verdict} once the triage pass has run.
+        Every key is copied to the record verbatim; absent keys stay absent. An absent
+        tally means the run failed open, which challenge_ran / verify_ran state directly.
 stdout: the path of the JSON record written.
 exit 0 on success. exit 1 on an unparseable payload (nothing written).
 

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -22,6 +22,7 @@ const agentStub =
   (prompt, opts) => {
     const { challenge, integrate } = opt;
     const verify = "verify" in opt ? opt.verify : "verify pass output";
+    const snapshot = opt.snapshot;
     const label = opts && opts.label;
     if (label === "route") {
       return { files: [{ path: "sample.js", churn: 0 }] };
@@ -39,7 +40,9 @@ const agentStub =
     if (label === "challenge") return challenge;
     if (label === "verify") return verify;
     if (label === "integrate") return integrate;
-    // snapshot は戻り値を消費しない経路にフォールバックさせるため undefined のまま。
+    // snapshot の既定は undefined (agent が結果を返さなかった経路)。件数の照合を突く test
+    // だけが件数つきの返り値を渡す。
+    if (label === "snapshot") return snapshot;
     return undefined;
   };
 
@@ -60,6 +63,13 @@ const run = (opts) =>
     args: { focus: "security", skipPreflight: true },
     stubs: { agent: agentStub(opts) },
   });
+
+const BOTH_CONFIRMED = {
+  verdicts: [
+    { id: "R-1", verdict: "confirmed" },
+    { id: "R-2", verdict: "confirmed" },
+  ],
+};
 
 const INTEGRATED = {
   findings: [{ file: "sample.js", line: "1", severity: "high", summary: "integrated finding" }],
@@ -122,6 +132,43 @@ test("T-022 disputed で落ちた finding も snapshot payload の raw_findings 
     payload.needs_context.map((f) => f.id),
     ["R-2"],
     "needs_context の id が payload にも載る",
+  );
+});
+
+test("T-024 書き出された record の件数が payload と食い違う run は snapshot.truncated=true を返す", async () => {
+  const { result } = await run({
+    challenge: BOTH_CONFIRMED,
+    integrate: INTEGRATED,
+    // reviewer 2 体が 1 件ずつ返すので payload の raw_findings は 2 件。record 側が 1 件だけ
+    // 書けた状況を作る。
+    snapshot: { path: "/tmp/audit-x.json", raw_findings_count: 1, findings_count: 1 },
+  });
+  assert.equal(result.snapshot.truncated, true, "件数が食い違えば truncated を立てる");
+  assert.deepEqual(
+    result.snapshot.expected,
+    { raw: 2, findings: 1 },
+    "期待した件数が返り値に残り、何件失われたか読める",
+  );
+  assert.deepEqual(result.snapshot.actual, { raw: 1, findings: 1 }, "ディスク上の実件数も残る");
+});
+
+test("T-025 件数が payload と一致する run は snapshot.truncated=false を返す", async () => {
+  const { result } = await run({
+    challenge: BOTH_CONFIRMED,
+    integrate: INTEGRATED,
+    snapshot: { path: "/tmp/audit-y.json", raw_findings_count: 2, findings_count: 1 },
+  });
+  assert.equal(result.snapshot.truncated, false, "一致すれば truncated は false");
+  assert.equal(result.snapshot.written, true, "record が書かれたことも返り値に残る");
+});
+
+test("T-026 snapshot agent が結果を返さない run は written=false を持ち truncated を断定しない", async () => {
+  const { result } = await run({ challenge: BOTH_CONFIRMED, integrate: INTEGRATED });
+  assert.equal(result.snapshot.written, false, "結果が無い run は written=false");
+  assert.equal(
+    result.snapshot.truncated,
+    null,
+    "書かれたか未確認の run を truncated=false と断定しない",
   );
 });
 

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -13,7 +13,7 @@ const auditJs = join(here, "..", "..", "audit.js");
 
 // Route -> Review (security / silence の 2 reviewer) -> Challenge/Verify -> Integrate まで
 // 通す最小 stub。focus: "security" で rawFindings の id を R-1 (security) / R-2 (silence) に
-// 固定するのは audit.triage.test.js / audit.effort.test.js と同じ組み方。
+// 固定する。
 // verify は既定で出力を返す。verify_ran の fail-open を突く test だけが verify: undefined を
 // 明示的に渡す。デフォルト引数は値が undefined のとき発動してしまい「返さなかった」を表現
 // できないので、キーが渡されたかどうかで既定値を分ける。

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -145,6 +145,25 @@ const counts = (over) => ({
   ...over,
 });
 
+test("T-028 downgraded の finding は元の severity と下げ後の両方を record に残す", async () => {
+  const { calls } = await run({
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "downgraded", severity: "low" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    integrate: INTEGRATED,
+  });
+  // reviewer が severity を過大に付ける傾向は、元の値と下げ後の差でしか測れない。survivors は
+  // 下げ後しか持たず、Integrate が merge した後は finding 単位で追えない。
+  const payload = snapshotPayload(calls);
+  const raw = Object.fromEntries(payload.raw_findings.map((f) => [f.id, f]));
+  assert.equal(raw["R-1"].severity, "high", "元の severity は reviewer が付けた値のまま残る");
+  assert.equal(raw["R-1"].downgraded_to, "low", "critic が下げた先も併せて残る");
+  assert.equal(raw["R-2"].downgraded_to, undefined, "downgraded でない finding に下げ先は付かない");
+});
+
 test("T-024 snapshot.py が数えた件数が payload と食い違う run は失われた配列名を返す", async () => {
   const { result } = await run({
     challenge: BOTH_CONFIRMED,

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -95,6 +95,36 @@ test("T-006 challenge が全件を confirmed と判定した run は challenge_r
   assert.equal(payload.challenge_ran, true, "snapshot payload の challenge_ran も true");
 });
 
+test("T-022 disputed で落ちた finding も snapshot payload の raw_findings に verdict つきで残る", async () => {
+  const { calls } = await run({
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "disputed" },
+        { id: "R-2", verdict: "needs_context", why: "呼び出し元が不明" },
+      ],
+    },
+    integrate: INTEGRATED,
+  });
+  const payload = snapshotPayload(calls);
+  const byId = Object.fromEntries(payload.raw_findings.map((f) => [f.id, f]));
+  assert.equal(
+    byId["R-1"].verdict,
+    "disputed",
+    "survivors から外れた finding も id と verdict を record に残す",
+  );
+  assert.equal(byId["R-2"].verdict, "needs_context", "needs_context の finding も verdict を残す");
+  assert.equal(
+    byId["R-1"].reviewer,
+    "security",
+    "reviewer と verdict を突き合わせて生存率を測れる",
+  );
+  assert.deepEqual(
+    payload.needs_context.map((f) => f.id),
+    ["R-2"],
+    "needs_context の id が payload にも載る",
+  );
+});
+
 test("T-020 verify が結果を返さない run は返り値と snapshot payload の両方に verify_ran=false を持つ", async () => {
   const { result, calls } = await run({
     challenge: { verdicts: [{ id: "R-1", verdict: "confirmed" }] },

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -14,9 +14,14 @@ const auditJs = join(here, "..", "..", "audit.js");
 // Route -> Review (security / silence の 2 reviewer) -> Challenge/Verify -> Integrate まで
 // 通す最小 stub。focus: "security" で rawFindings の id を R-1 (security) / R-2 (silence) に
 // 固定するのは audit.triage.test.js / audit.effort.test.js と同じ組み方。
+// verify は既定で出力を返す。verify_ran の fail-open を突く test だけが verify: undefined を
+// 明示的に渡す。デフォルト引数は値が undefined のとき発動してしまい「返さなかった」を表現
+// できないので、キーが渡されたかどうかで既定値を分ける。
 const agentStub =
-  ({ challenge, integrate } = {}) =>
+  (opt = {}) =>
   (prompt, opts) => {
+    const { challenge, integrate } = opt;
+    const verify = "verify" in opt ? opt.verify : "verify pass output";
     const label = opts && opts.label;
     if (label === "route") {
       return { files: [{ path: "sample.js", churn: 0 }] };
@@ -32,7 +37,7 @@ const agentStub =
       };
     }
     if (label === "challenge") return challenge;
-    if (label === "verify") return "verify pass output";
+    if (label === "verify") return verify;
     if (label === "integrate") return integrate;
     // snapshot は戻り値を消費しない経路にフォールバックさせるため undefined のまま。
     return undefined;
@@ -88,6 +93,27 @@ test("T-006 challenge が全件を confirmed と判定した run は challenge_r
   );
   const payload = snapshotPayload(calls);
   assert.equal(payload.challenge_ran, true, "snapshot payload の challenge_ran も true");
+});
+
+test("T-020 verify が結果を返さない run は返り値と snapshot payload の両方に verify_ran=false を持つ", async () => {
+  const { result, calls } = await run({
+    challenge: { verdicts: [{ id: "R-1", verdict: "confirmed" }] },
+    integrate: INTEGRATED,
+    verify: undefined,
+  });
+  assert.equal(result.verify_ran, false, "verify が結果を返さないとき返り値の verify_ran は false");
+  const payload = snapshotPayload(calls);
+  assert.equal(payload.verify_ran, false, "snapshot payload の verify_ran も false");
+});
+
+test("T-021 verify が出力を返した run は verify_ran=true を持ち fail-open した run と区別できる", async () => {
+  const { result, calls } = await run({
+    challenge: { verdicts: [{ id: "R-1", verdict: "confirmed" }] },
+    integrate: INTEGRATED,
+  });
+  assert.equal(result.verify_ran, true, "verify が出力を返したとき verify_ran は true");
+  const payload = snapshotPayload(calls);
+  assert.equal(payload.verify_ran, true, "snapshot payload の verify_ran も true");
 });
 
 test("T-007 Integrate が結果を返さないとき最終 findings は survivors であって triage 前の findings ではない", async () => {

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -1,0 +1,130 @@
+// challenge / verify / integrate が結果を返さない run (fail-open) を、全件 confirmed の
+// run と区別できる形で記録する挙動を固定する。WORKFLOWS.md § Degradation recording の
+// "失敗が飲み込まれ fail-open で次段に進む" 行に対応: 何が検証できなかったか、未検証である
+// ことが challenge_ran / verify_ran として返り値と snapshot payload の両方に残る。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const auditJs = join(here, "..", "..", "audit.js");
+
+// Route -> Review (security / silence の 2 reviewer) -> Challenge/Verify -> Integrate まで
+// 通す最小 stub。focus: "security" で rawFindings の id を R-1 (security) / R-2 (silence) に
+// 固定するのは audit.triage.test.js / audit.effort.test.js と同じ組み方。
+const agentStub =
+  ({ challenge, integrate } = {}) =>
+  (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "route") {
+      return { files: [{ path: "sample.js", churn: 0 }] };
+    }
+    if (label === "security") {
+      return {
+        findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+      };
+    }
+    if (label === "silence") {
+      return {
+        findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+      };
+    }
+    if (label === "challenge") return challenge;
+    if (label === "verify") return "verify pass output";
+    if (label === "integrate") return integrate;
+    // snapshot は戻り値を消費しない経路にフォールバックさせるため undefined のまま。
+    return undefined;
+  };
+
+const callOf = (calls, label) => calls.agent.find((c) => c.opts && c.opts.label === label);
+
+// snapshot agent への prompt 末尾に payload が JSON.stringify の 1 行で埋め込まれる
+// (audit.js の writeSnapshot 参照)。そこを取り出して parse する。
+const snapshotPayload = (calls) => {
+  const call = callOf(calls, "snapshot");
+  assert.ok(call, "snapshot agent が起動する");
+  const match = call.prompt.match(/The payload is as follows\.\n(.*)$/s);
+  assert.ok(match, "snapshot prompt に payload が乗る");
+  return JSON.parse(match[1]);
+};
+
+const run = (opts) =>
+  runWorkflow(auditJs, {
+    args: { focus: "security", skipPreflight: true },
+    stubs: { agent: agentStub(opts) },
+  });
+
+const INTEGRATED = {
+  findings: [{ file: "sample.js", line: "1", severity: "high", summary: "integrated finding" }],
+};
+
+test("T-005 challenge が結果を返さない run は返り値と snapshot payload の両方に challenge_ran=false を持つ", async () => {
+  const { result, calls } = await run({ challenge: undefined, integrate: INTEGRATED });
+  assert.equal(
+    result.challenge_ran,
+    false,
+    "challenge が結果を返さないとき返り値の challenge_ran は false",
+  );
+  const payload = snapshotPayload(calls);
+  assert.equal(payload.challenge_ran, false, "snapshot payload の challenge_ran も false");
+});
+
+test("T-006 challenge が全件を confirmed と判定した run は challenge_ran=true を持ち fail-open した run と区別できる", async () => {
+  const { result, calls } = await run({
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    integrate: INTEGRATED,
+  });
+  assert.equal(
+    result.challenge_ran,
+    true,
+    "challenge が verdict を返したとき challenge_ran は true",
+  );
+  const payload = snapshotPayload(calls);
+  assert.equal(payload.challenge_ran, true, "snapshot payload の challenge_ran も true");
+});
+
+test("T-007 Integrate が結果を返さないとき最終 findings は survivors であって triage 前の findings ではない", async () => {
+  const { result } = await run({
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "disputed" },
+      ],
+    },
+    integrate: undefined,
+  });
+  assert.deepEqual(
+    result.findings.map((f) => f.id),
+    ["R-1"],
+    "Integrate が結果を返さないとき最終 findings は disputed を除いた survivors になる",
+  );
+});
+
+test("T-008 needs_context の finding は survivors から外れて返り値の needs_context に載る", async () => {
+  const { result } = await run({
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "needs_context", why: "human judgement needed" },
+      ],
+    },
+    integrate: INTEGRATED,
+  });
+  assert.deepEqual(
+    result.survivors.map((s) => s.id),
+    ["R-1"],
+    "needs_context の R-2 は survivors から外れる",
+  );
+  assert.deepEqual(
+    result.needs_context.map((n) => n.id),
+    ["R-2"],
+    "needs_context の R-2 は返り値の needs_context に載る",
+  );
+});

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -135,31 +135,63 @@ test("T-022 disputed で落ちた finding も snapshot payload の raw_findings 
   );
 });
 
-test("T-024 書き出された record の件数が payload と食い違う run は snapshot.truncated=true を返す", async () => {
+// snapshot.py が stdout に返す counts の形。agent はこれをそのまま持ち帰る。
+const counts = (over) => ({
+  raw_findings: 2,
+  findings: 1,
+  skipped: 0,
+  needs_context: 0,
+  zero_reviewer_files: 0,
+  ...over,
+});
+
+test("T-024 snapshot.py が数えた件数が payload と食い違う run は失われた配列名を返す", async () => {
   const { result } = await run({
     challenge: BOTH_CONFIRMED,
     integrate: INTEGRATED,
-    // reviewer 2 体が 1 件ずつ返すので payload の raw_findings は 2 件。record 側が 1 件だけ
-    // 書けた状況を作る。
-    snapshot: { path: "/tmp/audit-x.json", raw_findings_count: 1, findings_count: 1 },
+    // reviewer 2 体が 1 件ずつ返すので payload の raw_findings は 2 件。書き写しの途中で
+    // 1 件落ちた状況を作る。
+    snapshot: { path: "/tmp/audit-x.json", counts: counts({ raw_findings: 1 }) },
   });
   assert.equal(result.snapshot.truncated, true, "件数が食い違えば truncated を立てる");
   assert.deepEqual(
-    result.snapshot.expected,
-    { raw: 2, findings: 1 },
-    "期待した件数が返り値に残り、何件失われたか読める",
+    result.snapshot.lost,
+    ["raw_findings"],
+    "どの配列が痩せたかを名前で残す。件数だけでは何を失ったか読めない",
   );
-  assert.deepEqual(result.snapshot.actual, { raw: 1, findings: 1 }, "ディスク上の実件数も残る");
+  assert.equal(result.snapshot.expected.raw_findings, 2, "期待した件数が残る");
+  assert.equal(result.snapshot.actual.raw_findings, 1, "snapshot.py が数えた実件数も残る");
 });
 
 test("T-025 件数が payload と一致する run は snapshot.truncated=false を返す", async () => {
   const { result } = await run({
     challenge: BOTH_CONFIRMED,
     integrate: INTEGRATED,
-    snapshot: { path: "/tmp/audit-y.json", raw_findings_count: 2, findings_count: 1 },
+    snapshot: { path: "/tmp/audit-y.json", counts: counts() },
   });
   assert.equal(result.snapshot.truncated, false, "一致すれば truncated は false");
+  assert.deepEqual(result.snapshot.lost, [], "失われた配列は無い");
   assert.equal(result.snapshot.written, true, "record が書かれたことも返り値に残る");
+});
+
+test("T-027 raw_findings 以外の配列が痩せた run も検出する", async () => {
+  const { result } = await run({
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "needs_context", why: "呼び出し元が不明" },
+      ],
+    },
+    integrate: INTEGRATED,
+    // needs_context は 1 件あるのに record 側が 0 件。raw_findings と findings だけを
+    // 見ていると、この欠落は素通りする。
+    snapshot: { path: "/tmp/audit-z.json", counts: counts({ raw_findings: 2, findings: 1 }) },
+  });
+  assert.deepEqual(
+    result.snapshot.lost,
+    ["needs_context"],
+    "側表の欠落も検出する。needs_context は why を持つ唯一の場所で raw_findings から復元できない",
+  );
 });
 
 test("T-026 snapshot agent が結果を返さない run は written=false を持ち truncated を断定しない", async () => {

--- a/workflows/audit/tests/audit.effort.test.js
+++ b/workflows/audit/tests/audit.effort.test.js
@@ -56,3 +56,49 @@ test("challenge / verify agent の effort が xhigh である", async () => {
   assert.equal(challengeCalls[0].opts.effort, "xhigh", "challenge agent の effort が xhigh");
   assert.equal(verifyCalls[0].opts.effort, "xhigh", "verify agent の effort が xhigh");
 });
+
+// challenge の stub が verdicts を返す経路が fail-open (challenge 未応答で全件 confirmed 扱い) と
+// 区別できる形で返り値に残ることを確認する。stub の challenge 分岐は polish.js /
+// audit.js 双方の VERDICTS_SCHEMA と同じ { verdicts: [{ id, verdict, severity, why }] } 形
+// (rawFindings の id は R-1 = security / R-2 = silence の順、audit.triage.test.js と同じ組み方)。
+const tallyAgentStub = (prompt, opts) => {
+  const label = opts && opts.label;
+  if (label === "route") {
+    return { files: [{ path: "sample.js", churn: 0 }] };
+  }
+  if (label === "security" || label === "silence") {
+    return {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: `${label} finding` }],
+    };
+  }
+  if (label === "challenge") {
+    return {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    };
+  }
+  if (label === "verify") return "verify pass output";
+  if (label === "integrate") {
+    return {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "integrated finding" }],
+    };
+  }
+  return undefined;
+};
+
+test("challenge stub が verdicts を返す run は返り値に challenge_ran=true と件数の入った tally を持つ", async () => {
+  const { result } = await runWorkflow(auditJs, {
+    args: { focus: "security", skipPreflight: true },
+    stubs: { agent: tallyAgentStub },
+  });
+  assert.equal(
+    result.challenge_ran,
+    true,
+    "challenge stub が verdicts を返したら challenge_ran が true (fail-open との区別)",
+  );
+  assert.equal(result.tally.survived, 2, "confirmed 2 件が tally.survived に計上される");
+  assert.equal(result.tally.needs_context, 0, "needs_context は 0 件");
+  assert.equal(result.tally.no_verdict, 0, "verdict 欠落は 0 件");
+});

--- a/workflows/audit/tests/audit.effort.test.js
+++ b/workflows/audit/tests/audit.effort.test.js
@@ -12,32 +12,37 @@ const auditJs = join(here, "..", "..", "audit.js");
 // Review -> Challenge/Verify -> Integrate まで到達させる最小 stub。
 // findings が空だと早期 return して Challenge 以降へ進まない。focus: "security" を選ぶのは
 // routing 表で security と silence がどちらも *.js に載り、reviewer が 2 件に収まるため。
-// skipPreflight: true は pre-flight agent の stub を不要にする。
-const agentStub = (prompt, opts) => {
-  const label = opts && opts.label;
-  if (label === "route") {
-    return { files: [{ path: "sample.js", churn: 0 }] };
-  }
-  if (label === "security" || label === "silence") {
-    return {
-      findings: [{ file: "sample.js", line: "1", severity: "high", summary: `${label} finding` }],
-    };
-  }
-  if (label === "challenge") return "challenge pass output";
-  if (label === "verify") return "verify pass output";
-  if (label === "integrate") {
-    return {
-      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "integrated finding" }],
-    };
-  }
-  // snapshot は戻り値を消費しないので undefined のままでよい。
-  return undefined;
-};
+// skipPreflight: true は pre-flight agent の stub を不要にする。challenge の返り値だけが
+// テストごとに変わるので引数化する (既定は素通しの文字列、tally test だけ verdicts を渡す)。
+const agentStub =
+  (challenge = "challenge pass output") =>
+  (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "route") {
+      return { files: [{ path: "sample.js", churn: 0 }] };
+    }
+    if (label === "security" || label === "silence") {
+      return {
+        findings: [{ file: "sample.js", line: "1", severity: "high", summary: `${label} finding` }],
+      };
+    }
+    if (label === "challenge") return challenge;
+    if (label === "verify") return "verify pass output";
+    if (label === "integrate") {
+      return {
+        findings: [
+          { file: "sample.js", line: "1", severity: "high", summary: "integrated finding" },
+        ],
+      };
+    }
+    // snapshot は戻り値を消費しないので undefined のままでよい。
+    return undefined;
+  };
 
 const runToIntegrate = () =>
   runWorkflow(auditJs, {
     args: { focus: "security", skipPreflight: true },
-    stubs: { agent: agentStub },
+    stubs: { agent: agentStub() },
   });
 
 test("integrate agent の effort が high である", async () => {
@@ -58,40 +63,22 @@ test("challenge / verify agent の effort が xhigh である", async () => {
 });
 
 // challenge の stub が verdicts を返す経路が fail-open (challenge 未応答で全件 confirmed 扱い) と
-// 区別できる形で返り値に残ることを確認する。stub の challenge 分岐は polish.js /
-// audit.js 双方の VERDICTS_SCHEMA と同じ { verdicts: [{ id, verdict, severity, why }] } 形
+// 区別できる形で返り値に残ることを確認する。verdicts の形は polish.js / audit.js 双方の
+// VERDICTS_SCHEMA と同じ { verdicts: [{ id, verdict, severity, why }] }
 // (rawFindings の id は R-1 = security / R-2 = silence の順、audit.triage.test.js と同じ組み方)。
-const tallyAgentStub = (prompt, opts) => {
-  const label = opts && opts.label;
-  if (label === "route") {
-    return { files: [{ path: "sample.js", churn: 0 }] };
-  }
-  if (label === "security" || label === "silence") {
-    return {
-      findings: [{ file: "sample.js", line: "1", severity: "high", summary: `${label} finding` }],
-    };
-  }
-  if (label === "challenge") {
-    return {
-      verdicts: [
-        { id: "R-1", verdict: "confirmed" },
-        { id: "R-2", verdict: "confirmed" },
-      ],
-    };
-  }
-  if (label === "verify") return "verify pass output";
-  if (label === "integrate") {
-    return {
-      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "integrated finding" }],
-    };
-  }
-  return undefined;
-};
-
+// route/security/silence/verify/integrate の枝は runToIntegrate と共通なので、challenge の
+// 返り値だけを agentStub に渡して差し替える。
 test("challenge stub が verdicts を返す run は返り値に challenge_ran=true と件数の入った tally を持つ", async () => {
   const { result } = await runWorkflow(auditJs, {
     args: { focus: "security", skipPreflight: true },
-    stubs: { agent: tallyAgentStub },
+    stubs: {
+      agent: agentStub({
+        verdicts: [
+          { id: "R-1", verdict: "confirmed" },
+          { id: "R-2", verdict: "confirmed" },
+        ],
+      }),
+    },
   });
   assert.equal(
     result.challenge_ran,

--- a/workflows/audit/tests/audit.integrate.test.js
+++ b/workflows/audit/tests/audit.integrate.test.js
@@ -52,6 +52,29 @@ const BOTH_CONFIRMED = {
   ],
 };
 
+test("T-023 Integrate に渡す schema だけが source_ids を必須にし、reviewer 用は property ごと持たない", async () => {
+  const { calls } = await run({ challenge: BOTH_CONFIRMED, integrate: { findings: [] } });
+  const item = (label) => callOf(calls, label).opts.schema.properties.findings.items;
+
+  const integrate = item("integrate");
+  assert.ok(
+    integrate.required.includes("source_ids"),
+    "source_ids を required にしないと Integrate が省いても validation を通り、R-N の追跡が run ごとに切れる",
+  );
+
+  const reviewer = item("security");
+  assert.equal(
+    reviewer.properties.source_ids,
+    undefined,
+    "reviewer 用 schema は source_ids を持たず、捏造した id は additionalProperties: false が弾く",
+  );
+  assert.equal(
+    reviewer.required.includes("source_ids"),
+    false,
+    "reviewer に source_ids は求めない",
+  );
+});
+
 test("T-009 Integrate が返す finding の source_ids が返り値の findings に保持される", async () => {
   const { result, calls } = await run({
     challenge: BOTH_CONFIRMED,

--- a/workflows/audit/tests/audit.integrate.test.js
+++ b/workflows/audit/tests/audit.integrate.test.js
@@ -1,7 +1,6 @@
 // Integrate 段が吸収した R-N id を root cause の source_ids に残す挙動と、その入力を
 // survivors のみに絞る挙動 (disputed を再び integrate に渡さない) を固定する。
-// polish.js には無い audit.js 固有の段 (Integrate) なので、rawFindings の id (R-N) を
-// 起点にした組み方は audit.triage.test.js / audit.degradation.test.js と同じにする。
+// Integrate は polish.js に対応する段が無く、id の追跡は audit.js 固有の要件になる。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -13,7 +12,7 @@ const auditJs = join(here, "..", "..", "audit.js");
 
 // Route -> Review (security / silence の 2 reviewer) -> Challenge/Verify -> Integrate まで
 // 通す最小 stub。focus: "security" で rawFindings の id を R-1 (security) / R-2 (silence) に
-// 固定するのは他の audit.*.test.js と同じ組み方。
+// 固定する。
 const agentStub =
   ({ challenge, verify, integrate } = {}) =>
   (prompt, opts) => {

--- a/workflows/audit/tests/audit.integrate.test.js
+++ b/workflows/audit/tests/audit.integrate.test.js
@@ -1,0 +1,144 @@
+// Integrate 段が吸収した R-N id を root cause の source_ids に残す挙動と、その入力を
+// survivors のみに絞る挙動 (disputed を再び integrate に渡さない) を固定する。
+// polish.js には無い audit.js 固有の段 (Integrate) なので、rawFindings の id (R-N) を
+// 起点にした組み方は audit.triage.test.js / audit.degradation.test.js と同じにする。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const auditJs = join(here, "..", "..", "audit.js");
+
+// Route -> Review (security / silence の 2 reviewer) -> Challenge/Verify -> Integrate まで
+// 通す最小 stub。focus: "security" で rawFindings の id を R-1 (security) / R-2 (silence) に
+// 固定するのは他の audit.*.test.js と同じ組み方。
+const agentStub =
+  ({ challenge, verify, integrate } = {}) =>
+  (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "route") {
+      return { files: [{ path: "sample.js", churn: 0 }] };
+    }
+    if (label === "security") {
+      return {
+        findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+      };
+    }
+    if (label === "silence") {
+      return {
+        findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+      };
+    }
+    if (label === "challenge") return challenge;
+    if (label === "verify") return verify !== undefined ? verify : "verify pass output";
+    if (label === "integrate") return integrate;
+    // snapshot は戻り値を消費しない経路にフォールバックさせるため undefined のまま。
+    return undefined;
+  };
+
+const callOf = (calls, label) => calls.agent.find((c) => c.opts && c.opts.label === label);
+
+const run = (opts) =>
+  runWorkflow(auditJs, {
+    args: { focus: "security", skipPreflight: true },
+    stubs: { agent: agentStub(opts) },
+  });
+
+const BOTH_CONFIRMED = {
+  verdicts: [
+    { id: "R-1", verdict: "confirmed" },
+    { id: "R-2", verdict: "confirmed" },
+  ],
+};
+
+test("T-009 Integrate が返す finding の source_ids が返り値の findings に保持される", async () => {
+  const { result, calls } = await run({
+    challenge: BOTH_CONFIRMED,
+    integrate: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "root cause absorbing both findings",
+          source_ids: ["R-1", "R-2"],
+        },
+      ],
+    },
+  });
+  assert.deepEqual(
+    result.findings[0].source_ids,
+    ["R-1", "R-2"],
+    "Integrate が返した source_ids がそのまま返り値の findings に乗る",
+  );
+  const integrateCall = callOf(calls, "integrate");
+  assert.ok(integrateCall, "integrate agent が起動する");
+  const itemSchema = integrateCall.opts.schema.properties.findings.items;
+  assert.equal(
+    itemSchema.properties.source_ids && itemSchema.properties.source_ids.type,
+    "array",
+    "FINDINGS_SCHEMA の finding item に source_ids (array) が定義されている",
+  );
+});
+
+test("T-010 Integrate に渡す入力に disputed と判定された finding が含まれない", async () => {
+  const { calls } = await run({
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "disputed" },
+      ],
+    },
+    integrate: { findings: [] },
+  });
+  const integrateCall = callOf(calls, "integrate");
+  assert.ok(integrateCall, "integrate agent が起動する");
+  assert.doesNotMatch(
+    integrateCall.prompt,
+    /R-2/,
+    "disputed と判定された R-2 は integrate への入力から外れる",
+  );
+});
+
+test("T-011 Integrate が survivors を全件返した run の最終 findings は survivors と同数になる", async () => {
+  const { result, calls } = await run({
+    challenge: BOTH_CONFIRMED,
+    // verify の自由記述には survivor の内容 (summary) を含めない。integrate プロンプトに
+    // survivor の内容が乗るとしたら、それは survivors 入力自体からのみ、という前提を保つ。
+    verify: "verify pass output",
+    integrate: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "security finding",
+          source_ids: ["R-1"],
+        },
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "silence finding",
+          source_ids: ["R-2"],
+        },
+      ],
+    },
+  });
+  assert.equal(
+    result.findings.length,
+    result.survivors.length,
+    "survivors を全件返した run の最終 findings は survivors と同数になる",
+  );
+  const integrateCall = callOf(calls, "integrate");
+  assert.ok(integrateCall, "integrate agent が起動する");
+  for (const s of result.survivors) {
+    assert.match(
+      integrateCall.prompt,
+      new RegExp(s.message),
+      `survivor ${s.id} (${s.message}) の内容が integrate への入力 (survivors) に乗る`,
+    );
+  }
+});

--- a/workflows/audit/tests/audit.routing.test.js
+++ b/workflows/audit/tests/audit.routing.test.js
@@ -69,17 +69,11 @@ const parseRoutingLikeConst = (source, name) => {
   }
   return result;
 };
-// causation / readability / conformance の移設先。契約には具体名が無いため、audit.js
-// 側にこの名前の配列定数が導入される想定でテストを固定する (Green 側の実装契約。
-// 未実装の間は空配列扱いになり T-014 は Red のまま)。
-const parseSkillOnlyAllowlist = (source) => {
-  const marker = "const SKILL_ONLY_REVIEWERS = [";
-  const idx = source.indexOf(marker);
-  if (idx === -1) return [];
-  const bracketStart = source.indexOf("[", idx);
-  const bracketEnd = source.indexOf("]", bracketStart);
-  return [...source.slice(bracketStart, bracketEnd).matchAll(/"([^"]+)"/g)].map((x) => x[1]);
-};
+// agents/reviewers/に定義はあるが ROUTING に行を持たない reviewer。skill から直接呼ばれる
+// ときだけ走るので glob 表の行を持たず、audit.js の実行時にはこの区別が要らない (ROUTING に
+// 無い名前は routing されないだけ)。よって期待値はここに置く。ここにも ROUTING にも名前の
+// 無い定義は誰からも呼ばれないまま残るので、T-014 がそれを検知する。
+const SKILL_ONLY_REVIEWERS = ["causation", "readability", "conformance"];
 
 test("yaml と yml と json を含む diff で audit が Route 段を通過し 3 ファイルとも assignments に載る", async () => {
   const files = ["config.yaml", "ci.yml", "package.json"];
@@ -145,7 +139,7 @@ test("T-014 agents/reviewers/の定義は ROUTING か skill-only allowlist の�
   assert.ok(routing, "audit.js から ROUTING を抽出できる");
 
   const routedReviewers = new Set(Object.values(routing).flat());
-  const skillOnly = new Set(parseSkillOnlyAllowlist(source));
+  const skillOnly = new Set(SKILL_ONLY_REVIEWERS);
   const definedNames = readdirSync(reviewersDir)
     .filter((f) => f.startsWith("reviewer-") && f.endsWith(".md"))
     .map((f) => f.slice("reviewer-".length, -".md".length));
@@ -154,7 +148,15 @@ test("T-014 agents/reviewers/の定義は ROUTING か skill-only allowlist の�
   assert.deepEqual(
     orphaned,
     [],
-    `ROUTING にも SKILL_ONLY_REVIEWERS にも載らない agents/reviewers/定義: ${orphaned.join(", ")}`,
+    `ROUTING にも skill-only allowlist にも載らない agents/reviewers/定義: ${orphaned.join(", ")}`,
+  );
+
+  // 両方に載る名前は ROUTING 側で発火するので、skill-only に置いた意図が消える。
+  const both = [...routedReviewers].filter((n) => skillOnly.has(n));
+  assert.deepEqual(
+    both,
+    [],
+    `ROUTING と skill-only allowlist の両方に載る reviewer: ${both.join(", ")}`,
   );
 });
 

--- a/workflows/audit/tests/audit.routing.test.js
+++ b/workflows/audit/tests/audit.routing.test.js
@@ -2,13 +2,14 @@
 // 表の編集ごとに落ちる change detector になるため。
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runWorkflow } from "../../_lib/run-workflow.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const auditJs = join(here, "..", "..", "audit.js");
+const reviewersDir = join(here, "..", "..", "..", "agents", "reviewers");
 
 // Challenge 以降の stub は置かない。reviewer label に undefined を返すと findings が
 // 空になり、assignments を持つ早期 return に落ちるため。
@@ -19,12 +20,12 @@ const routeOnlyStub = (files) => (prompt, opts) => {
   return undefined;
 };
 
-const runRoute = async (files) => {
-  const { result } = await runWorkflow(auditJs, {
-    args: { skipPreflight: true },
+const runRoute = async (files, extra = {}) => {
+  const { result, logs } = await runWorkflow(auditJs, {
+    args: { skipPreflight: true, ...extra },
     stubs: { agent: routeOnlyStub(files) },
   });
-  return result;
+  return { result, logs };
 };
 
 const unassigned = (result, files) => {
@@ -32,10 +33,58 @@ const unassigned = (result, files) => {
   return files.filter((p) => !assigned.has(p));
 };
 
+// ROUTING / FOCUS の中身そのものは通常 assert しない (上のコメント参照)。だが
+// T-012〜T-014 は ROUTING と FOCUS と agents/reviewers/ の 3 者の整合性を見る回
+// なので、ここだけは audit.js のソースから両定数を抽出して突き合わせる。eval 系は
+// 使わず、キーと配列を正規表現で読み取る。ROUTING/FOCUS の値は文字列配列か null
+// のみという前提に依る。
+const extractBracedBody = (source, name) => {
+  const marker = `const ${name} = {`;
+  const idx = source.indexOf(marker);
+  if (idx === -1) return null;
+  const braceStart = source.indexOf("{", idx);
+  let depth = 0;
+  let end = -1;
+  for (let i = braceStart; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  return source.slice(braceStart + 1, end - 1);
+};
+const parseRoutingLikeConst = (source, name) => {
+  const body = extractBracedBody(source, name);
+  if (body === null) return null;
+  const result = {};
+  const rowPattern = /(?:"([^"]+)"|(\w+))\s*:\s*(\[([^\]]*)\]|null)/g;
+  let m;
+  while ((m = rowPattern.exec(body))) {
+    const key = m[1] || m[2];
+    result[key] = m[3] === "null" ? null : [...m[4].matchAll(/"([^"]+)"/g)].map((x) => x[1]);
+  }
+  return result;
+};
+// causation / readability / conformance の移設先。契約には具体名が無いため、audit.js
+// 側にこの名前の配列定数が導入される想定でテストを固定する (Green 側の実装契約。
+// 未実装の間は空配列扱いになり T-014 は Red のまま)。
+const parseSkillOnlyAllowlist = (source) => {
+  const marker = "const SKILL_ONLY_REVIEWERS = [";
+  const idx = source.indexOf(marker);
+  if (idx === -1) return [];
+  const bracketStart = source.indexOf("[", idx);
+  const bracketEnd = source.indexOf("]", bracketStart);
+  return [...source.slice(bracketStart, bracketEnd).matchAll(/"([^"]+)"/g)].map((x) => x[1]);
+};
+
 test("yaml と yml と json を含む diff で audit が Route 段を通過し 3 ファイルとも assignments に載る", async () => {
   const files = ["config.yaml", "ci.yml", "package.json"];
 
-  const result = await runRoute(files);
+  const { result } = await runRoute(files);
 
   assert.deepEqual(unassigned(result, files), [], "assignments から漏れたファイルは無い");
 });
@@ -52,7 +101,82 @@ test("classify がソース上で分岐する全拡張子について、その�
   // classify 先頭の test 判定に吸われるため。
   const files = extensions.map((e, i) => `src/sample-${i}${e}`);
 
-  const result = await runRoute(files);
+  const { result } = await runRoute(files);
 
   assert.deepEqual(unassigned(result, files), [], "assignments から漏れたファイルは無い");
+});
+
+test("T-012 FOCUS のどのキーに載る reviewer 名も ROUTING のいずれかの行に存在する", () => {
+  const source = readFileSync(auditJs, "utf8");
+  const routing = parseRoutingLikeConst(source, "ROUTING");
+  const focus = parseRoutingLikeConst(source, "FOCUS");
+  assert.ok(routing, "audit.js から ROUTING を抽出できる");
+  assert.ok(focus, "audit.js から FOCUS を抽出できる");
+
+  const routedReviewers = new Set(Object.values(routing).flat());
+  const missing = [];
+  for (const [key, reviewers] of Object.entries(focus)) {
+    if (!Array.isArray(reviewers)) continue; // all: null はスキップ
+    for (const r of reviewers) {
+      if (!routedReviewers.has(r)) missing.push(`${key}:${r}`);
+    }
+  }
+  assert.deepEqual(missing, [], `ROUTING のどの行にも無い FOCUS reviewer: ${missing.join(", ")}`);
+});
+
+test("T-013 ROUTING に載る reviewer 名は agents/reviewers/に定義ファイルを持つ", () => {
+  const source = readFileSync(auditJs, "utf8");
+  const routing = parseRoutingLikeConst(source, "ROUTING");
+  assert.ok(routing, "audit.js から ROUTING を抽出できる");
+
+  const routedReviewers = [...new Set(Object.values(routing).flat())];
+  const definedFiles = new Set(readdirSync(reviewersDir));
+  const missing = routedReviewers.filter((r) => !definedFiles.has(`reviewer-${r}.md`));
+  assert.deepEqual(
+    missing,
+    [],
+    `agents/reviewers/に定義ファイルの無い ROUTING reviewer: ${missing.join(", ")}`,
+  );
+});
+
+test("T-014 agents/reviewers/の定義は ROUTING か skill-only allowlist のどちらかに載る", () => {
+  const source = readFileSync(auditJs, "utf8");
+  const routing = parseRoutingLikeConst(source, "ROUTING");
+  assert.ok(routing, "audit.js から ROUTING を抽出できる");
+
+  const routedReviewers = new Set(Object.values(routing).flat());
+  const skillOnly = new Set(parseSkillOnlyAllowlist(source));
+  const definedNames = readdirSync(reviewersDir)
+    .filter((f) => f.startsWith("reviewer-") && f.endsWith(".md"))
+    .map((f) => f.slice("reviewer-".length, -".md".length));
+
+  const orphaned = definedNames.filter((n) => !routedReviewers.has(n) && !skillOnly.has(n));
+  assert.deepEqual(
+    orphaned,
+    [],
+    `ROUTING にも SKILL_ONLY_REVIEWERS にも載らない agents/reviewers/定義: ${orphaned.join(", ")}`,
+  );
+});
+
+test("T-015 focus 指定で 0 reviewer になったファイルが件数とパスつきで返り値に載る", async () => {
+  // *.js は ROUTING["*.js"] に accessibility / progressive を含まないため、
+  // focus: "a11y" (FOCUS.a11y = ["accessibility", "progressive"]) と交差させると
+  // このファイルは reviewer 0 件になる。
+  const files = ["src/sample.js"];
+
+  const { result, logs } = await runRoute(files, { focus: "a11y" });
+
+  assert.ok(
+    Array.isArray(result.zero_reviewer_files),
+    "0 reviewer になったファイルの配列を返り値に持つ",
+  );
+  assert.deepEqual(
+    result.zero_reviewer_files.map((f) => f.path),
+    files,
+    "0 reviewer になったファイルのパスが返り値に載る",
+  );
+  assert.ok(
+    logs.some((l) => /zero.?reviewer/i.test(l) && l.includes(String(files.length))),
+    "0 reviewer になった件数が log() に出る",
+  );
 });

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -27,7 +27,10 @@ const runSnapshot = (payload) => {
       env: { ...process.env, HOME: home },
     });
     assert.equal(res.status, 0, `snapshot.py が exit 0 で終わる (stderr: ${res.stderr})`);
-    return JSON.parse(readFileSync(res.stdout.trim(), "utf8"));
+    // stdout は {path, counts} の JSON 1 行。counts は snapshot.py 自身が数えた値で、
+    // 呼び出し元はこれと payload を照合して切り詰めを検出する。
+    const out = JSON.parse(res.stdout);
+    return JSON.parse(readFileSync(out.path, "utf8"));
   } finally {
     rmSync(home, { recursive: true, force: true });
   }

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -1,13 +1,12 @@
 // audit.js が組んだ snapshot payload を実 workflows/audit/snapshot.py まで通し、書き出された
 // record から R-N id / verdict tally / zero-reviewer file を追える挙動を固定する。
-// audit.degradation.test.js は "snapshot" ラベルを常に undefined へフォールバックさせて payload
-// の中身だけ検証するが、ここでは snapshot ラベルを実 subprocess 実行に差し替え、ディスクに
-// 書かれた record 自体を検証する (U-001〜U-006 が組んだ各段が実際につながっているかの seam)。
+// snapshot ラベルだけ実 subprocess 実行に差し替え、payload でなくディスクに書かれた record
+// 自体を検証する。各段が実際につながっているかは、この経路を通さないと分からない。
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdtempSync, readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { runWorkflow } from "../../_lib/run-workflow.js";
@@ -21,14 +20,17 @@ const snapshotPy = join(here, "..", "snapshot.py");
 // 混ざらないようにする。
 const runSnapshot = (payload) => {
   const home = mkdtempSync(join(tmpdir(), "audit-seam-"));
-  const res = spawnSync("python3", [snapshotPy], {
-    input: payload,
-    encoding: "utf8",
-    env: { ...process.env, HOME: home },
-  });
-  assert.equal(res.status, 0, `snapshot.py が exit 0 で終わる (stderr: ${res.stderr})`);
-  const outPath = res.stdout.trim();
-  return JSON.parse(readFileSync(outPath, "utf8"));
+  try {
+    const res = spawnSync("python3", [snapshotPy], {
+      input: payload,
+      encoding: "utf8",
+      env: { ...process.env, HOME: home },
+    });
+    assert.equal(res.status, 0, `snapshot.py が exit 0 で終わる (stderr: ${res.stderr})`);
+    return JSON.parse(readFileSync(res.stdout.trim(), "utf8"));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 };
 
 const INTEGRATED = {

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -87,6 +87,13 @@ test("T-017 reviewer の findings を実 snapshot.py まで流すと、書き出
   );
   assert.ok(record.tally, "record に verdict tally が載る");
   assert.equal(record.tally.survived, 2, "tally.survived に confirmed 2 件が計上される");
+  // AC は集約値でなく「finding ごとの verdict が載る」を求める。payload ではなく実際に
+  // 書き出された record 側で、id と verdict が対応していることを確かめる。
+  assert.equal(
+    record.raw_findings.find((f) => f.id === "R-1").verdict,
+    "confirmed",
+    "書き出された record の finding ごとに verdict が載る",
+  );
 });
 
 test("T-018 fail-open した run を実 snapshot.py まで流すと、書き出された record に degraded 印が載り件数の入った tally は載らない", async () => {

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -1,0 +1,120 @@
+// audit.js が組んだ snapshot payload を実 workflows/audit/snapshot.py まで通し、書き出された
+// record から R-N id / verdict tally / zero-reviewer file を追える挙動を固定する。
+// audit.degradation.test.js は "snapshot" ラベルを常に undefined へフォールバックさせて payload
+// の中身だけ検証するが、ここでは snapshot ラベルを実 subprocess 実行に差し替え、ディスクに
+// 書かれた record 自体を検証する (U-001〜U-006 が組んだ各段が実際につながっているかの seam)。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const auditJs = join(here, "..", "..", "audit.js");
+const snapshotPy = join(here, "..", "snapshot.py");
+
+// snapshot.py の HISTORY_DIR は $HOME/.claude/history 由来 (snapshot.py 参照)。テストごとに
+// HOME を隔離した一時ディレクトリへ向け、実ユーザーの履歴を書き換えず、テスト間の record も
+// 混ざらないようにする。
+const runSnapshot = (payload) => {
+  const home = mkdtempSync(join(tmpdir(), "audit-seam-"));
+  const res = spawnSync("python3", [snapshotPy], {
+    input: payload,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home },
+  });
+  assert.equal(res.status, 0, `snapshot.py が exit 0 で終わる (stderr: ${res.stderr})`);
+  const outPath = res.stdout.trim();
+  return JSON.parse(readFileSync(outPath, "utf8"));
+};
+
+const INTEGRATED = {
+  findings: [{ file: "sample.js", line: "1", severity: "high", summary: "integrated finding" }],
+};
+
+// audit.js の writeSnapshot は payload を prompt 末尾に JSON.stringify 1行で埋め込む
+// (audit.degradation.test.js の snapshotPayload と同じ抽出)。snapshot ラベルの呼び出しだけ実
+// snapshot.py に流し、書き出された record を run() の戻り値として返す。
+const run = async (routeFiles, { security, silence, challenge, integrate } = {}) => {
+  let record;
+  const agentStub = (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "route") return { files: routeFiles };
+    if (label === "security") return security;
+    if (label === "silence") return silence;
+    if (label === "challenge") return challenge;
+    if (label === "verify") return "verify pass output";
+    if (label === "integrate") return integrate;
+    if (label === "snapshot") {
+      const match = prompt.match(/The payload is as follows\.\n(.*)$/s);
+      assert.ok(match, "snapshot prompt に payload が乗る");
+      record = runSnapshot(match[1]);
+      return undefined;
+    }
+    return undefined;
+  };
+  const { result, calls } = await runWorkflow(auditJs, {
+    args: { focus: "security", skipPreflight: true },
+    stubs: { agent: agentStub },
+  });
+  return { result, calls, record };
+};
+
+test("T-017 reviewer の findings を実 snapshot.py まで流すと、書き出された record に R-N id と verdict tally が載る", async () => {
+  const { record } = await run([{ path: "sample.js", churn: 0 }], {
+    security: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+    },
+    silence: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+    },
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    integrate: INTEGRATED,
+  });
+  assert.ok(record, "snapshot が record をディスクに書き出す");
+  assert.deepEqual(
+    record.raw_findings.map((f) => f.id).sort(),
+    ["R-1", "R-2"],
+    "書き出された record の raw_findings から R-N id を追える",
+  );
+  assert.ok(record.tally, "record に verdict tally が載る");
+  assert.equal(record.tally.survived, 2, "tally.survived に confirmed 2 件が計上される");
+});
+
+test("T-018 fail-open した run を実 snapshot.py まで流すと、書き出された record に degraded 印が載り件数の入った tally は載らない", async () => {
+  const { record } = await run([{ path: "sample.js", churn: 0 }], {
+    security: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+    },
+    silence: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+    },
+    challenge: undefined,
+    integrate: undefined,
+  });
+  assert.ok(record, "snapshot が record をディスクに書き出す");
+  assert.equal(
+    record.challenge_ran,
+    false,
+    "fail-open した run は record.challenge_ran=false で degraded と分かる",
+  );
+  assert.equal(record.tally, undefined, "件数の入った tally は record に載らない");
+});
+
+test("T-019 focus=security でテストファイルのみの diff を流すと、0 reviewer で落ちたファイルが書き出された record に載る", async () => {
+  const { record } = await run([{ path: "sample.test.js", churn: 0 }], {});
+  assert.ok(record, "snapshot が record をディスクに書き出す");
+  assert.ok(
+    Array.isArray(record.zero_reviewer_files) &&
+      record.zero_reviewer_files.some((f) => f.path === "sample.test.js"),
+    "0 reviewer で落ちた sample.test.js が record に載る",
+  );
+});

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -12,7 +12,7 @@ const auditJs = join(here, "..", "..", "audit.js");
 
 // Route -> Review (security / silence の 2 reviewer) -> Challenge まで通す最小 stub。
 // focus: "security" は ROUTING["*.js"] を security / silence だけに絞り、rawFindings の
-// id を R-1 (security) / R-2 (silence) に固定する (audit.effort.test.js と同じ組み方)。
+// id を R-1 (security) / R-2 (silence) に固定する。
 const agentStub =
   ({ challenge } = {}) =>
   (prompt, opts) => {

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -1,0 +1,101 @@
+// challenge (critic-audit) を id 付き rawFindings で駆動し、survivor 判定を script 側の
+// triage ループ (finding 側を回して verdict を引く) に持たせる挙動を先に固定する。
+// polish.js の VERDICTS_SCHEMA (confirmed/disputed/downgraded/needs_context) を踏襲する。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const auditJs = join(here, "..", "..", "audit.js");
+
+// Route -> Review (security / silence の 2 reviewer) -> Challenge まで通す最小 stub。
+// focus: "security" は ROUTING["*.js"] を security / silence だけに絞り、rawFindings の
+// id を R-1 (security) / R-2 (silence) に固定する (audit.effort.test.js と同じ組み方)。
+const agentStub =
+  ({ challenge } = {}) =>
+  (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "route") {
+      return { files: [{ path: "sample.js", churn: 0 }] };
+    }
+    if (label === "security") {
+      return {
+        findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+      };
+    }
+    if (label === "silence") {
+      return {
+        findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+      };
+    }
+    if (label === "challenge") return challenge;
+    if (label === "verify") return "verify pass output";
+    // integrate / snapshot は戻り値を消費しない経路にフォールバックさせるため undefined のまま。
+    return undefined;
+  };
+
+const callOf = (calls, label) => calls.agent.find((c) => c.opts && c.opts.label === label);
+
+const runChallenge = (challenge) =>
+  runWorkflow(auditJs, {
+    args: { focus: "security", skipPreflight: true },
+    stubs: { agent: agentStub({ challenge }) },
+  });
+
+test("T-001 challenge が disputed を返した finding は survivors から外れる", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "confirmed" },
+      { id: "R-2", verdict: "disputed" },
+    ],
+  });
+  assert.deepEqual(
+    result.survivors.map((s) => s.id),
+    ["R-1"],
+    "disputed の R-2 は survivors に残らない",
+  );
+});
+
+test("T-002 challenge が downgraded を返した finding は下げた severity で survivors に残る", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "downgraded", severity: "low" },
+      { id: "R-2", verdict: "confirmed" },
+    ],
+  });
+  const byId = new Map(result.survivors.map((s) => [s.id, s]));
+  assert.equal(byId.get("R-1").severity, "low", "downgraded は下げた severity で残る");
+  assert.equal(byId.get("R-2").severity, "high", "confirmed は元の severity のまま残る");
+});
+
+test("T-003 challenge が verdict を返さなかった finding は confirmed 扱いで survivors に入り no_verdict に計上される", async () => {
+  const { result, logs } = await runChallenge({
+    verdicts: [{ id: "R-1", verdict: "confirmed" }],
+  });
+  assert.deepEqual(
+    result.survivors.map((s) => s.id).sort(),
+    ["R-1", "R-2"],
+    "verdict の付かなかった R-2 も confirmed 扱いで survivors に入る",
+  );
+  const byId = new Map(result.survivors.map((s) => [s.id, s]));
+  assert.equal(byId.get("R-2").severity, "high", "confirmed 扱いなので元の severity のまま");
+  assert.ok(
+    logs.some((l) => /no_verdict/.test(l) && /1/.test(l)),
+    "verdict の付かなかった件数が no_verdict として log() に出る",
+  );
+});
+
+test("T-004 critic に渡す入力に reviewer 名が含まれない", async () => {
+  const { calls } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "confirmed" },
+      { id: "R-2", verdict: "confirmed" },
+    ],
+  });
+  const call = callOf(calls, "challenge");
+  assert.ok(call, "challenge agent が起動する");
+  assert.match(call.prompt, /"id":"R-1"/, "critic 入力に rawFindings の id (R-N) が乗る");
+  assert.doesNotMatch(call.prompt, /"reviewer"/, "critic 入力に reviewer 名は含めない");
+});

--- a/workflows/audit/tests/snapshot_test.py
+++ b/workflows/audit/tests/snapshot_test.py
@@ -3,8 +3,8 @@
 Run: python3 workflows/audit/tests/snapshot_test.py
 
 compute_delta() is exercised directly; the CLI contract (stdin JSON -> a written
-audit-*.json carrying resolved fields + delta, path on stdout, exit 1 on a bad
-payload) is exercised via subprocess with an isolated HOME.
+audit-*.json carrying resolved fields + delta, {path, counts} JSON on stdout,
+exit 1 on a bad payload) is exercised via subprocess with an isolated HOME.
 """
 
 import importlib.util
@@ -57,6 +57,70 @@ class ComputeDeltaTest(unittest.TestCase):
         )
 
 
+class BaselineSelectionTest(unittest.TestCase):
+    """切り詰められた record を baseline に取ると delta が 2 回連続で壊れる。
+
+    raw_findings は survived + needs_context + disputed なので、tally を持つ record では
+    len(raw_findings) >= survived + needs_context が成り立つ。実測では raw 2 件に対し
+    survived 21 の record が baseline になり、42 件すべてが new と報告された。
+    """
+
+    def _write(self, history_dir, name, payload):
+        path = history_dir / f"audit-{name}.json"
+        path.write_text(json.dumps(payload))
+        return path
+
+    def test_record_contradicting_its_own_tally_is_skipped_for_the_one_before_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            history = Path(tmp)
+            self._write(
+                history,
+                "2026-08-02-100000",
+                {"raw_findings": [raw("a.rs", "keep"), raw("b.rs", "keep2")]},
+            )
+            self._write(
+                history,
+                "2026-08-02-110000",
+                {
+                    "raw_findings": [raw("a.rs", "keep")],
+                    "tally": {"survived": 21, "needs_context": 2, "no_verdict": 0},
+                },
+            )
+            self.assertEqual(
+                snapshot.latest_prior_raw(history),
+                [raw("a.rs", "keep"), raw("b.rs", "keep2")],
+                "矛盾した最新 record を飛ばし、その 1 つ前を baseline にする",
+            )
+
+    def test_record_whose_tally_matches_its_raw_findings_is_used(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            history = Path(tmp)
+            self._write(history, "2026-08-02-100000", {"raw_findings": [raw("old.rs", "x")]})
+            self._write(
+                history,
+                "2026-08-02-110000",
+                {
+                    "raw_findings": [raw("a.rs", "keep"), raw("b.rs", "ctx"), raw("c.rs", "gone")],
+                    "tally": {"survived": 1, "needs_context": 1, "no_verdict": 0},
+                },
+            )
+            self.assertEqual(
+                snapshot.latest_prior_raw(history),
+                [raw("a.rs", "keep"), raw("b.rs", "ctx"), raw("c.rs", "gone")],
+                "disputed の分だけ raw が tally を上回る record は正常なので baseline に使う",
+            )
+
+    def test_record_without_a_tally_is_used_unchanged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            history = Path(tmp)
+            self._write(history, "2026-08-02-100000", {"raw_findings": [raw("a.rs", "x")]})
+            self.assertEqual(
+                snapshot.latest_prior_raw(history),
+                [raw("a.rs", "x")],
+                "照合する相手が無い record は判定対象にしない",
+            )
+
+
 class CliTest(unittest.TestCase):
     def _run(self, payload, home):
         env = {"HOME": str(home), "PATH": ""}
@@ -80,7 +144,7 @@ class CliTest(unittest.TestCase):
             }
             result = self._run(payload, home)
             self.assertEqual(result.returncode, 0, result.stderr)
-            out_path = Path(result.stdout.strip())
+            out_path = Path(json.loads(result.stdout)["path"])
             self.assertTrue(out_path.exists())
             record = json.loads(out_path.read_text())
             self.assertEqual(record["branch"], "unknown")  # PATH="" -> no git
@@ -94,10 +158,40 @@ class CliTest(unittest.TestCase):
             second = {"raw_findings": [raw("a.rs", "keep"), raw("c.rs", "add")]}
             result = self._run(second, home)
             self.assertEqual(result.returncode, 0, result.stderr)
-            record = json.loads(Path(result.stdout.strip()).read_text())
+            record = json.loads(Path(json.loads(result.stdout)["path"]).read_text())
             self.assertEqual(
                 record["delta"], {"resolved": 1, "new": 1, "carried": 1}
             )
+
+    def test_stdout_reports_element_counts_of_what_was_written(self):
+        """呼び出し元が agent の自己申告でなくこの出力と照合できる。
+
+        payload は prompt 埋め込みでしか agent に渡せず、書き写す途中で要約されると
+        record だけが痩せる。件数を agent に自己申告させると、切り詰めた当人が
+        報告することになる。stdin を受けた Python が数えれば agent は介在できない。
+        """
+        with tempfile.TemporaryDirectory() as home:
+            payload = {
+                "raw_findings": [raw("a.rs", "x"), raw("b.rs", "y")],
+                "findings": [raw("a.rs", "root")],
+                "skipped": [],
+                "needs_context": [{"id": "R-2", "why": "unclear"}],
+                "zero_reviewer_files": [],
+            }
+            result = self._run(payload, home)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            out = json.loads(result.stdout)
+            self.assertEqual(
+                out["counts"],
+                {
+                    "raw_findings": 2,
+                    "findings": 1,
+                    "skipped": 0,
+                    "needs_context": 1,
+                    "zero_reviewer_files": 0,
+                },
+            )
+            self.assertTrue(Path(out["path"]).exists())
 
     def test_unparseable_payload_exits_1_and_writes_nothing(self):
         with tempfile.TemporaryDirectory() as home:

--- a/workflows/audit/tests/snapshot_test.py
+++ b/workflows/audit/tests/snapshot_test.py
@@ -110,6 +110,30 @@ class BaselineSelectionTest(unittest.TestCase):
                 "disputed の分だけ raw が tally を上回る record は正常なので baseline に使う",
             )
 
+    def test_record_with_a_non_integer_tally_is_stepped_over_not_raised_on(self):
+        """壊れた prior は例外でなく skip で扱う。
+
+        latest_prior_raw が拾うのは OSError と ValueError だけなので、tally の値が
+        文字列だと加算が TypeError を投げ、main() ごと落ちて record が 1 つも
+        書かれなくなる。読めない prior を飛ばすという既存の姿勢を保つ。
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            history = Path(tmp)
+            self._write(history, "2026-08-02-100000", {"raw_findings": [raw("a.rs", "x")]})
+            self._write(
+                history,
+                "2026-08-02-110000",
+                {
+                    "raw_findings": [raw("b.rs", "y")],
+                    "tally": {"survived": "21", "needs_context": 2},
+                },
+            )
+            self.assertEqual(
+                snapshot.latest_prior_raw(history),
+                [raw("b.rs", "y")],
+                "型が壊れた tally は判定を諦めて record 自体は使う",
+            )
+
     def test_record_without_a_tally_is_used_unchanged(self):
         with tempfile.TemporaryDirectory() as tmp:
             history = Path(tmp)


### PR DESCRIPTION
## What & Why

`/audit` を 1 回走らせると、finding ごとの verdict と刈られた経路が `history/audit-*.json` と workflow の返り値の両方から読める。R-N id は reviewer の出力から最終 findings まで途切れずに追える。

これまでは reviewer の生 findings と challenge/Integrate を経た後の findings が id で紐付いておらず、どの finding が誰の指摘で・どの段階で・なぜ生き残ったか死んだかを snapshot から再構成できなかった。R-N id を軸に triage (confirmed/disputed/downgraded/no_verdict) を追跡し、challenge が実際に走ったか (fail-open か) と Integrate が受け取った入力の由来を snapshot の payload に載せることで、reviewer 別の生存率や二重刈りの有無を後から検証できるようにした。

## Review focus

- `workflows/audit.js` の triage ロジック (rawFindings → challengeInput → challenged → survivors → Integrate) の id 受け渡し。特に Integrate が no-return だった場合のフォールバック先が triage 前の `findings` でなく `survivors` になっているか
- `writeSnapshot` に渡す payload に `tally`/`zeroReviewerFiles`/`challengeRan`/`verifyRan`/`needsContext` が実際に流れ込んでいるか
- triage ループが `f.verdict` を `rawFindings` に書き戻す形。record を読む側が reviewer と verdict を突き合わせられる唯一の経路になっている
- `.ja/workflows/audit.js` との mirror 差分。プロース (コメント) が翻訳されているか、コード構造・キー名・R-N id の形式が両側で一致しているか

## Changes

build workflow が 7 unit を実装したあと、conformance の指摘、`/simplify` のレビュー、4 回の dogfood run を受けて手作業でコミットを重ねている。全 23 コミット。

**build による実装 (U-001〜U-007)**

- R-N id 付き triage を script 側に置き、critic は verdict のみを返す (`36fadd4b`)
- 劣化の記録と Integrate fallback の是正 (`adc16455` `5ddca1bc` `a839d11b`)
- `FINDINGS_SCHEMA` に `source_ids` を追加し、Integrate 入力を survivors のみに絞る (`87e6b403`)
- skill-only reviewer の allowlist を新設し、ROUTING/FOCUS/`agents/reviewers/` の 3 者一致を test で固定 (`3ab664e3`)
- membership 判定の移管を DR-0095 に記録 (`a74ac047`)
- `toCriticRef()` で `challengeInput` と `survivorsInput` の射影重複を統合 (`20f36312`)

**conformance 指摘への対応**

- `tally` と `zero_reviewer_files` を snapshot payload に渡す。あわせて canonical (`.ja`) 側に `challengeRan` と `tally` の定義が欠けて未定義の識別子を参照していたミラー漏れを修正 (`9c3278d1`)
- `verify_ran` を実装。U-002 の contract が求めていたが実装がどこにも無く、T-NNN も割り当てられていなかった。T-020/T-021 を新規採番 (`380b36ff`)
- finding ごとの verdict を `rawFindings` に書き戻し、`needs_context` を payload に渡す。集約値の `tally` だけでは disputed で落ちた id が record から消え、reviewer 別の生存率を測れなかった。`.ja` に英語のまま残っていたコメント 4 行を翻訳 (`4187a485`)
- T-022 は payload をアサートしており AC の水準 (書き出された record) に届いていなかったため、T-017 側で record を検証 (`79d20440`)

**`/simplify` のレビュー結果**

- コメントの再述を削除。`writeSnapshot` の説明が呼び出し側の分岐を書いていた分を呼び出し側へ移し、Challenge/Verify のバナーが「Integrate が 2 pass を reconcile する」と実態と食い違っていた記述を修正 (`bbea0970`)
- `needs_context` の側表を id と why だけに絞る。同じ finding は `raw_findings` に verdict つきで載るため payload に 2 度書いていた
- seam test が `mkdtempSync` した一時ディレクトリを削除しておらず、suite 実行ごとに 3 つ残していた
- `snapshot.py` の docstring が payload 6 キーのまま実際の 11 キーと食い違っていた。record の形が書かれている唯一の場所
- DR-0095 の行番号アンカーが、それを書いた同じ diff の中で既にずれていたため symbol 名に置換

**dogfood run が暴いた欠陥への対応**

record を残したこと自体が、record を壊す経路を 3 つ暴いた。詳細はコメントの表を参照。

- `source_ids` が `FINDINGS_SCHEMA` の required に無く、run ごとに落ちていた。Integrate 専用 schema を分けて必須化 (`f6d63c7a`)
- snapshot agent が payload を切り詰め、`raw_findings` 44 件が 2 件になった。判定を agent の自己申告から `snapshot.py` の実測へ移し、照合対象を 5 配列に広げた (`01f13aed` `505b1fac`)。model も haiku から sonnet へ (`a74db31c`)
- 切り詰められた record が次回の delta baseline になり、delta が 2 回連続で壊れる経路を塞いだ。あわせて `contradicts_own_tally` が加算前に型を見ていなかった件を修正 (`403e7360`)
- critic が下げた severity が record に残らず、downgraded 10 件のうち 6 件が元の `high` のまま記録されていた。`downgraded_to` を足し、元の値と下げ後の両方を残す (`bc8f1dc9`)

**削ぎ落とし**

- ROUTING と SKILL_ONLY_REVIEWERS の overlap を実行時に log する check を削除 (`e2482348`)。どちらも同じファイル内のリテラルで実行時に値が変わらず、test が緑なら実行時も緑にしかならない。overlap の assert は T-014 に移した
- `SKILL_ONLY_REVIEWERS` は audit.js の実行時には要らないため test 側の定数にした
- コメントから計測値を削除。同じ「44 件が 2 件」が 3 箇所にあり、いずれも振る舞いを変えずに古くなる。audit.js の追加コメントは 61 行から 47 行へ

**この PR に含まれる #298 スコープ外の変更**

`.ja` の prose が英語に退行する incident が作業中に 4 件目として発覚したため、同じ PR で扱っている。

- `.ja/workflows/audit/snapshot.py` が `4f1fd3aa` の復旧漏れのまま英語だったのを日本語に戻した (`8b6b341e`)
- `hooks/ja-prose-guard.sh` を追加 (`d5ff358b`)。`.ja` 配下の py/js/ts/sh で prose に日本語が 1 文字も無ければ警告する。ブロックはしない。py は `ast` + `tokenize` で prose を正確に取る
- guard が検出した残り 6 ファイルを日本語化 (`fee6a4de`)。`.ja` 配下の py 全件がスキャンを通過する状態になった

## Design Decisions

- 判定は外部から観測できる形だけで行う
- prompt の文言の存在を固定する test は置かない。言い換えのたびに落ちる change detector になるため、二重刈りの確認は手動検証に回した
- fail-open した run の `tally` は payload から落とす (plan の contract)。`challenge_ran`/`verify_ran` が degraded 印を担う
- 既存の類似 test は `workflows/audit/tests/audit.routing.test.js`

## How to Test

1. `node --test workflows/audit/tests/*.test.js workflows/build/tests/*.test.js` を実行し、82 tests が pass することを確認する
2. `python3 -m unittest discover -s workflows/audit/tests -p 'snapshot_test.py'` で 12 tests が pass することを確認する

---

_build workflow が自動生成した検証記録に、その後の修正状況を追記している。_

Closes #298

<details>
<summary><code>verify tests=pass (JS 82 / Py 12) gates=pass</code> · <code>conformance 5 (2 high) → 2 未対応</code> · <code>structure 1</code> · <code>dogfood record 添付済み</code></summary>

**実機確認**
- [x] 実 `/audit` を走らせ、`history/audit-*.json` の verdict tally が空でなく R-N id を含むことを確認した。record はこの PR のコメントに添付してある。critic は入力の id をそのまま返しており、`source_ids` の 39 個すべてが `raw_findings` の id に対応する
- [ ] Integrate に渡す prompt が triage 済みである旨と再度の除外禁止を含むことをコードレビューで確認する。二重刈りは prompt 文言でしか止められず、文言の存在を T-NNN で固定すると言い換えのたびに落ちる change detector になる

**dogfood で判明した欠陥**

record を残したこと自体が、record を壊す経路を 3 つ暴いた。

| run | 症状 | 修正 |
| --- | --- | --- |
| 1 回目 | 修正前の script が走った。`Workflow({name})` はセッション開始時のスナップショットを解決する | `scriptPath` 指定に変更 |
| 2 回目 | 最終 findings 8 件すべてで `source_ids` が欠落。id は summary の散文に流れていた | `f6d63c7a` Integrate 専用 schema で必須化 |
| 3 回目 | snapshot agent が payload を切り詰め。`raw_findings` 44 件が 2 件になり、`tally.survived` 21 と矛盾 | `01f13aed` 件数の照合、`a74db31c` model を sonnet へ |
| 4 回目 | 全項目を満たす record を取得。ただしこの run 自身が high 2 件を挙げた | 未対応、コメントに triage を記載 |

2 回目の欠落は「1 回目は載っていた」との比較で、3 回目の切り詰めは tally との内部矛盾で初めて見つかった。どちらも record が無ければ観測できない。

3 回目への対応は切り詰めを**検出**するが**防止**しない。その検出自体が 4 回目の audit に `[high]` で否定されたため、`505b1fac` で判定を agent の自己申告から `snapshot.py` の実測へ移した。切り詰められた record が次回の delta baseline になる経路も同コミットで塞いである (添付した record の `delta` はこの理由で誤っており、以降の run では起きない)。詳細はコメントを参照。

`a74db31c` で snapshot の model を haiku から sonnet に上げた。`/audit` の全 run に効き、build から入れ子で呼ばれる分も含めてコストが上がる。

**前提 (veto 対象)**
- 依存する既存ファイルは `## Plan` の Preconditions を参照。anchor は 2026-08-02 時点で `ugrep -F` により存在を確認済み
- ~~critic が入力の R-N id をそのまま返すかは未検証~~ → 返すことを確認した。`source_ids` の 39 個すべてが `raw_findings` の id に存在し、振り直しは起きていない
- ~~Challenge と Verify の実行モデルは 2026-07-22 の sonnet 化以降 1 度も観測されていない~~ → 4 回の dogfood run で観測した。`challenge_ran` / `verify_ran` とも true、challenge は 42 件中 3 件を disputed で刈り 10 件を downgrade している

**Issue 適合性 (独立レビュー) — 5 件中 2 件は対応済み**

- ~~`[high] missing` 永続化された snapshot に id 単位の verdict と `needsContext` が渡っておらず、reviewer 別の生存率を測定できない~~ → **`4187a485` で対応**。triage ループが `f.verdict` を `rawFindings` に書き戻し、`needs_context` も payload に渡る。T-022 と T-017 で固定
- ~~`[medium] wrong` Integrate-absent フォールバックのコメント 4 行が canonical な `.ja` に英語のまま追加されている~~ → **`4187a485` で対応**。`.ja` 側に未翻訳のコメントが残っていないことを確認済み
- ~~`[high] missing` dogfood の `/audit` 実行と record の添付~~ → **対応済み**。`audit-2026-08-03-015400.json` をこの PR のコメントに整形して添付。`challenge_ran: true` / `tally: {survived: 39, needs_context: 0, no_verdict: 4}` / `raw_findings` 42 件すべてに id と verdict / `source_ids` 欠落 0
- `[medium] scope_creep` **対象外**: `skills/use-cli-scout/SKILL.md` と `.ja` 版は未コミットの working-tree 変更で、この PR の diff には入っていない。audit とは無関係の別作業
- `[low] scope_creep` **見送り**: ROUTING と SKILL_ONLY_REVIEWERS の runtime overlap warning が unit contract 外。`/simplify` も「両方とも同じファイル内のリテラルなので実行時に発火し得ない」と指摘したが、今回の修正範囲から外す判断をしている

**参照モジュールからの構造逸脱 — 未対応**

- `[convention]` polish.js の triage log は disputed/dropped count を第三の bucket として出すが、audit.js の `log()` と `tally` はその位置に `no_verdict` を置き、disputed count をどこにも出していない。`workflows/audit.js` の triage log 周辺 · ref: `workflows/polish.js` の triage log line

**`/simplify` が挙げて今回見送った項目**

いずれも変更範囲がこの PR を超えるため、必要なら別 issue に切り出す。

- テスト 5 ファイルに `agentStub`/`callOf`/payload 抽出 regex が重複している (call sites 5)。`workflows/audit/tests/` に共有 fixture を置く形の抽出になる
- `VERDICTS_SCHEMA` が `workflows/polish.js` と重複。mirror を掛けると 4 ファイル編集になるが、抽出には `.ja/workflows/_lib/` の新設が要る
- Verify pass が `parallel()` の barrier 内にあり Integrate を待たせている。`verified` の最初の消費は `writeSnapshot` なので、await を後ろにずらせば critical path から外れる
- `findings` が `rawFindings` と冗長。3 つの return site でキーセットが異なる
- `verifyRan` が文字列の空判定で「走ったが指摘なし」と「stall」を区別できない。verify に schema を与えるのが本筋

**異常 (Red 未確認)**

- U-002 (no-red): 割り当てられた 4 シナリオのうち 3 つが意図通りの理由で Red。T-008 は無改変のコードに対して pass し、needs_context の分岐は `36fadd4b` (U-001) で導入済みだったため実装変更不要と判断。`verify_ran` は本 unit に T-NNN が割り当てられておらず未検証のまま残されたが、これは後に `380b36ff` で実装と T-020/T-021 の採番により解消している
- U-007 (no-red): 23 tests 中 T-017 と T-019 が正真正銘の Red。原因は `writeSnapshot()` payload が計算済みの `tally` と `zeroReviewerFiles` を渡していないことにあり、`9c3278d1` で解消。T-018 は pass していたが、これは fail-open guard によるものではなく tally が全 branch で欠落していた副作用であり、T-017 の修正後に有効な regression guard として機能する

</details>
