### PR TITLE
reviewer が memory を根拠に finding を伏せ、その cull だけ記録が残らない

### DIFF
--- a/.ja/agents/_lib/finding-schema.md
+++ b/.ja/agents/_lib/finding-schema.md
@@ -87,6 +87,16 @@ Evidence, Trigger, Reasoning は具体的な言語を使う。
 
 各 reviewer の Calibration セクションにドメイン別 REPORT/SKIP 例がある。迷ったら SKIP を優先。challenger は false negative を捕まえる存在だが、false positive は pipeline capacity を浪費する。
 
+## Memory の用途
+
+frontmatter に `memory` を持つ reviewer は、agent-memory を下表の線引きで使う。false positive の判定は critic-audit が担い、disputed として record に残る。そのため reviewer は見つけた finding をすべて報告し、過去に報告済みで受理済みのパターンも報告対象に含める。既知であるという事実は severity の判断材料として使う。
+
+| 用途                                           | 可否     |
+| ---------------------------------------------- | -------- |
+| severity の判断材料 (actor、threat model など) | 使う     |
+| 報告前の再チェック手順 (grep、確認コマンド)    | 使う     |
+| finding を報告するかどうかの判断               | 使わない |
+
 ## 概要表
 
 複数 finding がある場合、この summary 表を先頭に置く。

--- a/agents/_lib/finding-schema.md
+++ b/agents/_lib/finding-schema.md
@@ -87,6 +87,16 @@ Apply in order. If any filter excludes, do not report.
 
 Each reviewer's Calibration section has domain-specific REPORT/SKIP examples. When uncertain, prefer SKIP. The challenger exists to catch false negatives, but false positives waste pipeline capacity.
 
+## Memory Usage
+
+A reviewer with `memory` in its frontmatter uses agent-memory within the boundary in the table below. critic-audit owns the false-positive verdict, which lands in the record as disputed. Therefore the reviewer reports every finding it discovers, including patterns reported and accepted in past runs. The fact that a pattern is known feeds the severity judgment.
+
+| Use                                               | Allowed |
+| ------------------------------------------------- | ------- |
+| Severity judgment material (actor, threat model)  | Yes     |
+| Pre-report re-check steps (grep, verify commands) | Yes     |
+| Whether to report a finding                       | No      |
+
 ## Overview Table
 
 When multiple findings exist, prepend this summary table.


### PR DESCRIPTION
## What & Why

audit の cull は件数・id・理由のいずれかが必ず record に残る設計になっている。一方で reviewer-security が memory に自書きした抑制ルールに従って finding を伏せると、その cull だけ何も残らない。そこで報告可否の判断を reviewer の裁量から外し、false positive の判定は critic-audit の disputed に一本化する。

## Review focus

- `## Memory の用途` の線引きが既存の報告基準とキャリブレーションフィルタに矛盾しないかを重点で見る。英語側は `.ja` の訳なので流し読みで可

## Changes

- `.ja/agents/_lib/finding-schema.md` (canonical) に memory の用途の線引きを追加し、英語ミラーを同一コミットで更新 (ADR-0073)
- `agent-memory/reviewer-security/` の既存 memory から抑制ルールを削除。gitignore 対象のためこの PR の diff には出ない

## Scope

- Not included: reviewer 18 体の frontmatter から `memory: project` を外すこと。severity 判断の根拠と再チェック手順まで失うため
- Not included: `FINDINGS_SCHEMA` への `acked_by` 追加

## Design Decisions

- `acked_by` で「既知だが報告する」と印を付けさせる案は不採用。schema は `additionalProperties: false` の共有オブジェクトで、付け忘れが finding ごと validation 落ちになる

## How to Test

1. `agents/_lib/finding-schema.md` の `## Memory Usage` を開く
2. 報告可否の判断に memory を使わない線引きが書かれている
3. 次回 `/audit` で既知パターンが再報告され、false positive は disputed として record に残る

## Related

- Closes #308

https://claude.ai/code/session_01E6264MWyWRpiuSfYahZLzW
