### PR TITLE
fix(workflows): rehome を本番の JSON 化に合わせる

### DIFF
--- a/workflows/_lib/run-workflow.js
+++ b/workflows/_lib/run-workflow.js
@@ -41,12 +41,10 @@ const toHostRealmError = (err) => {
 // Plain objects and arrays built inside the vm context carry that context's intrinsics
 // (its own Array.prototype, Object.prototype, ...), so a host-side assert.deepStrictEqual
 // sees them as structurally equal but not reference-equal to a host literal and fails.
-// Rebuilding them with host intrinsics is what lets a test assert against a plain literal.
 // Map, Set, Date, RegExp and Error are deliberately not special-cased. Production turns a
-// workflow's return value into JSON, where each of those becomes {} (measured). Copying
-// them by type would keep, in tests alone, what the real run drops -- the same
-// tests-pass-production-fails split this context exists to close. Falling through to the
-// own-keys copy reproduces production's {}.
+// workflow's return value into JSON, where each of those arrives as {} (measured). Copying
+// them by type would keep in tests alone what the real run drops, which is the same
+// tests-pass-production-fails split this context exists to close.
 const rehome = (value, seen = new Map()) => {
   if (value === null || typeof value !== "object") return value;
   if (seen.has(value)) return seen.get(value);

--- a/workflows/_lib/run-workflow.js
+++ b/workflows/_lib/run-workflow.js
@@ -38,36 +38,23 @@ const toHostRealmError = (err) => {
   return err;
 };
 
-// Plain objects/arrays/Dates/etc. built inside the vm context carry that context's
-// intrinsics (its own Array.prototype, Object.prototype, ...), so a host-side
-// assert.deepStrictEqual sees them as structurally equal but not reference-equal to a
-// host literal and fails. Rebuild every value crossing the context/host boundary with
-// host intrinsics.
+// Plain objects and arrays built inside the vm context carry that context's intrinsics
+// (its own Array.prototype, Object.prototype, ...), so a host-side assert.deepStrictEqual
+// sees them as structurally equal but not reference-equal to a host literal and fails.
+// Rebuilding them with host intrinsics is what lets a test assert against a plain literal.
+// Map, Set, Date, RegExp and Error are deliberately not special-cased. Production turns a
+// workflow's return value into JSON, where each of those becomes {} (measured). Copying
+// them by type would keep, in tests alone, what the real run drops -- the same
+// tests-pass-production-fails split this context exists to close. Falling through to the
+// own-keys copy reproduces production's {}.
 const rehome = (value, seen = new Map()) => {
   if (value === null || typeof value !== "object") return value;
   if (seen.has(value)) return seen.get(value);
-
-  const tag = Object.prototype.toString.call(value);
-  if (tag === "[object Error]") return toHostRealmError(value);
-  if (tag === "[object Date]") return new Date(value.getTime());
-  if (tag === "[object RegExp]") return new RegExp(value.source, value.flags);
 
   if (Array.isArray(value)) {
     const out = [];
     seen.set(value, out);
     for (const item of value) out.push(rehome(item, seen));
-    return out;
-  }
-  if (tag === "[object Map]") {
-    const out = new Map();
-    seen.set(value, out);
-    for (const [k, v] of value) out.set(rehome(k, seen), rehome(v, seen));
-    return out;
-  }
-  if (tag === "[object Set]") {
-    const out = new Set();
-    seen.set(value, out);
-    for (const v of value) out.add(rehome(v, seen));
     return out;
   }
   const out = {};

--- a/workflows/_lib/tests/run-workflow.test.js
+++ b/workflows/_lib/tests/run-workflow.test.js
@@ -89,8 +89,6 @@ test("T-008 返り値に置いた Map と Set と Date と RegExp は、本番�
     "return { map: new Map([['k', 'v']]), set: new Set([1]), date: new Date(0), re: /x/g, plain: { a: 1 }, arr: [1, 2] };",
     async (path) => {
       const { result } = await runWorkflow(path, {});
-      // 本番は返り値を JSON にするため、この 4 つはどれも {} で届く。harness が型どおりに
-      // 複製すると、テストだけが本番より多くの情報を見ることになる。
       assert.deepEqual(result.map, {}, "Map は本番と同じく空オブジェクトで届く");
       assert.deepEqual(result.set, {}, "Set は本番と同じく空オブジェクトで届く");
       assert.deepEqual(result.date, {}, "Date は本番と同じく空オブジェクトで届く");

--- a/workflows/_lib/tests/run-workflow.test.js
+++ b/workflows/_lib/tests/run-workflow.test.js
@@ -83,3 +83,20 @@ test("T-007 引数つき new Date と Math.floor は落ちずに値を返す", a
     },
   );
 });
+
+test("T-008 返り値に置いた Map と Set と Date と RegExp は、本番の JSON 化と同じく空オブジェクトになる", async () => {
+  await withScript(
+    "return { map: new Map([['k', 'v']]), set: new Set([1]), date: new Date(0), re: /x/g, plain: { a: 1 }, arr: [1, 2] };",
+    async (path) => {
+      const { result } = await runWorkflow(path, {});
+      // 本番は返り値を JSON にするため、この 4 つはどれも {} で届く。harness が型どおりに
+      // 複製すると、テストだけが本番より多くの情報を見ることになる。
+      assert.deepEqual(result.map, {}, "Map は本番と同じく空オブジェクトで届く");
+      assert.deepEqual(result.set, {}, "Set は本番と同じく空オブジェクトで届く");
+      assert.deepEqual(result.date, {}, "Date は本番と同じく空オブジェクトで届く");
+      assert.deepEqual(result.re, {}, "RegExp は本番と同じく空オブジェクトで届く");
+      assert.deepEqual(result.plain, { a: 1 }, "plain object は中身を保ったまま届く");
+      assert.deepEqual(result.arr, [1, 2], "array は中身を保ったまま届く");
+    },
+  );
+});


### PR DESCRIPTION
## What & Why

`rehome` は Map と Set と Date と RegExp と Error を型ごとに分岐し、vm 境界をそれぞれの型のまま越えさせていた。

本番は workflow の返り値を JSON にする。最小 workflow で 5 つとも返して実測したところ、すべて `{}` で届いた。保たれるのは plain object と array だけである。

つまり harness は、本番が捨てる情報をテストの中だけで保っていた。#317 で塞いだ「テストが通り本番が落ちる」食い違いの、向きが逆の同型である。plain object の複製へ落ちれば、そのまま本番の `{}` を再現する。

5 分岐はいずれも既存 173 テストで 1 度も通らなかった (一時的に計数を仕込んで全テストで計測)。

## Changes

- `workflows/_lib/run-workflow.js` の `rehome` から型別の 5 分岐を削り、plain object と array と primitive の経路だけを残した
- `workflows/_lib/tests/run-workflow.test.js` に T-008 を追加した。返り値に置いた Map と Set と Date と RegExp が `{}` で届き、plain object と array は中身を保つことを見る

## Review focus

- `toHostRealmError` は残した。throw されたエラーは JSON を通らないため、catch 節がホスト realm の型を作り直す必要がある
- 削除後も Map を返す script は壊れない。`Object.keys(map)` が空を返し、本番と同じ `{}` になる

## Testing

`node --test 'workflows/**/tests/*.test.js'` が 174 件すべて緑。

## 関連

- `toHostRealmError` が `errors` と `cause` と独自プロパティを落とす件は #326
