### PR TITLE
fix(audit): fence marker を payload の 1 パス走査で決める

### DIFF
--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -55,22 +55,22 @@ const anchor = (p) =>
 // payload 内の同じ文字列から閉じられる。marker を予測されても、その文字列が payload に
 // ある限り marker 自体がずれるので早期クローズは成立しない。乱数源はサンドボックスに無く、
 // あっても resume をまたいで値が変わる。
-// base の中身に意味は無い。payload に現れにくければよく、衝突しても下の詰め物が引き受ける。
+// base の中身に意味は無い。payload に現れにくければよく、衝突しても詰め物が引き受ける。
+// 両方とも下の regex に埋め込むので、メタ文字を含まない文字から選ぶ。
 const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
+const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
 // marker を 1 文字ずつ伸ばすと、1 歩ごとに payload 全体を走査し直すことになる。その payload
 // こそ攻撃者が書く場所で、`base`、`base0`、`base00` と種を蒔けば歩数が payload の長さに
 // 応じて増える。最長連鎖より 1 つ長い marker が payload に出現しないのは、出現するなら
-// それが最長連鎖になるため。
+// それが最長連鎖になるため。base が 1 度も現れない payload では longest が -1 のままで、
+// 詰め物ゼロの base をそのまま返す。
 const fenceMarker = (value) => {
-  if (!value.includes(FENCE_BASE)) return FENCE_BASE;
-  let longestRun = 0;
-  for (let at = value.indexOf(FENCE_BASE); at !== -1; at = value.indexOf(FENCE_BASE, at + 1)) {
-    let run = 0;
-    for (let p = at + FENCE_BASE.length; value[p] === FENCE_PAD; p++) run++;
-    if (run > longestRun) longestRun = run;
+  let longest = -1;
+  for (const [hit] of value.matchAll(FENCE_RUNS)) {
+    longest = Math.max(longest, hit.length - FENCE_BASE.length);
   }
-  return FENCE_BASE + FENCE_PAD.repeat(longestRun + 1);
+  return FENCE_BASE + FENCE_PAD.repeat(longest + 1);
 };
 const fenced = (value) => {
   const marker = fenceMarker(value);

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -55,12 +55,22 @@ const anchor = (p) =>
 // payload 内の同じ文字列から閉じられる。marker を予測されても、その文字列が payload に
 // ある限り marker 自体がずれるので早期クローズは成立しない。乱数源はサンドボックスに無く、
 // あっても resume をまたいで値が変わる。
-// base の中身に意味は無い。payload に現れにくければよく、衝突しても伸長が引き受ける。
+// base の中身に意味は無い。payload に現れにくければよく、衝突しても下の詰め物が引き受ける。
 const FENCE_BASE = "e5f9a2";
+const FENCE_PAD = "0";
+// marker を 1 文字ずつ伸ばすと、1 歩ごとに payload 全体を走査し直すことになる。その payload
+// こそ攻撃者が書く場所で、`base`、`base0`、`base00` と種を蒔けば歩数が payload の長さに
+// 応じて増える。代わりに、payload 内で base に続く詰め物の最長連鎖を数え、一度で越える。
+// その連鎖より 1 つ長い marker は payload に出現しない。出現するならそれが最長連鎖になる。
 const fenceMarker = (value) => {
-  let marker = FENCE_BASE;
-  while (value.includes(marker)) marker += "0";
-  return marker;
+  if (!value.includes(FENCE_BASE)) return FENCE_BASE;
+  let longestRun = 0;
+  for (let at = value.indexOf(FENCE_BASE); at !== -1; at = value.indexOf(FENCE_BASE, at + 1)) {
+    let run = 0;
+    for (let p = at + FENCE_BASE.length; value[p] === FENCE_PAD; p++) run++;
+    if (run > longestRun) longestRun = run;
+  }
+  return FENCE_BASE + FENCE_PAD.repeat(longestRun + 1);
 };
 const fenced = (value) => {
   const marker = fenceMarker(value);

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -52,9 +52,8 @@ const anchor = (p) =>
 // finding の summary は LLM が生成した自由文で、次段の prompt へそのまま埋め込まれる。
 // そこに紛れ込んだ指示が命令として読まれてはならない。fenced が build.js の fencedBody と
 // 違うのはこの点にある。固定 marker は、JSON.stringify がハイフンをエスケープしないため
-// payload 内の同じ文字列から閉じられる。marker を予測されても、その文字列が payload に
-// ある限り marker 自体がずれるので早期クローズは成立しない。乱数源はサンドボックスに無く、
-// あっても resume をまたいで値が変わる。
+// payload 内の同じ文字列から閉じられる。乱数源はサンドボックスに無く、あっても resume を
+// またいで値が変わる。
 // base の中身に意味は無い。payload に現れにくければよい。base と詰め物はどちらも下の
 // regex に埋め込むので、メタ文字を含まない文字から選ぶ。
 const FENCE_BASE = "e5f9a2";
@@ -63,8 +62,8 @@ const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
 // marker を 1 文字ずつ伸ばすと、1 歩ごとに payload 全体を走査し直すことになる。その payload
 // こそ攻撃者が書く場所で、`base`、`base0`、`base00` と種を蒔けば歩数が payload の長さに
 // 応じて増える。最長連鎖より 1 つ長い marker が payload に出現しないのは、出現するなら
-// それが最長連鎖になるため。longest の初期値が -1 なのは、衝突しない payload を別の分岐に
-// せずに済ませるため。
+// それが最長連鎖になるため。marker を予測されても早期クローズが成立しないのも同じ理由に
+// よる。longest の初期値が -1 なのは、衝突しない payload を別の分岐にせずに済ませるため。
 const fenceMarker = (value) => {
   let longest = -1;
   for (const [hit] of value.matchAll(FENCE_RUNS)) {

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -60,8 +60,8 @@ const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
 // marker を 1 文字ずつ伸ばすと、1 歩ごとに payload 全体を走査し直すことになる。その payload
 // こそ攻撃者が書く場所で、`base`、`base0`、`base00` と種を蒔けば歩数が payload の長さに
-// 応じて増える。代わりに、payload 内で base に続く詰め物の最長連鎖を数え、一度で越える。
-// その連鎖より 1 つ長い marker は payload に出現しない。出現するならそれが最長連鎖になる。
+// 応じて増える。最長連鎖より 1 つ長い marker が payload に出現しないのは、出現するなら
+// それが最長連鎖になるため。
 const fenceMarker = (value) => {
   if (!value.includes(FENCE_BASE)) return FENCE_BASE;
   let longestRun = 0;

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -55,16 +55,16 @@ const anchor = (p) =>
 // payload 内の同じ文字列から閉じられる。marker を予測されても、その文字列が payload に
 // ある限り marker 自体がずれるので早期クローズは成立しない。乱数源はサンドボックスに無く、
 // あっても resume をまたいで値が変わる。
-// base の中身に意味は無い。payload に現れにくければよく、衝突しても詰め物が引き受ける。
-// 両方とも下の regex に埋め込むので、メタ文字を含まない文字から選ぶ。
+// base の中身に意味は無い。payload に現れにくければよい。base と詰め物はどちらも下の
+// regex に埋め込むので、メタ文字を含まない文字から選ぶ。
 const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
 const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
 // marker を 1 文字ずつ伸ばすと、1 歩ごとに payload 全体を走査し直すことになる。その payload
 // こそ攻撃者が書く場所で、`base`、`base0`、`base00` と種を蒔けば歩数が payload の長さに
 // 応じて増える。最長連鎖より 1 つ長い marker が payload に出現しないのは、出現するなら
-// それが最長連鎖になるため。base が 1 度も現れない payload では longest が -1 のままで、
-// 詰め物ゼロの base をそのまま返す。
+// それが最長連鎖になるため。longest の初期値が -1 なのは、衝突しない payload を別の分岐に
+// せずに済ませるため。
 const fenceMarker = (value) => {
   let longest = -1;
   for (const [hit] of value.matchAll(FENCE_RUNS)) {

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -63,10 +63,8 @@ const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
 // Growing the marker one character at a time re-scans the payload on every step, and
 // the payload is exactly where an attacker writes: seeding `base`, `base0`, `base00`, ...
-// makes the step count rise with the payload's own length. Instead, count the longest
-// run of padding that already follows the base anywhere in the payload, and clear it in
-// one go. A marker padded one longer than that run cannot occur, because a longer run
-// would have been the longest.
+// makes the step count rise with the payload's own length. A marker padded one longer
+// than the longest run cannot occur, because a longer run would have been the longest.
 const fenceMarker = (value) => {
   if (!value.includes(FENCE_BASE)) return FENCE_BASE;
   let longestRun = 0;

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -57,9 +57,9 @@ const anchor = (p) =>
 // the marker does not help either, because a marker present in the payload is shifted
 // away from what was predicted. No random source exists in the sandbox, and one would
 // change value across a resume even if it did.
-// The base's contents carry no meaning. It only has to be unlikely in a payload, and the
-// padding takes over whenever it does collide. Both go into the regex below, so pick them
-// from characters that carry no regex meaning.
+// The base's contents carry no meaning. It only has to be unlikely in a payload. Both the
+// base and the padding go into the regex below, so pick them from characters that carry
+// no regex meaning.
 const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
 const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
@@ -67,7 +67,7 @@ const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
 // the payload is exactly where an attacker writes: seeding `base`, `base0`, `base00`, ...
 // makes the step count rise with the payload's own length. A marker padded one longer
 // than the longest run cannot occur, because a longer run would have been the longest.
-// A payload without a single base leaves longest at -1, returning the bare base.
+// longest starts at -1 so a payload that never collides needs no branch of its own.
 const fenceMarker = (value) => {
   let longest = -1;
   for (const [hit] of value.matchAll(FENCE_RUNS)) {

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -53,10 +53,8 @@ const anchor = (p) =>
 // A finding's summary is LLM free text folded verbatim into the next stage's prompt,
 // so an injected directive hiding in it must not read as an instruction. This is why
 // fenced differs from build.js's fencedBody: a fixed marker can be closed early by a
-// payload string equal to it, since JSON.stringify does not escape hyphens. Predicting
-// the marker does not help either, because a marker present in the payload is shifted
-// away from what was predicted. No random source exists in the sandbox, and one would
-// change value across a resume even if it did.
+// payload string equal to it, since JSON.stringify does not escape hyphens. No random
+// source exists in the sandbox, and one would change value across a resume even if it did.
 // The base's contents carry no meaning. It only has to be unlikely in a payload. Both the
 // base and the padding go into the regex below, so pick them from characters that carry
 // no regex meaning.
@@ -66,7 +64,8 @@ const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
 // Growing the marker one character at a time re-scans the payload on every step, and
 // the payload is exactly where an attacker writes: seeding `base`, `base0`, `base00`, ...
 // makes the step count rise with the payload's own length. A marker padded one longer
-// than the longest run cannot occur, because a longer run would have been the longest.
+// than the longest run cannot occur, because a longer run would have been the longest,
+// so predicting the marker does not let an attacker close the fence early either.
 // longest starts at -1 so a payload that never collides needs no branch of its own.
 const fenceMarker = (value) => {
   let longest = -1;

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -58,12 +58,24 @@ const anchor = (p) =>
 // away from what was predicted. No random source exists in the sandbox, and one would
 // change value across a resume even if it did.
 // The base's contents carry no meaning. It only has to be unlikely in a payload, and
-// growth takes over whenever it does collide.
+// the padding below takes over whenever it does collide.
 const FENCE_BASE = "e5f9a2";
+const FENCE_PAD = "0";
+// Growing the marker one character at a time re-scans the payload on every step, and
+// the payload is exactly where an attacker writes: seeding `base`, `base0`, `base00`, ...
+// makes the step count rise with the payload's own length. Instead, count the longest
+// run of padding that already follows the base anywhere in the payload, and clear it in
+// one go. A marker padded one longer than that run cannot occur, because a longer run
+// would have been the longest.
 const fenceMarker = (value) => {
-  let marker = FENCE_BASE;
-  while (value.includes(marker)) marker += "0";
-  return marker;
+  if (!value.includes(FENCE_BASE)) return FENCE_BASE;
+  let longestRun = 0;
+  for (let at = value.indexOf(FENCE_BASE); at !== -1; at = value.indexOf(FENCE_BASE, at + 1)) {
+    let run = 0;
+    for (let p = at + FENCE_BASE.length; value[p] === FENCE_PAD; p++) run++;
+    if (run > longestRun) longestRun = run;
+  }
+  return FENCE_BASE + FENCE_PAD.repeat(longestRun + 1);
 };
 const fenced = (value) => {
   const marker = fenceMarker(value);

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -57,23 +57,23 @@ const anchor = (p) =>
 // the marker does not help either, because a marker present in the payload is shifted
 // away from what was predicted. No random source exists in the sandbox, and one would
 // change value across a resume even if it did.
-// The base's contents carry no meaning. It only has to be unlikely in a payload, and
-// the padding below takes over whenever it does collide.
+// The base's contents carry no meaning. It only has to be unlikely in a payload, and the
+// padding takes over whenever it does collide. Both go into the regex below, so pick them
+// from characters that carry no regex meaning.
 const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
+const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
 // Growing the marker one character at a time re-scans the payload on every step, and
 // the payload is exactly where an attacker writes: seeding `base`, `base0`, `base00`, ...
 // makes the step count rise with the payload's own length. A marker padded one longer
 // than the longest run cannot occur, because a longer run would have been the longest.
+// A payload without a single base leaves longest at -1, returning the bare base.
 const fenceMarker = (value) => {
-  if (!value.includes(FENCE_BASE)) return FENCE_BASE;
-  let longestRun = 0;
-  for (let at = value.indexOf(FENCE_BASE); at !== -1; at = value.indexOf(FENCE_BASE, at + 1)) {
-    let run = 0;
-    for (let p = at + FENCE_BASE.length; value[p] === FENCE_PAD; p++) run++;
-    if (run > longestRun) longestRun = run;
+  let longest = -1;
+  for (const [hit] of value.matchAll(FENCE_RUNS)) {
+    longest = Math.max(longest, hit.length - FENCE_BASE.length);
   }
-  return FENCE_BASE + FENCE_PAD.repeat(longestRun + 1);
+  return FENCE_BASE + FENCE_PAD.repeat(longest + 1);
 };
 const fenced = (value) => {
   const marker = fenceMarker(value);

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -324,8 +324,8 @@ test("T-011 base marker とその詰め物違いを並べて仕込んでも、ma
   const baseline = await run({});
   const baseMarker = extractFenced(callOf(baseline.calls, "snapshot").prompt).nonce;
 
-  // 1 文字ずつ伸ばす実装だと、この 3 つが順に marker を押し上げて走査が繰り返される。
-  // 最長連鎖を数える実装では 1 回の走査で決まり、歩数は仕込んだ数に依らない。
+  // 固めるのは決まった marker であって走査の歩数ではない。1 文字ずつ伸ばす実装も同じ
+  // marker に行き着くため、これは書き換えに対する回帰ガードとして働く。
   const { calls } = await run({
     security: {
       findings: [

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -320,6 +320,37 @@ test("T-001 base marker と同じ文字列を summary に仕込むと marker が
   );
 });
 
+test("T-011 base marker とその詰め物違いを並べて仕込んでも、marker は最長連鎖を 1 つ越えた長さで payload に出現しない", async () => {
+  const baseline = await run({});
+  const baseMarker = extractFenced(callOf(baseline.calls, "snapshot").prompt).nonce;
+
+  // 1 文字ずつ伸ばす実装だと、この 3 つが順に marker を押し上げて走査が繰り返される。
+  // 最長連鎖を数える実装では 1 回の走査で決まり、歩数は仕込んだ数に依らない。
+  const { calls } = await run({
+    security: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: `a ${baseMarker} b ${baseMarker}0 c ${baseMarker}00 d`,
+        },
+      ],
+    },
+  });
+  const fenced = extractFenced(callOf(calls, "snapshot").prompt);
+  assert.ok(fenced, "詰め物違いを並べた payload でも BEGIN/END marker で正しく囲まれる");
+  assert.equal(
+    fenced.nonce,
+    `${baseMarker}000`,
+    "payload 内の最長連鎖が 2 なので marker はそれを 1 つ越えた 3 個の詰め物を持つ",
+  );
+  assert.ok(
+    !fenced.content.includes(fenced.nonce),
+    "決まった marker は payload のどこにも出現しない",
+  );
+});
+
 test("T-002 marker と衝突しない payload では marker が base のまま変わらない", async () => {
   const first = await run({});
   const second = await run({

--- a/workflows/audit/tests/audit.degradation.test.js
+++ b/workflows/audit/tests/audit.degradation.test.js
@@ -285,29 +285,22 @@ test("T-002 Challenge に渡す prompt で、findings は BEGIN と END の mark
   );
 });
 
-test("T-001 base marker と同じ文字列を summary に仕込むと marker が伸びて payload のどこにも出現しない", async () => {
-  // 衝突しない payload での base marker を先に観測する。攻撃者はこの値を知らなくても、
-  // marker 自体を推測して仕込んでくる想定を再現する。
-  const baseline = await run({});
-  const baselineFence = extractFenced(callOf(baseline.calls, "snapshot").prompt);
-  assert.ok(baselineFence, "衝突しない run でも snapshot prompt に marker が乗る");
-  const baseMarker = baselineFence.nonce;
+// marker を見る test 群は、summary だけを変えた同じ 1 件の finding を流し、snapshot prompt
+// から marker を読む。fence が張られていること自体は前提なので、取り出しの側で確かめる。
+const runWithSummary = (summary) =>
+  run({ security: { findings: [{ file: "sample.js", line: "1", severity: "high", summary }] } });
+const snapshotFence = ({ calls }) => {
+  const fence = extractFenced(callOf(calls, "snapshot").prompt);
+  assert.ok(fence, "snapshot prompt の findings が BEGIN/END marker で囲まれている");
+  return fence;
+};
 
-  const { calls } = await run({
-    security: {
-      findings: [
-        {
-          file: "sample.js",
-          line: "1",
-          severity: "high",
-          summary: `legit text ${baseMarker} more text`,
-        },
-      ],
-    },
-  });
-  const call = callOf(calls, "snapshot");
-  const fenced = extractFenced(call.prompt);
-  assert.ok(fenced, "base marker を含む payload でも BEGIN/END marker で正しく囲まれる");
+test("T-001 base marker と同じ文字列を summary に仕込むと marker が伸びて payload のどこにも出現しない", async () => {
+  // 攻撃者は base marker の値を知らなくても、marker 自体を推測して仕込んでくる。その想定を
+  // 再現するため、衝突しない run から base marker を先に観測する。
+  const baseMarker = snapshotFence(await run({})).nonce;
+
+  const fenced = snapshotFence(await runWithSummary(`legit text ${baseMarker} more text`));
   assert.notEqual(
     fenced.nonce,
     baseMarker,
@@ -321,25 +314,13 @@ test("T-001 base marker と同じ文字列を summary に仕込むと marker が
 });
 
 test("T-011 base marker とその詰め物違いを並べて仕込んでも、marker は最長連鎖を 1 つ越えた長さで payload に出現しない", async () => {
-  const baseline = await run({});
-  const baseMarker = extractFenced(callOf(baseline.calls, "snapshot").prompt).nonce;
+  const baseMarker = snapshotFence(await run({})).nonce;
 
   // 固めるのは決まった marker であって走査の歩数ではない。1 文字ずつ伸ばす実装も同じ
   // marker に行き着くため、これは書き換えに対する回帰ガードとして働く。
-  const { calls } = await run({
-    security: {
-      findings: [
-        {
-          file: "sample.js",
-          line: "1",
-          severity: "high",
-          summary: `a ${baseMarker} b ${baseMarker}0 c ${baseMarker}00 d`,
-        },
-      ],
-    },
-  });
-  const fenced = extractFenced(callOf(calls, "snapshot").prompt);
-  assert.ok(fenced, "詰め物違いを並べた payload でも BEGIN/END marker で正しく囲まれる");
+  const fenced = snapshotFence(
+    await runWithSummary(`a ${baseMarker} b ${baseMarker}0 c ${baseMarker}00 d`),
+  );
   assert.equal(
     fenced.nonce,
     `${baseMarker}000`,
@@ -352,16 +333,8 @@ test("T-011 base marker とその詰め物違いを並べて仕込んでも、ma
 });
 
 test("T-002 marker と衝突しない payload では marker が base のまま変わらない", async () => {
-  const first = await run({});
-  const second = await run({
-    security: {
-      findings: [
-        { file: "sample.js", line: "1", severity: "high", summary: "unrelated summary text" },
-      ],
-    },
-  });
-  const firstNonce = extractFenced(callOf(first.calls, "snapshot").prompt).nonce;
-  const secondNonce = extractFenced(callOf(second.calls, "snapshot").prompt).nonce;
+  const firstNonce = snapshotFence(await run({})).nonce;
+  const secondNonce = snapshotFence(await runWithSummary("unrelated summary text")).nonce;
   assert.equal(
     secondNonce,
     firstNonce,


### PR DESCRIPTION
## What & Why

`fenceMarker` は marker を 1 文字ずつ伸ばしながら、1 歩ごとに payload 全体を走査し直していた。その payload は攻撃者がテキストを書き込む場所そのもので、`e5f9a2` と `e5f9a20` と `e5f9a200` を並べて仕込めば歩数が payload の長さに応じて増える。fence が守ろうとしている境界に、上限の無いループが乗っていた。

marker の決め方を、payload 内で base に続く詰め物の最長連鎖を 1 回の走査で数え、それを 1 つ越える長さを一度に付ける形に変えた。その連鎖より 1 つ長い marker は payload に出現しない。出現するならそれが最長連鎖になるため。

/audit の実行 (run wf_0c0029c3-620) が high として報告し、5 reviewer が同じ根本原因に収束した。

## Changes

- `workflows/audit.js` と `.ja/workflows/audit.js` の `fenceMarker` を 1 パス方式にした。`FENCE_PAD` を定数として切り出し、marker の文字クラスは `workflows/audit/tests/_fixtures.js` の抽出 regex に収まる範囲に保った
- `workflows/audit/tests/audit.degradation.test.js` に T-011 を追加した。base と詰め物違いを 3 つ並べた payload で、marker が最長連鎖を 1 つ越えた長さになり payload に出現しないことを見る

## Review focus

- 最長連鎖の数え方。`value.indexOf(FENCE_BASE, at + 1)` で前回位置から進むため、走査は payload 長に線形に収まる
- T-011 が固めるのは結果であって歩数ではない。旧実装も同じ marker に到達するため、このテストは今後の書き換えに対する回帰ガードとして働き、走査が安くなったことの証拠にはならない

## Testing

`node --test 'workflows/**/tests/*.test.js'` が 174 件すべて緑。

Closes #317 の Manual verification
