### PR TITLE
test(assert): audit stub 生成の中間関数を inline してテストを簡潔にする

### DIFF
--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -274,8 +274,8 @@ if (boot.mode === "none") {
 }
 
 // env fail (worktree 不可 / install fail) と build smoke fail (対象がビルドできない) を区別する。
-// caveat 落としは env fail のみに許す。build smoke fail を caveat に落とすと壊れたビルドが
-// merge に届く false-Ready を生む。
+// 動的 evidence の欠落のうち caveat 落としを許すのは env fail のみ。build smoke fail を caveat に
+// 落とすと壊れたビルドが merge に届く false-Ready を生む。
 const envFail = !boot.worktree_ok || boot.install === "fail";
 const buildCol = envFail ? "skipped" : boot.build;
 const dynamicOk = !envFail && buildCol !== "fail";

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -531,9 +531,9 @@ try {
   const challengeStalled = codexFindings.length > 0 && !challenged && !verified;
   // 入れ子の audit workflow 自身の challenge_ran は「challenge が verdicts を返した run」と
   // 「fail-open (challenge が走らず audit.js が全件 confirmed のまま通した run)」を区別する
-  // 値。degraded とみなすのは後者のときだけで、findings が空の run は audit.js 側の早期
-  // return であり degradation ではない。
-  const auditDegraded = auditFindings.length > 0 && !!audit && audit.challenge_ran === false;
+  // 値。findings が 0 件の早期 return も challenge_ran=false を返すため degraded に含める。
+  // reviewer が何も出さず challenge も走らなかった run が issues 0 件のまま Ready に届く穴を塞ぐ。
+  const auditDegraded = !!audit && audit.challenge_ran === false;
   const auditFindingsIntro = auditDegraded
     ? "入れ子の audit workflow の challenge stage が走らなかった (fail-open) ため、以下の findings は未検証として扱う。そのまま issues に含めてよいが、report で表面化する。"
     : "audit workflow の統合済み findings (critic 検証済み。そのまま issues に含める) は次のとおり。";
@@ -561,8 +561,9 @@ try {
   issues = mergeIssues(synth ? synth.issues : [...auditFindings, ...promoted]);
 
   // gate 規則。build smoke fail / test fail / issues 1 件以上は
-  // NotReady。severity は修正優先度のヒントに留まり、gate には影響しない。caveat は動的
-  // evidence が env 起因などで欠けたときだけで、issues 0 が前提。
+  // NotReady。severity は修正優先度のヒントに留まり、gate には影響しない。caveat は issues 0 を
+  // 前提に、動的 evidence が env 起因などで欠けたとき、または入れ子の audit が fail-open して
+  // findings が未検証のときに付く。
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
   } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -529,11 +529,19 @@ try {
   // ---- Synthesize: enhancer-evidence 統合 -> script が gate 判定 ----
   phase("Synthesize");
   const challengeStalled = codexFindings.length > 0 && !challenged && !verified;
+  // 入れ子の audit workflow 自身の challenge_ran は「challenge が verdicts を返した run」と
+  // 「fail-open (challenge が走らず audit.js が全件 confirmed のまま通した run)」を区別する
+  // 値。degraded とみなすのは後者のときだけで、findings が空の run は audit.js 側の早期
+  // return であり degradation ではない。
+  const auditDegraded = auditFindings.length > 0 && !!audit && audit.challenge_ran === false;
+  const auditFindingsIntro = auditDegraded
+    ? "入れ子の audit workflow の challenge stage が走らなかった (fail-open) ため、以下の findings は未検証として扱う。そのまま issues に含めてよいが、report で表面化する。"
+    : "audit workflow の統合済み findings (critic 検証済み。そのまま issues に含める) は次のとおり。";
   synth = await agent(
     anchor(
       `enhancer-evidence として、静的 findings、outcome evidence、adversarial 結果を root cause と最終 issues 集合に統合する。\n` +
         `Outcome 基準 (OUTCOME.md) は次のとおり。\n${boot.outcome}\n\n` +
-        `audit workflow の統合済み findings (critic 検証済み。そのまま issues に含める) は次のとおり。\n${JSON.stringify(auditFindings)}\n\n` +
+        `${auditFindingsIntro}\n${JSON.stringify(auditFindings)}\n\n` +
         `Codex findings への challenge pass (membership はこの pass が決める。false positive として刈られた finding は verification pass が evidence を見つけていても復活させない) は次のとおり。\n${challenged || "(challenge stall / findings なし)"}\n\n` +
         `Codex findings への verification pass (survivor への実行経路 evidence と severity 付与のみ) は次のとおり。\n${verified || "(verify stall / findings なし)"}\n\n` +
         `${challengeStalled ? "challenger / verifier が双方 stall したため、Codex findings は未検証。issues に含めず report で表面化する。\n\n" : ""}` +
@@ -557,7 +565,7 @@ try {
   // evidence が env 起因などで欠けたときだけで、issues 0 が前提。
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
-  } else if (!envFail && (testsCol === "pass" || testsCol === "no-runner")) {
+  } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
   } else {
     gate = "Ready (caveat)";

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -688,11 +688,10 @@ log(
 // 全 finding が no_verdict 経由で confirmed に落ちる) を区別する。verify は自由記述の
 // テキストを返すため、schema の形ではなく中身の有無で判定する。
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
-// assert.js の challengeStalled による prompt 分岐に倣う: Integrate に membership 確定済みと
-// 伝えてよいかどうか。challengeRan だけでは空の verdicts 配列も確定済みと数えてしまう
-// (challengeRan 自身の定義はここでは変えない) が、その run では verdict が実際には 1 件も
-// 出ていないので、challengeRan には無い件数チェックをここに足す。
-const membershipDecided = challengeRan && challenged.verdicts.length > 0;
+// assert.js の challengeStalled と同じく劣化側を指す boolean。challengeRan だけでは空の
+// verdicts 配列も走ったと数えてしまう (challengeRan 自身の定義はここでは変えない) が、その run
+// では verdict が 1 件も出ていないので、challengeRan には無い件数チェックをここに足す。
+const challengeDegraded = !challengeRan || challenged.verdicts.length === 0;
 const verifyRan = !!String(verified || "").trim();
 const tally = {
   survived: survivors.length,
@@ -710,7 +709,7 @@ const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
   anchor(
     `enhancer-integration として、challenge triage を生き残った survivors を file:line で突き合わせ、cross-domain の root cause と severity 順のリストに reconcile する。\n` +
-      `${membershipDecided ? "Membership は既に確定している。以下の survivors はすべて challenge pass を通過済みなので、再び刈ったり disputed 扱いにしたり drop したりしない。merge と並べ替えだけを行う。\n" : ""}` +
+      `${challengeDegraded ? "challenge pass が verdict を 1 件も返さなかったため、以下の survivors は未検証のまま通っている。membership は未確定として扱い、根拠が立たない finding は root cause から外してよい。\n" : "Membership は既に確定している。以下の survivors はすべて challenge pass を通過済みなので、再び刈ったり disputed 扱いにしたり drop したりしない。merge と並べ替えだけを行う。\n"}` +
       `返す finding には、吸収した survivor の id (R-N) を source_ids に全件残す。複数の survivor を統合した root cause なら、その全 id を source_ids に持つ。\n` +
       `Survivors は次のとおり。\n${fenced(JSON.stringify(survivorsInput))}`,
   ),

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -688,6 +688,11 @@ log(
 // 全 finding が no_verdict 経由で confirmed に落ちる) を区別する。verify は自由記述の
 // テキストを返すため、schema の形ではなく中身の有無で判定する。
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
+// assert.js の challengeStalled による prompt 分岐に倣う: Integrate に membership 確定済みと
+// 伝えてよいかどうか。challengeRan だけでは空の verdicts 配列も確定済みと数えてしまう
+// (challengeRan 自身の定義はここでは変えない) が、その run では verdict が実際には 1 件も
+// 出ていないので、challengeRan には無い件数チェックをここに足す。
+const membershipDecided = challengeRan && challenged.verdicts.length > 0;
 const verifyRan = !!String(verified || "").trim();
 const tally = {
   survived: survivors.length,
@@ -705,7 +710,7 @@ const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
   anchor(
     `enhancer-integration として、challenge triage を生き残った survivors を file:line で突き合わせ、cross-domain の root cause と severity 順のリストに reconcile する。\n` +
-      `Membership は既に確定している。以下の survivors はすべて challenge pass を通過済みなので、再び刈ったり disputed 扱いにしたり drop したりしない。merge と並べ替えだけを行う。\n` +
+      `${membershipDecided ? "Membership は既に確定している。以下の survivors はすべて challenge pass を通過済みなので、再び刈ったり disputed 扱いにしたり drop したりしない。merge と並べ替えだけを行う。\n" : ""}` +
       `返す finding には、吸収した survivor の id (R-N) を source_ids に全件残す。複数の survivor を統合した root cause なら、その全 id を source_ids に持つ。\n` +
       `Survivors は次のとおり。\n${fenced(JSON.stringify(survivorsInput))}`,
   ),

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -538,11 +538,19 @@ try {
   // ---- Synthesize: enhancer-evidence integration -> script decides the gate ----
   phase("Synthesize");
   const challengeStalled = codexFindings.length > 0 && !challenged && !verified;
+  // The nested audit workflow's own challenge_ran distinguishes "challenge produced
+  // verdicts" from "fail-open (challenge did not run, so audit.js let all findings through
+  // as confirmed)". Findings are degraded only in the latter case; an empty-findings run is
+  // audit.js's own early return, not a degradation.
+  const auditDegraded = auditFindings.length > 0 && !!audit && audit.challenge_ran === false;
+  const auditFindingsIntro = auditDegraded
+    ? "The nested audit workflow's challenge stage did not run (fail-open), so treat the following findings as unverified; include them in issues as-is but flag this in the report."
+    : "The integrated findings from the audit workflow (critic-verified; include them in issues as-is) are as follows.";
   synth = await agent(
     anchor(
       `As enhancer-evidence, integrate the static findings, outcome evidence, and adversarial results into root causes and a final issues set.\n` +
         `The Outcome criteria (OUTCOME.md) are as follows.\n${boot.outcome}\n\n` +
-        `The integrated findings from the audit workflow (critic-verified; include them in issues as-is) are as follows.\n${JSON.stringify(auditFindings)}\n\n` +
+        `${auditFindingsIntro}\n${JSON.stringify(auditFindings)}\n\n` +
         `The challenge pass over the Codex findings (this pass decides membership; findings pruned as false positives stay pruned even if the verification pass found evidence) is as follows.\n${challenged || "(challenge stalled / no findings)"}\n\n` +
         `The verification pass over the Codex findings (only attaches execution-path evidence and severity to survivors) is as follows.\n${verified || "(verify stalled / no findings)"}\n\n` +
         `${challengeStalled ? "Both challenger and verifier stalled, so the Codex findings are unverified. Do not include them in issues; surface this in the report.\n\n" : ""}` +
@@ -567,7 +575,7 @@ try {
   // presumes zero issues.
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
-  } else if (!envFail && (testsCol === "pass" || testsCol === "no-runner")) {
+  } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
   } else {
     gate = "Ready (caveat)";

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -274,8 +274,9 @@ if (boot.mode === "none") {
 }
 
 // Distinguish env fail (worktree impossible / install fail) from build smoke fail (the
-// target itself does not build). Only env fail may demote to caveat. Demoting a build
-// smoke fail would produce a false Ready that lets a broken build reach merge.
+// target itself does not build). Among dynamic-evidence gaps, only env fail may demote to
+// caveat. Demoting a build smoke fail would produce a false Ready that lets a broken build
+// reach merge.
 const envFail = !boot.worktree_ok || boot.install === "fail";
 const buildCol = envFail ? "skipped" : boot.build;
 const dynamicOk = !envFail && buildCol !== "fail";

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -540,9 +540,10 @@ try {
   const challengeStalled = codexFindings.length > 0 && !challenged && !verified;
   // The nested audit workflow's own challenge_ran distinguishes "challenge produced
   // verdicts" from "fail-open (challenge did not run, so audit.js let all findings through
-  // as confirmed)". Findings are degraded only in the latter case; an empty-findings run is
-  // audit.js's own early return, not a degradation.
-  const auditDegraded = auditFindings.length > 0 && !!audit && audit.challenge_ran === false;
+  // as confirmed)". The zero-findings early return carries challenge_ran=false too and
+  // counts as degraded, closing the hole where a run whose reviewers found nothing and
+  // whose challenge never ran still reaches Ready with zero issues.
+  const auditDegraded = !!audit && audit.challenge_ran === false;
   const auditFindingsIntro = auditDegraded
     ? "The nested audit workflow's challenge stage did not run (fail-open), so treat the following findings as unverified; include them in issues as-is but flag this in the report."
     : "The integrated findings from the audit workflow (critic-verified; include them in issues as-is) are as follows.";
@@ -571,8 +572,8 @@ try {
 
   // Gate rule. Build smoke fail / test fail / one or more
   // issues means NotReady. Severity remains a fix-priority hint and never affects the
-  // gate. caveat applies only when dynamic evidence is missing for env reasons, and
-  // presumes zero issues.
+  // gate. caveat presumes zero issues and applies when dynamic evidence is missing for env
+  // reasons, or when the nested audit failed open and left its findings unverified.
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
   } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -125,26 +125,6 @@ test("triage block 内で throw が起きた時、result.adversarial が stall �
 
 // U-002: 入れ子の workflow("audit") が fail-open (challenge_ran=false) した run では、
 // audit findings を critic 検証済みと呼ばず、gate も Ready にならない。
-// T-004 audit が challenge_ran=false を返した run の Synthesize prompt は audit findings を
-//       critic 検証済みと書かない
-// T-005 audit が challenge_ran=true を返した run の文言は変わらない
-// T-006 audit が challenge_ran=false で issues が0件の run の gate は Ready ではなく
-//       Ready (caveat) になる
-// T-007 audit が challenge_ran=true で issues が0件かつ tests が pass の run の gate は
-//       Ready のままになる
-// T-009 audit が findings 0件かつ challenge_ran=false を返した run の gate も Ready ではなく
-//       Ready (caveat) になる
-//
-// contract: workflows/assert.js の challengeStalled (verification signal が run しなかったこと
-// を示す boolean を script が計算する形) と同じ形で auditDegraded を計算する。audit.js 自身の
-// challenge_ran は「verdicts を返した run」と「fail-open (challenge が走らず全件 confirmed に
-// なった run)」を区別する値なので、challenge_ran===false を degraded とみなす。findings 0件の
-// 早期 return も challenge_ran=false を返し、reviewer が何も出さず challenge も走らなかった run
-// が issues 0件のまま Ready に届く穴そのものなので、件数では除外しない。劣化を示す値は script が
-// 計算し、agent には判定させない。Synthesize prompt の audit findings を紹介する一文は劣化時
-// だけ切り替え、通常時 (challenge_ran=true) の "critic-verified" 文言は変えない。gate rule は
-// Ready 分岐の条件に auditDegraded を加える (buildCol=pass, testsCol=pass, issues=0 でも
-// degraded なら Ready でなく Ready (caveat) に落ちる)。
 
 // challenge_ran だけを差し替え、findings は両ケースとも1件持たせる。findings 0件との組み合わせは
 // T-009 が別に押さえる。
@@ -157,8 +137,7 @@ const makeAuditWorkflowStub = (challengeRan) => (name) =>
       }
     : undefined;
 
-// synthesize agent への呼び出しは opts.label === "synthesize" の 1 件のみなので、その prompt
-// 文字列を取り出して audit findings の紹介文言を検査する。
+// synthesize agent への呼び出しは run 全体で 1 件のみ。
 const synthesizePromptOf = (calls) => {
   const call = calls.agent.find((c) => c.opts && c.opts.label === "synthesize");
   return (call && call.prompt) || "";
@@ -243,18 +222,13 @@ test("T-009 audit が findings 0件かつ challenge_ran=false を返した run �
 });
 
 // U-003: audit workflow の返り値を実際に受け取った assert が、劣化を gate に反映する。
-// T-008 は T-004〜T-007 と異なり、workflow("audit") を手書きオブジェクトへ置き換えない。
-// assert.js の workflow stub から workflows/audit.js を runWorkflow でネストして本当に走らせ、
-// audit.js 自身の challenge 段 (label "challenge") にだけ無出力を返して agent stall を再現する。
-// challenge_ran は audit.js 側の fail-open ロジック
-// (`!!(challenged && Array.isArray(challenged.verdicts))`) が自力で false に落とすので、
-// このテストは challenge_ran を直接書かない。audit の返り値から assert の gate 計算までが
-// 実際に繋がっていることが検証対象で、内部レイヤーのスタブ化はしない (seam unit の契約)。
+// T-008 は workflow("audit") を手書きオブジェクトへ置き換えず、audit.js をネストで本当に走らせる。
+// 検証対象が audit の返り値から assert の gate 計算までの接続なので、内部レイヤーはスタブ化しない
+// (seam unit の契約)。
 const auditJs = join(here, "..", "..", "audit.js");
 
-// audit.js の各 stage label に対応する最小応答。found した finding が1件、
-// challenge/snapshot と他の reviewer は無出力 (undefined) のまま返し、
-// challenge_ran=false と findings 非空を audit.js 自身の計算で導く。
+// audit.js の各 stage label に対応する最小応答。challenge 段だけ無出力にして、
+// challenge_ran=false と findings 非空を audit.js 自身に計算させる。
 const auditAgentStub = (prompt, opts) => {
   const label = opts && opts.label;
   if (label === "route") return { files: [{ path: "a.js", churn: 0 }] };
@@ -268,9 +242,7 @@ const auditAgentStub = (prompt, opts) => {
       ],
     };
   // "challenge" (audit.js 自身の challenge 段) / "snapshot" / 他の reviewer label は
-  // 意図的に無出力のまま返す。audit.js の challengeRan は
-  // `!!(challenged && Array.isArray(challenged.verdicts))` で自己計算されるため、
-  // ここで challenge_ran を直接指定する必要はない。
+  // 意図的に無出力のまま返す。
   return undefined;
 };
 

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -147,14 +147,14 @@ test("triage block 内で throw が起きた時、result.adversarial が stall �
 // audit findings を非空にして challenge_ran だけを差し替える。findings が空だと audit.js 側の
 // 早期 return (challenge_ran=false だが degradation ではない) と区別できなくなるため、
 // 両ケースとも findings を1件持たせる。
-const auditWithChallengeRan = (challengeRan) => ({
-  findings: [{ file: "a.js", line: 5, severity: "high", summary: "audit finding" }],
-  challenge_ran: challengeRan,
-  verify_ran: challengeRan,
-});
-
 const makeAuditWorkflowStub = (challengeRan) => (name) =>
-  name === "audit" ? auditWithChallengeRan(challengeRan) : undefined;
+  name === "audit"
+    ? {
+        findings: [{ file: "a.js", line: 5, severity: "high", summary: "audit finding" }],
+        challenge_ran: challengeRan,
+        verify_ran: challengeRan,
+      }
+    : undefined;
 
 // synthesize agent への呼び出しは opts.label === "synthesize" の 1 件のみなので、その prompt
 // 文字列を取り出して audit findings の紹介文言を検査する。

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -132,21 +132,22 @@ test("triage block 内で throw が起きた時、result.adversarial が stall �
 //       Ready (caveat) になる
 // T-007 audit が challenge_ran=true で issues が0件かつ tests が pass の run の gate は
 //       Ready のままになる
+// T-009 audit が findings 0件かつ challenge_ran=false を返した run の gate も Ready ではなく
+//       Ready (caveat) になる
 //
-// contract: workflows/assert.js の challengeStalled (findings が存在するのに verification
-// signal が run しなかったことを示す boolean を script が計算する形) と同じ形で auditDegraded
-// を計算する。audit.js 自身の challenge_ran は「verdicts を返した run」と「fail-open (findings
-// はあるが challenge が走らず全件 confirmed になった run)」を区別する値なので、audit findings
-// が非空かつ challenge_ran===false のときだけ degraded とみなす (findings が空の run は audit.js
-// 側の早期 return であり degradation ではない)。劣化を示す値は script が計算し、agent には
-// 判定させない。Synthesize prompt の audit findings を紹介する一文は劣化時だけ切り替え、
-// 通常時 (challenge_ran=true) の "critic-verified" 文言は変えない。gate rule は Ready 分岐の
-// 条件に auditDegraded を加える (buildCol=pass, testsCol=pass, issues=0 でも degraded なら
-// Ready でなく Ready (caveat) に落ちる)。
+// contract: workflows/assert.js の challengeStalled (verification signal が run しなかったこと
+// を示す boolean を script が計算する形) と同じ形で auditDegraded を計算する。audit.js 自身の
+// challenge_ran は「verdicts を返した run」と「fail-open (challenge が走らず全件 confirmed に
+// なった run)」を区別する値なので、challenge_ran===false を degraded とみなす。findings 0件の
+// 早期 return も challenge_ran=false を返し、reviewer が何も出さず challenge も走らなかった run
+// が issues 0件のまま Ready に届く穴そのものなので、件数では除外しない。劣化を示す値は script が
+// 計算し、agent には判定させない。Synthesize prompt の audit findings を紹介する一文は劣化時
+// だけ切り替え、通常時 (challenge_ran=true) の "critic-verified" 文言は変えない。gate rule は
+// Ready 分岐の条件に auditDegraded を加える (buildCol=pass, testsCol=pass, issues=0 でも
+// degraded なら Ready でなく Ready (caveat) に落ちる)。
 
-// audit findings を非空にして challenge_ran だけを差し替える。findings が空だと audit.js 側の
-// 早期 return (challenge_ran=false だが degradation ではない) と区別できなくなるため、
-// 両ケースとも findings を1件持たせる。
+// challenge_ran だけを差し替え、findings は両ケースとも1件持たせる。findings 0件との組み合わせは
+// T-009 が別に押さえる。
 const makeAuditWorkflowStub = (challengeRan) => (name) =>
   name === "audit"
     ? {
@@ -222,6 +223,22 @@ test("T-007 audit が challenge_ran=true で issues が0件かつ tests が pass
     result.gate,
     "Ready",
     "audit の challenge が正常に走った run は issues 0件かつ tests pass のとき Ready のままになる",
+  );
+});
+
+test("T-009 audit が findings 0件かつ challenge_ran=false を返した run の gate は Ready ではなく Ready (caveat) になる", async () => {
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: makeAgent({ ran: true, tests: [] }),
+      workflow: (name) =>
+        name === "audit" ? { findings: [], challenge_ran: false, verify_ran: false } : undefined,
+    },
+  });
+  assert.equal(
+    result.gate,
+    "Ready (caveat)",
+    "reviewer が何も出さず challenge も走らなかった run は issues 0件でも Ready にならない",
   );
 });
 

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -264,9 +264,9 @@ test("T-008 challenge を stub しない audit を入れ子で走らせた asser
       workflow: runRealAudit,
     },
   });
-  assert.notEqual(
+  assert.equal(
     result.gate,
-    "Ready",
-    "audit を実際に入れ子で走らせ challenge が fail-open (challenge_ran=false) になった run は gate が Ready にならない",
+    "Ready (caveat)",
+    "audit を実際に入れ子で走らせ challenge が fail-open (challenge_ran=false) になった run は gate が Ready (caveat) になる",
   );
 });

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -122,3 +122,105 @@ test("triage block 内で throw が起きた時、result.adversarial が stall �
     "triage block の throw が stall として記録され、clean な 0 件と区別できる",
   );
 });
+
+// U-002: 入れ子の workflow("audit") が fail-open (challenge_ran=false) した run では、
+// audit findings を critic 検証済みと呼ばず、gate も Ready にならない。
+// T-004 audit が challenge_ran=false を返した run の Synthesize prompt は audit findings を
+//       critic 検証済みと書かない
+// T-005 audit が challenge_ran=true を返した run の文言は変わらない
+// T-006 audit が challenge_ran=false で issues が0件の run の gate は Ready ではなく
+//       Ready (caveat) になる
+// T-007 audit が challenge_ran=true で issues が0件かつ tests が pass の run の gate は
+//       Ready のままになる
+//
+// contract: workflows/assert.js の challengeStalled (findings が存在するのに verification
+// signal が run しなかったことを示す boolean を script が計算する形) と同じ形で auditDegraded
+// を計算する。audit.js 自身の challenge_ran は「verdicts を返した run」と「fail-open (findings
+// はあるが challenge が走らず全件 confirmed になった run)」を区別する値なので、audit findings
+// が非空かつ challenge_ran===false のときだけ degraded とみなす (findings が空の run は audit.js
+// 側の早期 return であり degradation ではない)。劣化を示す値は script が計算し、agent には
+// 判定させない。Synthesize prompt の audit findings を紹介する一文は劣化時だけ切り替え、
+// 通常時 (challenge_ran=true) の "critic-verified" 文言は変えない。gate rule は Ready 分岐の
+// 条件に auditDegraded を加える (buildCol=pass, testsCol=pass, issues=0 でも degraded なら
+// Ready でなく Ready (caveat) に落ちる)。
+
+// audit findings を非空にして challenge_ran だけを差し替える。findings が空だと audit.js 側の
+// 早期 return (challenge_ran=false だが degradation ではない) と区別できなくなるため、
+// 両ケースとも findings を1件持たせる。
+const auditWithChallengeRan = (challengeRan) => ({
+  findings: [{ file: "a.js", line: 5, severity: "high", summary: "audit finding" }],
+  challenge_ran: challengeRan,
+  verify_ran: challengeRan,
+});
+
+const makeAuditWorkflowStub = (challengeRan) => (name) =>
+  name === "audit" ? auditWithChallengeRan(challengeRan) : undefined;
+
+// synthesize agent への呼び出しは opts.label === "synthesize" の 1 件のみなので、その prompt
+// 文字列を取り出して audit findings の紹介文言を検査する。
+const synthesizePromptOf = (calls) => {
+  const call = calls.agent.find((c) => c.opts && c.opts.label === "synthesize");
+  return (call && call.prompt) || "";
+};
+
+test("T-004 audit が challenge_ran=false を返した run の Synthesize prompt は audit findings を critic 検証済みと書かない", async () => {
+  const { calls } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: makeAgent({ ran: true, tests: [] }),
+      workflow: makeAuditWorkflowStub(false),
+    },
+  });
+  const prompt = synthesizePromptOf(calls);
+  assert.ok(prompt.length > 0, "synthesize agent が呼ばれる");
+  assert.ok(
+    !/critic-verified/i.test(prompt),
+    "audit の challenge が fail-open (challenge_ran=false) の run では audit findings を critic 検証済みと書かない",
+  );
+});
+
+test("T-005 audit が challenge_ran=true を返した run の文言は変わらない", async () => {
+  const { calls } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: makeAgent({ ran: true, tests: [] }),
+      workflow: makeAuditWorkflowStub(true),
+    },
+  });
+  const prompt = synthesizePromptOf(calls);
+  assert.ok(prompt.length > 0, "synthesize agent が呼ばれる");
+  assert.ok(
+    /critic-verified/i.test(prompt),
+    "audit の challenge が正常に走った (challenge_ran=true) run の文言は既存の critic-verified 表記のままになる",
+  );
+});
+
+test("T-006 audit が challenge_ran=false で issues が0件の run の gate は Ready ではなく Ready (caveat) になる", async () => {
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: makeAgent({ ran: true, tests: [] }),
+      workflow: makeAuditWorkflowStub(false),
+    },
+  });
+  assert.equal(
+    result.gate,
+    "Ready (caveat)",
+    "audit が fail-open した run は issues 0件でも Ready でなく Ready (caveat) になる",
+  );
+});
+
+test("T-007 audit が challenge_ran=true で issues が0件かつ tests が pass の run の gate は Ready のままになる", async () => {
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: makeAgent({ ran: true, tests: [] }),
+      workflow: makeAuditWorkflowStub(true),
+    },
+  });
+  assert.equal(
+    result.gate,
+    "Ready",
+    "audit の challenge が正常に走った run は issues 0件かつ tests pass のとき Ready のままになる",
+  );
+});

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -224,3 +224,60 @@ test("T-007 audit が challenge_ran=true で issues が0件かつ tests が pass
     "audit の challenge が正常に走った run は issues 0件かつ tests pass のとき Ready のままになる",
   );
 });
+
+// U-003: audit workflow の返り値を実際に受け取った assert が、劣化を gate に反映する。
+// T-008 は T-004〜T-007 と異なり、workflow("audit") を手書きオブジェクトへ置き換えない。
+// assert.js の workflow stub から workflows/audit.js を runWorkflow でネストして本当に走らせ、
+// audit.js 自身の challenge 段 (label "challenge") にだけ無出力を返して agent stall を再現する。
+// challenge_ran は audit.js 側の fail-open ロジック
+// (`!!(challenged && Array.isArray(challenged.verdicts))`) が自力で false に落とすので、
+// このテストは challenge_ran を直接書かない。audit の返り値から assert の gate 計算までが
+// 実際に繋がっていることが検証対象で、内部レイヤーのスタブ化はしない (seam unit の契約)。
+const auditJs = join(here, "..", "..", "audit.js");
+
+// audit.js の各 stage label に対応する最小応答。found した finding が1件、
+// challenge/snapshot と他の reviewer は無出力 (undefined) のまま返し、
+// challenge_ran=false と findings 非空を audit.js 自身の計算で導く。
+const auditAgentStub = (prompt, opts) => {
+  const label = opts && opts.label;
+  if (label === "route") return { files: [{ path: "a.js", churn: 0 }] };
+  if (label === "security")
+    return { findings: [{ file: "a.js", line: 5, severity: "high", summary: "issue" }] };
+  if (label === "verify") return "verified: execution path confirmed";
+  if (label === "integrate")
+    return {
+      findings: [
+        { file: "a.js", line: 5, severity: "high", summary: "issue", source_ids: ["R-1"] },
+      ],
+    };
+  // "challenge" (audit.js 自身の challenge 段) / "snapshot" / 他の reviewer label は
+  // 意図的に無出力のまま返す。audit.js の challengeRan は
+  // `!!(challenged && Array.isArray(challenged.verdicts))` で自己計算されるため、
+  // ここで challenge_ran を直接指定する必要はない。
+  return undefined;
+};
+
+// assert.js の workflow("audit", wfArgs) を、audit.js を本当にネストで走らせる形に差し替える。
+const runRealAudit = async (name, wfArgs) => {
+  if (name !== "audit") return undefined;
+  const { result } = await runWorkflow(auditJs, {
+    args: wfArgs,
+    stubs: { agent: auditAgentStub },
+  });
+  return result;
+};
+
+test("T-008 challenge を stub しない audit を入れ子で走らせた assert は、audit の challenge_ran=false を受け取って gate を Ready にしない", async () => {
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: makeAgent({ ran: true, tests: [] }),
+      workflow: runRealAudit,
+    },
+  });
+  assert.notEqual(
+    result.gate,
+    "Ready",
+    "audit を実際に入れ子で走らせ challenge が fail-open (challenge_ran=false) になった run は gate が Ready にならない",
+  );
+});

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -698,6 +698,11 @@ log(
 // verdictById drops every finding to confirmed via no_verdict). verify returns free-form
 // text, so it is judged by whether content came back rather than by a schema shape.
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
+// Mirrors assert.js's challengeStalled prompt branch: whether Integrate can be told
+// membership is already settled. challengeRan alone would count an empty verdicts array as
+// decided (its own definition stays out of scope here), but no verdict was actually
+// rendered for that run, so this adds a length check challengeRan does not have.
+const membershipDecided = challengeRan && challenged.verdicts.length > 0;
 const verifyRan = !!String(verified || "").trim();
 const tally = {
   survived: survivors.length,
@@ -715,7 +720,7 @@ const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
   anchor(
     `enhancer-integration. Reconcile these survivors of the challenge triage, matched by file:line, into cross-domain root causes and a severity-ordered list.\n` +
-      `Membership is already decided: every survivor below already passed the challenge pass. Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes.\n` +
+      `${membershipDecided ? "Membership is already decided: every survivor below already passed the challenge pass. Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes.\n" : ""}` +
       `Each finding you return must carry source_ids listing every survivor id (R-N) it absorbed, so a root cause merged from several survivors keeps all of their ids.\n` +
       `The survivors are as follows.\n${fenced(JSON.stringify(survivorsInput))}`,
   ),

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -698,11 +698,11 @@ log(
 // verdictById drops every finding to confirmed via no_verdict). verify returns free-form
 // text, so it is judged by whether content came back rather than by a schema shape.
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
-// Mirrors assert.js's challengeStalled prompt branch: whether Integrate can be told
-// membership is already settled. challengeRan alone would count an empty verdicts array as
-// decided (its own definition stays out of scope here), but no verdict was actually
-// rendered for that run, so this adds a length check challengeRan does not have.
-const membershipDecided = challengeRan && challenged.verdicts.length > 0;
+// Names the degraded side, as assert.js's challengeStalled does. challengeRan alone would
+// count an empty verdicts array as having run (its own definition stays out of scope here),
+// but no verdict was actually rendered for that run, so this adds a length check
+// challengeRan does not have.
+const challengeDegraded = !challengeRan || challenged.verdicts.length === 0;
 const verifyRan = !!String(verified || "").trim();
 const tally = {
   survived: survivors.length,
@@ -720,7 +720,7 @@ const survivorsInput = survivors.map(toCriticRef);
 const integrated = await agent(
   anchor(
     `enhancer-integration. Reconcile these survivors of the challenge triage, matched by file:line, into cross-domain root causes and a severity-ordered list.\n` +
-      `${membershipDecided ? "Membership is already decided: every survivor below already passed the challenge pass. Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes.\n" : ""}` +
+      `${challengeDegraded ? "The challenge pass returned no verdicts, so every survivor below came through unverified. Treat membership as unsettled and drop any finding you cannot ground in evidence.\n" : "Membership is already decided: every survivor below already passed the challenge pass. Do not re-cull, dispute, or drop any survivor; only merge and reorder them into root causes.\n"}` +
       `Each finding you return must carry source_ids listing every survivor id (R-N) it absorbed, so a root cause merged from several survivors keeps all of their ids.\n` +
       `The survivors are as follows.\n${fenced(JSON.stringify(survivorsInput))}`,
   ),

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -375,3 +375,39 @@ test("T-004 別 run の fence は前 run と異なる marker を使う", async (
   assert.ok(secondFence, "2 回目の run の snapshot prompt に marker が乗る");
   assert.notEqual(firstFence.nonce, secondFence.nonce, "別 run の fence は異なる nonce を使う");
 });
+
+// workflows/assert.js の challengeStalled による prompt 分岐に倣う。challenge が verdict を
+// 返さなかった run では、Integrate に「刈るな」と指示しない (membership 確定の一文を出さない)。
+// challenge_ran の定義 (空配列を ran と刻印する) は変えないので、ここでは Integrate prompt の
+// 文言だけを見る。
+const MEMBERSHIP_SENTENCE = "Membership is already decided";
+
+test("T-001 challenge が verdict を返した run の Integrate prompt には membership 確定の一文が入る", async () => {
+  const { calls } = await run({ challenge: BOTH_CONFIRMED, integrate: INTEGRATED });
+  const call = callOf(calls, "integrate");
+  assert.ok(call, "integrate agent が起動する");
+  assert.ok(
+    call.prompt.includes(MEMBERSHIP_SENTENCE),
+    "challenge が verdict を返した run では Integrate prompt に membership 確定の一文が入る",
+  );
+});
+
+test("T-002 challenge が結果を返さない run の Integrate prompt には membership 確定の一文が入らない", async () => {
+  const { calls } = await run({ challenge: undefined, integrate: INTEGRATED });
+  const call = callOf(calls, "integrate");
+  assert.ok(call, "integrate agent が起動する");
+  assert.ok(
+    !call.prompt.includes(MEMBERSHIP_SENTENCE),
+    "challenge が結果を返さない run では Integrate prompt に membership 確定の一文が入らない",
+  );
+});
+
+test("T-003 challenge が空の verdicts を返した run も、結果を返さない run と同じ扱いになる", async () => {
+  const { calls } = await run({ challenge: { verdicts: [] }, integrate: INTEGRATED });
+  const call = callOf(calls, "integrate");
+  assert.ok(call, "integrate agent が起動する");
+  assert.ok(
+    !call.prompt.includes(MEMBERSHIP_SENTENCE),
+    "challenge が空の verdicts を返した run では Integrate prompt に membership 確定の一文が入らない (challenge が結果を返さない run と同じ扱い)",
+  );
+});

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -411,3 +411,16 @@ test("T-003 challenge が空の verdicts を返した run も、結果を返さ�
     "challenge が空の verdicts を返した run では Integrate prompt に membership 確定の一文が入らない (challenge が結果を返さない run と同じ扱い)",
   );
 });
+
+// 劣化側は一文を落とすだけで終わらせず、verdict が 1 件も出ていないことを Integrate に名指す
+// (rules/conventions/WORKFLOWS.md § Degradation recording)。この assert が無いと、劣化分岐を
+// 空文字列へ戻しても T-002 / T-003 は通ってしまう。
+test("T-004 challenge が結果を返さない run の Integrate prompt には verdict 不在を名指す一文が入る", async () => {
+  const { calls } = await run({ challenge: undefined, integrate: INTEGRATED });
+  const call = callOf(calls, "integrate");
+  assert.ok(call, "integrate agent が起動する");
+  assert.ok(
+    call.prompt.includes("The challenge pass returned no verdicts"),
+    "challenge が結果を返さない run では Integrate prompt に verdict 不在を名指す一文が入る",
+  );
+});

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -415,7 +415,7 @@ test("T-003 challenge が空の verdicts を返した run も、結果を返さ�
 // 劣化側は一文を落とすだけで終わらせず、verdict が 1 件も出ていないことを Integrate に名指す
 // (rules/conventions/WORKFLOWS.md § Degradation recording)。この assert が無いと、劣化分岐を
 // 空文字列へ戻しても T-002 / T-003 は通ってしまう。
-test("T-004 challenge が結果を返さない run の Integrate prompt には verdict 不在を名指す一文が入る", async () => {
+test("T-010 challenge が結果を返さない run の Integrate prompt には verdict 不在を名指す一文が入る", async () => {
   const { calls } = await run({ challenge: undefined, integrate: INTEGRATED });
   const call = callOf(calls, "integrate");
   assert.ok(call, "integrate agent が起動する");


### PR DESCRIPTION
## What & Why

audit の challenge が verdict を返さなかった run では、Integrate に「刈るな」と指示せず、assert が findings を「critic-verified」と呼ばず、gate が Ready にならない。劣化した run と正常な run が、下流の文言と gate の両方で区別できる。

audit.js の Integrate プロンプトを、challenge が verdict を返した時だけ「membership は決定済み、merge と並べ替えのみ」と伝える形に変え、assert.js には audit の `challenge_ran` を受けて `auditDegraded` を計算するロジックを追加した。

## Review focus

- `auditDegraded` は `envFail` と無関係に `Ready (caveat)` へ倒す条件になった。caveat の意味がここまで広がってよいかを判断してほしい
- `code_anomalies` の U-003 は no-red（新規実装なしで既存テストが通った）と報告されている。下の詳細セクションで根拠を確認してほしい

## 追加コミットでの対応

下の詳細セクションが挙げた conformance high 2 件と structure 1 件は、`408b6a11` `f49da703` `2ea97cf5` で解消した。記録として詳細セクションはそのまま残している。

| 指摘 | 対応 |
| --- | --- |
| gate rule のコメントが「caveat は env 理由のみ」のまま | `workflows/assert.js:575` と `:277` の 2 箇所を更新。`:277` は build のレビューが挙げていない 2 つ目の食い違い |
| `findings` 0 件かつ `challenge_ran: false` の run が Ready に届く | `auditDegraded` から `auditFindings.length > 0` を外した。T-009 で固定 (修正前に Red を確認済み) |
| `membershipDecided` の極性が参照実装と逆 | `challengeDegraded` に反転し、劣化時に verdict 不在を名指す一文を足す形にした。T-004 で固定 |

## Backlog candidates

- audit workflow 自体が stall して `null` を返す run では `auditDegraded` が false に倒れ、gate が Ready に届く。今回の受け入れ基準は `challenge_ran: false` を返す run だけを対象にしているためスコープ外にした

## Design Decisions

- 劣化の判定は script（assert.js/audit.js）が持ち、agent には判定させない
- .ja/側が canonical。英語側は同一コミットでミラーし、条件式と識別子は両側で同一にする (ADR-0073)
- gate rule は script が持つ。enhancer の散文から gate を復号する形に戻さない
- prompt の文言そのものを固定する test は置かず、劣化時に足す一文の有無で判定する

## How to Test

1. `node --test workflows/audit/tests/*.test.js workflows/assert/tests/*.test.js` を実行する
2. 52 件全てが pass する


---

_build workflow が自動生成した検証記録。深いレビューは含まない。開くかは下の status 行で判断する。_

Closes #305

<details>
<summary><code>verify tests=pass gates=pass</code> · <code>scope-deviations 0</code> · <code>missing-tests 0</code> · <code>conformance 2 (2 high)</code> · <code>structure 1</code></summary>

**実機確認 (merge 前に実施)**
- [x] `Ready (caveat)` の定義が「dynamic evidence が env 理由で欠けた場合」から広がることを、`workflows/assert.js` の gate rule のコメントに書き足す。caveat が何を意味するかは script のコメントにしか無く、読み手はそこで意味を取る (`2ea97cf5` で対応)

**前提 (veto 対象)**
- 依存する既存ファイルは ## Plan の Preconditions を参照。anchor は 2026-08-03 時点で ugrep -F により存在を確認済み
- Ready (caveat) の定義拡張が運用上どう受け取られるかは未確認 (tentative: 実装後に assert を 1 回走らせ、caveat が出る条件を目視する)

**Issue 適合性 (独立レビュー)**
- `[high] missing` gate rule のコメントは diff 前から変わらず「caveat applies only when dynamic evidence is missing for env reasons, and presumes zero issues」（.ja では「caveat は動的 evidence が env 起因などで欠けたときだけで、issues 0 が前提」）のままだが、コードは envFail と無関係な条件である `!auditDegraded` 経由でも caveat に入るようになった。これは文字通り検証可能な受け入れ基準であり、English 側・.ja 側どちらの diff でも修正されていない。
  `workflows/assert.js:571-574 and .ja/workflows/assert.js:563-565` · spec: `Ready (caveat)` の意味が「dynamic evidence が env 理由で欠けた場合」から広がったことが、gate rule のコメントから読める
- `[high] wrong` audit.js 自身の early-return パス（reviewer fan-out が 0 件の findings を返す場合）は issue がゲートの穴として名指す状況そのままに `challenge_ran: false` と `findings: []` を返すが、`auditDegraded` は `auditFindings.length > 0` でのみ立つため、この経路では `challenge_ran` の値に関わらず `auditDegraded` は false のままとなり、issues=0 のまま `Ready` に到達しうる。これは issue が指摘する「verified なしで Ready」の穴を正確に再現するものだが、T-004 から T-008 のいずれもこの 0 件ケースを検証しておらず、`makeAuditWorkflowStub` は `challenge_ran=true`/`false` どちらの分岐でも常に finding を 1 件返すため、この未検証のギャップは issue 自身の動機付け例と正確に一致する。
  `workflows/assert.js:545 (`const auditDegraded = auditFindings.length > 0 && ...`) and workflows/audit.js:560-575 (early return producing findings:[], challenge_ran:false)` · spec: gate 側の穴は findings が 0 件のときに出る。findings が残れば `issues.length > 0` で NotReady になるが、reviewer が何も出さなかった run では challenge が走らなくても issues 0 件で Ready になり、「検証されずに Ready」が成立する。

**参照モジュールからの構造逸脱**
- `[convention]` 参照実装の degradation 分岐は健全パスの文言はそのままに、常に失敗を名指す文言（"Both challenger and verifier stalled, so the Codex findings are unverified... surface this in the report"）を追加しており、assert.js の新しい `auditDegraded`/`auditFindingsIntro` 分岐（546 行目）も同じ形で finding の出所が unverified であることを読み手に伝える文言に置き換えている。これに対し audit.js の `membershipDecided` は逆で、健全パスでは既存の安心文言（"Membership is already decided... only merge and reorder"）を出す一方、degraded パス（`challengeRan` が false または `verdicts` が空配列）では何も出さず（`''`）、challenge が verdict を出せなかったことも membership が未確定であることも enhancer-integration に伝わらない。そのうえ audit.js:701-704 のコード内コメントは「assert.js の challengeStalled prompt 分岐を反映している」と主張するが、参照先は degraded 側で常に degradation を名指す文言を追加するのに対し、この bool 自体は degraded 側（`challengeStalled`, `auditDegraded`）でなく健全側の状態（`membershipDecided`）にちなんで命名されており、参照実装内の他の degradation フラグとは極性が逆である。
  `workflows/audit.js:701-723 (mirrored at .ja/workflows/audit.js), boolean `membershipDecided` and its use in the Integrate prompt at line 723` · ref: workflows/assert.js:540 `challengeStalled` and its use at line 556 (`${challengeStalled ? "Both challenger and verifier stalled, so the Codex findings are unverified..." : ""}`)

**異常 (Red 未確認)**
- U-003 (no-red): T-008 already passes because assert.js's gate rule (auditDegraded at workflows/assert.js:545, applied at :578-581) reads the nested audit.js's self-computed challenge_ran (workflows/audit.js:700, returned at :758) regardless of whether the nested run is a hand-written stub or a genuine nested run of audit.js, so no new implementation is needed for this unit。
  node --test workflows/assert/tests/assert.degradation.test.js -> 8/8 pass, including 'T-008 challenge を stub しない audit を入れ子で走らせた assert は、audit の challenge_ran=false を受け取って gate を Ready にしない'
  workflows/assert.js:503 nests workflow("audit", ...) and workflows/assert.js:545 computes `auditDegraded = auditFindings.length > 0 && !!audit && audit.challenge_ran === false` from that return value
  workflows/assert.js:576-581 gate rule: `else if (!envFail && !auditDegraded && ...) gate = "Ready"; else gate = "Ready (caveat)"` -- auditDegraded directly gates Ready vs Ready (caveat)
  workflows/audit.js:700 `const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));` and :758 returns it as `challenge_ran: challengeRan` -- computed by audit.js itself, not injected by the test
  Manual nested run of audit.js via runWorkflow with the test's exact auditAgentStub (challenge label returns undefined, security/integrate return 1 finding): result is `{ findings: [1 item], challenge_ran: false, verify_ran: true }`, confirming audit.js's own fail-open logic produces challenge_ran=false from genuine no-output on the challenge stage, not a hardcoded value
  Manual full run of assert.js with that same real-nested-audit stub reproduces the test scenario: gate resolves to a non-Ready value
  Control variant: changing only the nested audit.js 'challenge' label to return `{ verdicts: [...] }` (challenge_ran becomes true) while keeping everything else identical flips assert.js's result.gate from non-Ready to 'Ready', proving the seam (nested audit.js return -> assert.js auditDegraded -> gate) is genuinely connected and reactive, not a test-side shortcut

</details>

