### PR TITLE
refactor(hooks): drop unused tool_name extraction in issue-body-template

### DIFF
--- a/.ja/skills/issue/SKILL.md
+++ b/.ja/skills/issue/SKILL.md
@@ -104,7 +104,7 @@ issue の Why を、本文起草の前に確立する。1 メッセージにつ�
 ## Phase 4: 起票
 
 1. Issue プレビューを提示する。インライン仮マークがあれば仮ブロックに集約する。新規内容は足さず本文が持つものを写し、0 件なら省略する。最後に AskUserQuestion で `Create this issue?` と確認する。`## Plan` 節が無く build workflow に渡す規模なら、選択肢に「起票を保留して `/think` で plan を作る」を足す
-2. 本文を一時ファイルに書き出す。`${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py ${CLAUDE_SKILL_DIR}/templates/<type>.md <title> <body-file>` を実行し、エラーは後述の Error Handling に従って対処する。exit 0 になったらラベルを付けて `gh issue create --title "<title>" --body-file <path>` で起票する。出力から Issue URL を取得する
+2. 本文を一時ファイルに書き出す。`${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py <Template source で選んだ骨格ファイル> <title> <body-file>` を実行し、エラーは後述の Error Handling に従って対処する。exit 0 になったらラベルを付けて `gh issue create --title "<title>" --body-file <path>` で起票する。出力から Issue URL を取得する
 3. Phase 1 で分割を承認していれば、起票した epic 番号を添えて `/slice` の実行を提案する。自動では起動しない
 4. 分割しない issue には次の手を提案する。起票済み issue の渡し先は影響範囲で決め、1〜3 ファイルに収まる修正なら `/fix <番号>`、4 ファイル以上または新機能なら build workflow に番号を渡す。build workflow に渡す issue が Plan 節を持たないなら、`/think` で plan を作り `/issue <番号>` で転記してから渡し、渡す前の検分には `/qualify` を使う。いずれも自動では起動しない
 
@@ -120,3 +120,4 @@ issue の Why を、本文起草の前に確立する。1 メッセージにつ�
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------- |
 | `missing_section:<name>` | テンプレート骨格から落ちた見出しを戻し、再検証する                                                                   |
 | `type_mismatch:*`        | タイトルの角括弧の型を正とし、それに合うテンプレートを選び直して本文を書き直す。タイトルの書き換えによる解消はしない |
+| `unknown_section:<name>` | 骨格に無い見出しを外すか、骨格側の見出しに寄せる。`.yml` を骨格にした起票では出ない                                 |

--- a/.ja/skills/issue/SKILL.md
+++ b/.ja/skills/issue/SKILL.md
@@ -62,7 +62,9 @@ issue の Why を、本文起草の前に確立する。1 メッセージにつ�
 
 ### テンプレート選択
 
-`gh api "repos/{owner}/{repo}/contents/.github/ISSUE_TEMPLATE" --jq '.[].name'` で `.md` を列挙する。ファイル名や `name` が種別を含む GitHub テンプレートがあれば、その本文を読んで先頭 frontmatter の `name`/`about`/`labels`/`title` を外し骨格にする。無ければ、skill ディレクトリ直下の `templates/<type>.md` を使う。
+`gh api "repos/{owner}/{repo}/contents/.github/ISSUE_TEMPLATE" --jq '.[].name'` で列挙し、種別に対応するものを次の順で骨格に取る。`<type>.yml` (issue form) > `<type>.md` > skill ディレクトリ直下の `templates/<type>.md`。リポジトリ自身のテンプレートを先に取るのは、Web UI からの起票がそれを使うため。CLI 起票がそれを無視すると、同じ種別の issue が 1 つの tracker に 2 通りの形で並ぶ。
+
+`.yml` は各 `body` 要素の `attributes.label` が骨格の節名になり、`validations.required` が真のものだけが必須になる。form は Web UI が埋めさせる最小要件なので、CLI 起票がそこへ節を足すのは逸脱ではない。`.md` は先頭 frontmatter の `name`/`about`/`labels`/`title` を外して骨格にする。
 
 ### 確信度マーキング
 

--- a/.ja/skills/issue/SKILL.md
+++ b/.ja/skills/issue/SKILL.md
@@ -102,10 +102,19 @@ issue の Why を、本文起草の前に確立する。1 メッセージにつ�
 ## Phase 4: 起票
 
 1. Issue プレビューを提示する。インライン仮マークがあれば仮ブロックに集約する。新規内容は足さず本文が持つものを写し、0 件なら省略する。最後に AskUserQuestion で `Create this issue?` と確認する。`## Plan` 節が無く build workflow に渡す規模なら、選択肢に「起票を保留して `/think` で plan を作る」を足す
-2. 本文を一時ファイルに書き出し、ラベルを付けて `gh issue create --title "<title>" --body-file <path>` で起票する。出力から Issue URL を取得する
+2. 本文を一時ファイルに書き出す。`${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py ${CLAUDE_SKILL_DIR}/templates/<type>.md <title> <body-file>` を実行し、エラーは後述の Error Handling に従って対処する。exit 0 になったらラベルを付けて `gh issue create --title "<title>" --body-file <path>` で起票する。出力から Issue URL を取得する
 3. Phase 1 で分割を承認していれば、起票した epic 番号を添えて `/slice` の実行を提案する。自動では起動しない
 4. 分割しない issue には次の手を提案する。起票済み issue の渡し先は影響範囲で決め、1〜3 ファイルに収まる修正なら `/fix <番号>`、4 ファイル以上または新機能なら build workflow に番号を渡す。build workflow に渡す issue が Plan 節を持たないなら、`/think` で plan を作り `/issue <番号>` で転記してから渡し、渡す前の検分には `/qualify` を使う。いずれも自動では起動しない
 
 ### ラベル
 
 `priority:*` は必須とし、影響度に応じて critical、high、medium、low のいずれかを付ける。それ以外のラベルは、リポジトリの慣例に合わせる。
+
+## Error Handling
+
+`${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py` は `{errors, warnings, checks}` を JSON で標準出力に返し、`errors` が 1 件以上あれば exit 1 で終わる。既存 issue へ plan を転記する `/issue <番号>` の経路は Phase 4 の起票を `gh issue edit` に置き換えるため、この検査は対象外。エラーは下表に従って対処する。
+
+| エラー                   | 対処                                                                                                                 |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `missing_section:<name>` | テンプレート骨格から落ちた見出しを戻し、再検証する                                                                   |
+| `type_mismatch:*`        | タイトルの角括弧の型を正とし、それに合うテンプレートを選び直して本文を書き直す。タイトルの書き換えによる解消はしない |

--- a/.ja/skills/issue/scripts/validate-issue-body.py
+++ b/.ja/skills/issue/scripts/validate-issue-body.py
@@ -14,6 +14,10 @@ TYPE_PREFIX = re.compile(r"^\[([A-Za-z]+)\]")
 HEADING = re.compile(r"^## (.+?)\s*$", flags=re.MULTILINE)
 CODE_BLOCK = re.compile(r"```(?:markdown)?\n(.*?)```", flags=re.DOTALL)
 OPTIONAL_SUFFIX = re.compile(r"\s*\((?:optional|任意)\)\s*$")
+# 骨格に無くても errors にしない節。/think の plan を転記した issue はこの 2 節を必ず持ち、
+# skills/issue/SKILL.md の Phase 3 がそれを指示している。緩和はこの 2 つに限り、
+# 他の骨格外見出しは unknown_section として残す。
+ALLOWED_EXTRA = frozenset({"Plan", "Backlog candidates"})
 
 
 def skeleton_sections(template_text):
@@ -71,6 +75,13 @@ def main():
             results["checks"].append(f"section:{name}=ok")
         else:
             results["errors"].append(f"missing_section:{name}")
+
+    known = {name for name, _ in skeleton_sections(template_text)} | ALLOWED_EXTRA
+    extra = sorted(present - known)
+    for name in extra:
+        results["errors"].append(f"unknown_section:{name}")
+    if not extra:
+        results["checks"].append("unknown_section=none")
 
     print(json.dumps(results, indent=2))
     sys.exit(1 if results["errors"] else 0)

--- a/.ja/skills/issue/scripts/validate-issue-body.py
+++ b/.ja/skills/issue/scripts/validate-issue-body.py
@@ -14,20 +14,19 @@ TYPE_PREFIX = re.compile(r"^\[([A-Za-z]+)\]")
 HEADING = re.compile(r"^## (.+?)\s*$", flags=re.MULTILINE)
 CODE_BLOCK = re.compile(r"```(?:markdown)?\n(.*?)```", flags=re.DOTALL)
 OPTIONAL_SUFFIX = re.compile(r"\s*\((?:optional|任意)\)\s*$")
+FORM_SUFFIXES = (".yml", ".yaml")
 # 骨格に無くても errors にしない節。/think の plan を転記した issue はこの 2 節を必ず持ち、
-# skills/issue/SKILL.md の Phase 3 がそれを指示している。緩和はこの 2 つに限り、
-# 他の骨格外見出しは unknown_section として残す。
+# skills/issue/SKILL.md の Phase 3 がそれを指示している。
 ALLOWED_EXTRA = frozenset({"Plan", "Backlog candidates"})
 
 
 def skeleton_sections(template_text):
     """"## Template" 配下、最初のコードブロックから読む (name, optional) のペア。
 
-    section_body の stop 境界 ("^#{1,level} " の次の一致) はここでは使えない。
-    骨格そのものが "## " 見出しだらけの markdown をコードフェンスの中に持つため、
-    その境界だと "## Guidelines" ではなくフェンス内の最初の見出しで止まってしまう。
-    コードフェンスは自己完結して閉じるので、ここでは見出しの開始位置だけを特定し、
-    その後ろで CODE_BLOCK に最初のフェンスを探させる。
+    次の見出しまでを節の範囲とする読み方はここでは取れない。骨格そのものが "## " 見出し
+    だらけの markdown をコードフェンスの中に持つため、その境界だと "## Guidelines" では
+    なくフェンス内の最初の見出しで止まる。コードフェンスは自己完結して閉じるので、
+    見出しの開始位置だけを特定し、その後ろで最初のフェンスを探す。
     """
     heading_match = re.search(r"^## Template\s*$", template_text, flags=re.MULTILINE)
     if heading_match is None:
@@ -47,7 +46,7 @@ def form_sections(form_text):
 
     フォームは Web UI からの起票で label を見出しに変える。同じ label を CLI 起票の
     骨格にも使えば、どちらの経路で立った issue も同じ節を持つ。`validations.required`
-    が真の要素だけを必須とし、説明文だけの markdown 要素は label を持たないので落ちる。
+    が真の要素だけを必須とする。
 
     YAML パーサは標準ライブラリに無い。issue form の body は `- type:` 区切りの平坦な
     並びで入れ子を持たないため、区切りで割ってから各断片を読む。
@@ -69,12 +68,6 @@ def form_sections(form_text):
     return sections
 
 
-def template_sections(template_path, template_text):
-    if template_path.suffix in (".yml", ".yaml"):
-        return form_sections(template_text)
-    return skeleton_sections(template_text)
-
-
 def body_section_names(body_text):
     return {OPTIONAL_SUFFIX.sub("", name) for name in HEADING.findall(body_text)}
 
@@ -92,7 +85,7 @@ def main():
     results = {"errors": [], "warnings": [], "checks": []}
 
     title_match = TYPE_PREFIX.match(title)
-    template_type = Path(template_path).stem
+    template_type = template.stem
     if title_match:
         title_type = title_match.group(1).lower()
         if title_type != template_type:
@@ -102,7 +95,8 @@ def main():
     else:
         results["errors"].append("type_mismatch:title has no bracketed type prefix")
 
-    sections = template_sections(template, template_text)
+    is_form = template.suffix in FORM_SUFFIXES
+    sections = form_sections(template_text) if is_form else skeleton_sections(template_text)
     required = [name for name, optional in sections if not optional]
     present = body_section_names(body_text)
     for name in required:
@@ -113,7 +107,7 @@ def main():
 
     # .yml は Web UI フォームの最小要件を並べたもので、閉じた節リストではない。CLI 起票が
     # そこへ節を足すのは逸脱でないため、余計な節を咎めるのは .md 骨格のときに限る。
-    if template.suffix in (".yml", ".yaml"):
+    if is_form:
         results["checks"].append("unknown_section=skipped (form template)")
     else:
         known = {name for name, _ in sections} | ALLOWED_EXTRA

--- a/.ja/skills/issue/scripts/validate-issue-body.py
+++ b/.ja/skills/issue/scripts/validate-issue-body.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Usage: validate-issue-body.py <template-file> <title> <body-file>
+
+stdout: JSON { errors, warnings, checks }
+exit: 0 if no errors (warnings allowed), 1 if errors
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+TYPE_PREFIX = re.compile(r"^\[([A-Za-z]+)\]")
+HEADING = re.compile(r"^## (.+?)\s*$", flags=re.MULTILINE)
+CODE_BLOCK = re.compile(r"```(?:markdown)?\n(.*?)```", flags=re.DOTALL)
+OPTIONAL_SUFFIX = re.compile(r"\s*\((?:optional|任意)\)\s*$")
+
+
+def skeleton_sections(template_text):
+    """"## Template" 配下、最初のコードブロックから読む (name, optional) のペア。
+
+    section_body の stop 境界 ("^#{1,level} " の次の一致) はここでは使えない。
+    骨格そのものが "## " 見出しだらけの markdown をコードフェンスの中に持つため、
+    その境界だと "## Guidelines" ではなくフェンス内の最初の見出しで止まってしまう。
+    コードフェンスは自己完結して閉じるので、ここでは見出しの開始位置だけを特定し、
+    その後ろで CODE_BLOCK に最初のフェンスを探させる。
+    """
+    heading_match = re.search(r"^## Template\s*$", template_text, flags=re.MULTILINE)
+    if heading_match is None:
+        return []
+    code_match = CODE_BLOCK.search(template_text[heading_match.end() :])
+    skeleton = code_match.group(1) if code_match else ""
+    sections = []
+    for name in HEADING.findall(skeleton):
+        optional = bool(OPTIONAL_SUFFIX.search(name))
+        bare = OPTIONAL_SUFFIX.sub("", name)
+        sections.append((bare, optional))
+    return sections
+
+
+def body_section_names(body_text):
+    return {OPTIONAL_SUFFIX.sub("", name) for name in HEADING.findall(body_text)}
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: validate-issue-body.py <template-file> <title> <body-file>", file=sys.stderr)
+        sys.exit(1)
+    template_path, title, body_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    template_text = Path(template_path).read_text(encoding="utf-8")
+    body_text = Path(body_path).read_text(encoding="utf-8")
+
+    results = {"errors": [], "warnings": [], "checks": []}
+
+    title_match = TYPE_PREFIX.match(title)
+    template_type = Path(template_path).stem
+    if title_match:
+        title_type = title_match.group(1).lower()
+        if title_type != template_type:
+            results["errors"].append(f"type_mismatch:title={title_type} template={template_type}")
+        else:
+            results["checks"].append(f"type_match:{title_type}=ok")
+    else:
+        results["errors"].append("type_mismatch:title has no bracketed type prefix")
+
+    required = [name for name, optional in skeleton_sections(template_text) if not optional]
+    present = body_section_names(body_text)
+    for name in required:
+        if name in present:
+            results["checks"].append(f"section:{name}=ok")
+        else:
+            results["errors"].append(f"missing_section:{name}")
+
+    print(json.dumps(results, indent=2))
+    sys.exit(1 if results["errors"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.ja/skills/issue/scripts/validate-issue-body.py
+++ b/.ja/skills/issue/scripts/validate-issue-body.py
@@ -42,6 +42,39 @@ def skeleton_sections(template_text):
     return sections
 
 
+def form_sections(form_text):
+    """GitHub issue form (.yml) の body 要素から読む (name, optional) のペア。
+
+    フォームは Web UI からの起票で label を見出しに変える。同じ label を CLI 起票の
+    骨格にも使えば、どちらの経路で立った issue も同じ節を持つ。`validations.required`
+    が真の要素だけを必須とし、説明文だけの markdown 要素は label を持たないので落ちる。
+
+    YAML パーサは標準ライブラリに無い。issue form の body は `- type:` 区切りの平坦な
+    並びで入れ子を持たないため、区切りで割ってから各断片を読む。
+    """
+    body_start = re.search(r"^body:\s*$", form_text, flags=re.MULTILINE)
+    if body_start is None:
+        return []
+    entries = re.split(r"^\s*- type:\s*", form_text[body_start.end() :], flags=re.MULTILINE)[1:]
+    sections = []
+    for entry in entries:
+        if entry.split("\n", 1)[0].strip() == "markdown":
+            continue
+        label = re.search(r"^\s*label:\s*(.+?)\s*$", entry, flags=re.MULTILINE)
+        if label is None:
+            continue
+        name = label.group(1).strip().strip("\"'")
+        required = re.search(r"^\s*required:\s*true\s*$", entry, flags=re.MULTILINE) is not None
+        sections.append((name, not required))
+    return sections
+
+
+def template_sections(template_path, template_text):
+    if template_path.suffix in (".yml", ".yaml"):
+        return form_sections(template_text)
+    return skeleton_sections(template_text)
+
+
 def body_section_names(body_text):
     return {OPTIONAL_SUFFIX.sub("", name) for name in HEADING.findall(body_text)}
 
@@ -52,7 +85,8 @@ def main():
         sys.exit(1)
     template_path, title, body_path = sys.argv[1], sys.argv[2], sys.argv[3]
 
-    template_text = Path(template_path).read_text(encoding="utf-8")
+    template = Path(template_path)
+    template_text = template.read_text(encoding="utf-8")
     body_text = Path(body_path).read_text(encoding="utf-8")
 
     results = {"errors": [], "warnings": [], "checks": []}
@@ -68,7 +102,8 @@ def main():
     else:
         results["errors"].append("type_mismatch:title has no bracketed type prefix")
 
-    required = [name for name, optional in skeleton_sections(template_text) if not optional]
+    sections = template_sections(template, template_text)
+    required = [name for name, optional in sections if not optional]
     present = body_section_names(body_text)
     for name in required:
         if name in present:
@@ -76,12 +111,17 @@ def main():
         else:
             results["errors"].append(f"missing_section:{name}")
 
-    known = {name for name, _ in skeleton_sections(template_text)} | ALLOWED_EXTRA
-    extra = sorted(present - known)
-    for name in extra:
-        results["errors"].append(f"unknown_section:{name}")
-    if not extra:
-        results["checks"].append("unknown_section=none")
+    # .yml は Web UI フォームの最小要件を並べたもので、閉じた節リストではない。CLI 起票が
+    # そこへ節を足すのは逸脱でないため、余計な節を咎めるのは .md 骨格のときに限る。
+    if template.suffix in (".yml", ".yaml"):
+        results["checks"].append("unknown_section=skipped (form template)")
+    else:
+        known = {name for name, _ in sections} | ALLOWED_EXTRA
+        extra = sorted(present - known)
+        for name in extra:
+            results["errors"].append(f"unknown_section:{name}")
+        if not extra:
+            results["checks"].append("unknown_section=none")
 
     print(json.dumps(results, indent=2))
     sys.exit(1 if results["errors"] else 0)

--- a/hooks/issue-body-template.sh
+++ b/hooks/issue-body-template.sh
@@ -1,0 +1,70 @@
+#!/bin/zsh
+# PreToolUse hook: gh issue create の body を骨格の節構成と突き合わせ、外れた起票を止める
+# hooks/textlint-lint.sh と同じ形で PreToolUse Bash の入力から gh issue create を取り出し、
+# --body-file の中身とタイトルを skills/issue/scripts/validate-issue-body.py へ渡す。
+# errors が返ったときだけ hookSpecificOutput.permissionDecision を deny で返す (hooks/security/rm-to-trash.sh と同じ形)。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+VALIDATOR="$SCRIPT_DIR/../skills/issue/scripts/validate-issue-body.py"
+
+input=$(cat)
+
+# Fast-exit: skip jq fork unless input is a Bash `gh issue create` call
+case "$input" in
+  *'"tool_name":"Bash"'*gh*issue*create*) ;;
+  *) exit 0 ;;
+esac
+
+# printf, not echo: zsh echo expands backslash escapes and corrupts the JSON (\n inside strings)
+read -r tool_name command_str < <(printf '%s' "$input" | jq -r '[.tool_name // "", .tool_input.command // ""] | @tsv' 2>/dev/null) || true
+# @tsv doubles backslashes — undo to get original command string
+command_str="${command_str//\\\\/\\}"
+
+if [[ -z "$command_str" ]]; then
+  exit 0
+fi
+
+if ! [[ "$command_str" =~ gh[[:space:]]+issue[[:space:]]+create ]]; then
+  exit 0
+fi
+
+title=$(printf '%s\n' "$command_str" | sed -nE 's/.*--title "(([^"\\]|\\.)*)".*/\1/p')
+if [[ -z "$title" ]]; then
+  title=$(printf '%s\n' "$command_str" | sed -nE "s/.*--title '([^']*)'.*/\1/p")
+fi
+
+if [[ -z "$title" ]] || ! [[ "$title" =~ "^\[([A-Za-z]+)\]" ]]; then
+  jq -nc --arg r "issue-body-template: タイトルに型プレフィックス ([Bug] 等) が無く骨格の照合ができないため素通しした" \
+    '{"decision":"approve","reason":$r}'
+  exit 0
+fi
+issue_type="${match[1]:l}"
+
+body_file=$(printf '%s\n' "$command_str" | sed -nE "s/.*--body-file[[:space:]]+('([^']*)'|\"([^\"]*)\"|([^ ]+)).*/\2\3\4/p")
+if [[ -z "$body_file" ]]; then
+  jq -nc --arg r "issue-body-template: --body がインライン指定で --body-file 経由ではないため骨格の照合ができず素通しした" \
+    '{"decision":"approve","reason":$r}'
+  exit 0
+fi
+
+template="$SCRIPT_DIR/../skills/issue/templates/${issue_type}.md"
+if [[ ! -f "$template" ]]; then
+  # リポジトリ独自テンプレートなど、対応する骨格が無い経路は検査対象外 (plan の Backlog candidates 参照)
+  exit 0
+fi
+
+validate_output=$(python3 "$VALIDATOR" "$template" "$title" "$body_file" 2>/dev/null) || true
+errors=$(printf '%s' "$validate_output" | jq -c '.errors // []' 2>/dev/null) || errors="[]"
+error_count=$(printf '%s' "$errors" | jq 'length' 2>/dev/null) || error_count=0
+
+if [[ "$error_count" -gt 0 ]]; then
+  reason=$(printf '%s' "$errors" | jq -r 'join("; ")')
+  jq -nc --arg r "issue-body-template: 本文の節構成が骨格と食い違う ($reason)" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $r
+    }
+  }'
+fi

--- a/hooks/issue-body-template.sh
+++ b/hooks/issue-body-template.sh
@@ -26,7 +26,19 @@ if [[ -z "$command_str" ]]; then
   exit 0
 fi
 
-if ! [[ "$command_str" =~ gh[[:space:]]+issue[[:space:]]+create ]]; then
+# `gh issue create` が起票を指すのは、それがコマンドの先頭に立つときだけ。同じ語は
+# コミットメッセージの中にも現れる (このリポジトリの e7db3385 がその例)。文字列の
+# どこかにあるかで判定すると、無関係な git commit がこの hook を通ることになる。
+# 引用符の中の区切り文字でも切れるが、切れた断片の先頭が gh issue create になるのは
+# 起票コマンドを引用符で包んだときだけで、そのときは止めるほうが安全側になる。
+is_create=0
+while IFS= read -r segment; do
+  [[ "$segment" =~ '^[[:space:]]*gh[[:space:]]+issue[[:space:]]+create([[:space:]]|$)' ]] || continue
+  is_create=1
+  break
+done < <(printf '%s\n' "$command_str" | sed -E 's/(&&|\|\||[;|])/\n/g')
+
+if (( is_create == 0 )); then
   exit 0
 fi
 

--- a/hooks/issue-body-template.sh
+++ b/hooks/issue-body-template.sh
@@ -1,8 +1,10 @@
 #!/bin/zsh
-# PreToolUse hook: gh issue create の body を骨格の節構成と突き合わせ、外れた起票を止める
-# hooks/textlint-lint.sh と同じ形で PreToolUse Bash の入力から gh issue create を取り出し、
-# --body-file の中身とタイトルを skills/issue/scripts/validate-issue-body.py へ渡す。
-# errors が返ったときだけ hookSpecificOutput.permissionDecision を deny で返す (hooks/security/rm-to-trash.sh と同じ形)。
+# PreToolUse hook: match a gh issue create body against the skeleton its title's type
+# points at, and stop the filing when the two diverge.
+# Reads the Bash command out of the PreToolUse input the way hooks/textlint-lint.sh does,
+# then hands the --body-file contents and the title to
+# skills/issue/scripts/validate-issue-body.py. Only a non-empty errors list becomes a deny
+# (same shape as hooks/security/rm-to-trash.sh).
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -10,7 +12,8 @@ VALIDATOR="$SCRIPT_DIR/../skills/issue/scripts/validate-issue-body.py"
 
 input=$(cat)
 
-# Fast-exit: skip jq fork unless input is a Bash `gh issue create` call
+# Fast-exit: an input carrying all three words might be a filing. The strict check below
+# decides; this only keeps the jq fork off everything else.
 case "$input" in
   *'"tool_name":"Bash"'*gh*issue*create*) ;;
   *) exit 0 ;;
@@ -26,11 +29,11 @@ if [[ -z "$command_str" ]]; then
   exit 0
 fi
 
-# `gh issue create` が起票を指すのは、それがコマンドの先頭に立つときだけ。同じ語は
-# コミットメッセージの中にも現れる (このリポジトリの e7db3385 がその例)。文字列の
-# どこかにあるかで判定すると、無関係な git commit がこの hook を通ることになる。
-# 引用符の中の区切り文字でも切れるが、切れた断片の先頭が gh issue create になるのは
-# 起票コマンドを引用符で包んだときだけで、そのときは止めるほうが安全側になる。
+# `gh issue create` names a filing only where it leads a command. The same words turn up
+# inside commit messages (e7db3385 in this repository carries them), so matching anywhere
+# in the string drags an unrelated git commit through the validator. A separator inside
+# quotes splits here too, but a split piece starts with `gh issue create` only when the
+# filing command itself was quoted, and stopping on that is the safe side.
 is_create=0
 while IFS= read -r segment; do
   [[ "$segment" =~ '^[[:space:]]*gh[[:space:]]+issue[[:space:]]+create([[:space:]]|$)' ]] || continue
@@ -61,18 +64,36 @@ if [[ -z "$body_file" ]]; then
   exit 0
 fi
 
-template="$SCRIPT_DIR/../skills/issue/templates/${issue_type}.md"
-if [[ ! -f "$template" ]]; then
-  # リポジトリ独自テンプレートなど、対応する骨格が無い経路は検査対象外 (plan の Backlog candidates 参照)
+# The repository's own template wins: that is what the web UI files against, and a CLI
+# filing that ignores it would leave two shapes of the same issue type in one tracker.
+# The command's own `cd` names the repository when there is one; otherwise this hook
+# already runs where the tool call would.
+repo_dir=$(printf '%s\n' "$command_str" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^ &;|]+).*/\1/p')
+[[ -z "$repo_dir" ]] && repo_dir="$PWD"
+
+template=""
+for candidate in \
+  "$repo_dir/.github/ISSUE_TEMPLATE/${issue_type}.yml" \
+  "$repo_dir/.github/ISSUE_TEMPLATE/${issue_type}.yaml" \
+  "$repo_dir/.github/ISSUE_TEMPLATE/${issue_type}.md" \
+  "$SCRIPT_DIR/../skills/issue/templates/${issue_type}.md"; do
+  if [[ -f "$candidate" ]]; then
+    template="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$template" ]]; then
+  # No skeleton anywhere for this type, so there is nothing to compare the body against.
   exit 0
 fi
 
 validate_output=$(python3 "$VALIDATOR" "$template" "$title" "$body_file" 2>/dev/null) || true
-errors=$(printf '%s' "$validate_output" | jq -c '.errors // []' 2>/dev/null) || errors="[]"
-error_count=$(printf '%s' "$errors" | jq 'length' 2>/dev/null) || error_count=0
+# An empty join means the validator found nothing, could not run, or wrote no JSON. All
+# three leave the filing alone, so one extraction covers both the test and the message.
+reason=$(printf '%s' "$validate_output" | jq -r '.errors // [] | join("; ")' 2>/dev/null) || reason=""
 
-if [[ "$error_count" -gt 0 ]]; then
-  reason=$(printf '%s' "$errors" | jq -r 'join("; ")')
+if [[ -n "$reason" ]]; then
   jq -nc --arg r "issue-body-template: 本文の節構成が骨格と食い違う ($reason)" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/hooks/issue-body-template.sh
+++ b/hooks/issue-body-template.sh
@@ -17,7 +17,8 @@ case "$input" in
 esac
 
 # printf, not echo: zsh echo expands backslash escapes and corrupts the JSON (\n inside strings)
-read -r tool_name command_str < <(printf '%s' "$input" | jq -r '[.tool_name // "", .tool_input.command // ""] | @tsv' 2>/dev/null) || true
+# tool_name is already filtered by the fast-exit case above, so only command is extracted here.
+read -r command_str < <(printf '%s' "$input" | jq -r '[.tool_input.command // ""] | @tsv' 2>/dev/null) || true
 # @tsv doubles backslashes — undo to get original command string
 command_str="${command_str//\\\\/\\}"
 

--- a/hooks/tests/issue-body-template.test.js
+++ b/hooks/tests/issue-body-template.test.js
@@ -1,0 +1,157 @@
+// hooks/issue-body-template.sh を実 subprocess として起動し、gh issue create の抽出から
+// permissionDecision の返却までを固定する。hooks/textlint-lint.sh と同じ形で PreToolUse Bash
+// の入力 (stdin JSON) を読み、gh issue create のときだけ title と --body-file の中身を
+// skills/issue/scripts/validate-issue-body.py へ渡す。validate-issue-body.py が errors を返した
+// ときだけ hookSpecificOutput.permissionDecision を deny で返す (hooks/security/rm-to-trash.sh
+// と同じ形)。settings.json への配線はここでは扱わない (Manual verification が担う)。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..", "..");
+const hook = join(root, "hooks", "issue-body-template.sh");
+
+// gh issue create の --body-file は一時ファイルへ書き出してから渡す。
+// skills/issue/tests/validate-issue-body.test.js の runValidate と同じ形。
+const withBodyFile = (bodyText, fn) => {
+  const dir = mkdtempSync(join(tmpdir(), "issue-body-template-"));
+  try {
+    const bodyPath = join(dir, "body.md");
+    writeFileSync(bodyPath, bodyText, "utf8");
+    return fn(bodyPath);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+// hooks/tests/test-textlint-lint.sh の make_bash_json と同じ入力形 ({tool_name, tool_input.command})
+// を stdin から渡す。spawnSync の res.error (script 未実装で ENOENT など) はそのまま投げて、
+// 「stdout が空」を偽陽性の green にしない。
+const runHook = (command) => {
+  const input = JSON.stringify({ tool_name: "Bash", tool_input: { command } });
+  const res = spawnSync(hook, { input, encoding: "utf8" });
+  if (res.error) {
+    throw res.error;
+  }
+  let out = null;
+  const stdout = res.stdout ?? "";
+  if (stdout.trim()) {
+    try {
+      out = JSON.parse(stdout);
+    } catch {
+      out = null;
+    }
+  }
+  return { status: res.status, out, stdout, stderr: res.stderr ?? "" };
+};
+
+const validBugBody = [
+  "## What & Why",
+  "",
+  "Login fails for some users.",
+  "",
+  "## Steps to Reproduce",
+  "",
+  "1. Open app",
+  "2. Log in",
+  "",
+  "## Expected vs Actual",
+  "",
+  "- Expected: 200 OK",
+  "- Actual: 500 error",
+  "",
+  "## Scope",
+  "",
+  "- In scope: login flow",
+  "- Out of scope: signup flow",
+  "",
+].join("\n");
+
+// bug.md の必須節から "Expected vs Actual" を欠かせた本文。
+const missingSectionBugBody = [
+  "## What & Why",
+  "",
+  "Login fails for some users.",
+  "",
+  "## Steps to Reproduce",
+  "",
+  "1. Open app",
+  "2. Log in",
+  "",
+  "## Scope",
+  "",
+  "- In scope: login flow",
+  "- Out of scope: signup flow",
+  "",
+].join("\n");
+
+test("T-005 gh issue create 以外の Bash コマンドでは何も返さず素通しする", () => {
+  const { stdout } = runHook("gh issue list");
+  assert.equal(
+    stdout.trim(),
+    "",
+    `gh issue create 以外は無出力で終わる (実際: ${JSON.stringify(stdout)})`,
+  );
+});
+
+test("T-006 タイトルに型プレフィックスが無い起票は理由を残して素通しする", () => {
+  withBodyFile(validBugBody, (bodyPath) => {
+    const cmd = `gh issue create --title "Login fails for some users" --body-file ${bodyPath}`;
+    const { out, stdout } = runHook(cmd);
+    assert.ok(out, `stdout が JSON として parse できる (実際: ${JSON.stringify(stdout)})`);
+    assert.notEqual(
+      out?.hookSpecificOutput?.permissionDecision,
+      "deny",
+      "型プレフィックスが無いだけでは deny しない",
+    );
+    assert.ok(
+      stdout.includes("型プレフィックス"),
+      `理由に型プレフィックスが無い旨が残る (実際: ${JSON.stringify(stdout)})`,
+    );
+  });
+});
+
+test("T-007 本文が --body でインライン指定された起票は理由を残して素通しする", () => {
+  const cmd =
+    'gh issue create --title "[Bug] Login fails for some users" --body "Login fails for some users."';
+  const { out, stdout } = runHook(cmd);
+  assert.ok(out, `stdout が JSON として parse できる (実際: ${JSON.stringify(stdout)})`);
+  assert.notEqual(
+    out?.hookSpecificOutput?.permissionDecision,
+    "deny",
+    "--body のインライン指定だけでは deny しない",
+  );
+  assert.ok(
+    stdout.includes("--body-file"),
+    `理由に --body-file を使う旨が残る (実際: ${JSON.stringify(stdout)})`,
+  );
+});
+
+test("T-008 骨格の必須節を欠く本文の起票に permissionDecision deny を返す", () => {
+  withBodyFile(missingSectionBugBody, (bodyPath) => {
+    const cmd = `gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
+    const { out, stdout } = runHook(cmd);
+    assert.ok(out, `stdout が JSON として parse できる (実際: ${JSON.stringify(stdout)})`);
+    assert.equal(
+      out?.hookSpecificOutput?.hookEventName,
+      "PreToolUse",
+      `hookSpecificOutput.hookEventName は PreToolUse (実際: ${JSON.stringify(stdout)})`,
+    );
+    assert.equal(
+      out?.hookSpecificOutput?.permissionDecision,
+      "deny",
+      `errors があるときは deny を返す (実際: ${JSON.stringify(stdout)})`,
+    );
+    assert.ok(
+      out?.hookSpecificOutput?.permissionDecisionReason?.includes(
+        "missing_section:Expected vs Actual",
+      ),
+      `permissionDecisionReason に missing_section:Expected vs Actual が載る (実際: ${JSON.stringify(stdout)})`,
+    );
+  });
+});

--- a/hooks/tests/issue-body-template.test.js
+++ b/hooks/tests/issue-body-template.test.js
@@ -8,7 +8,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 
@@ -139,7 +139,10 @@ test("T-007 本文が --body でインライン指定された起票は理由を
 
 test("T-008 骨格の必須節を欠く本文の起票に permissionDecision deny を返す", () => {
   withBodyFile(missingSectionBugBody, (bodyPath) => {
-    const cmd = `gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
+    // cd で一時ディレクトリを指すのは、hook がリポジトリ独自テンプレートを先に探すため。
+    // 指さないと実行時の cwd が読まれ、このリポジトリの .github/ISSUE_TEMPLATE が骨格に
+    // なって、skill 直下の templates/bug.md を見るこの test の前提が崩れる。
+    const cmd = `cd ${dirname(bodyPath)} && gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
     const { out, stdout } = runHook(cmd);
     assert.ok(out, `stdout が JSON として parse できる (実際: ${JSON.stringify(stdout)})`);
     assert.equal(
@@ -185,7 +188,10 @@ const featureShapedBody = [
 
 test("T-009 Bug のタイトルで feature の節構成を持つ本文を起票しようとすると deny が返る", () => {
   withBodyFile(featureShapedBody, (bodyPath) => {
-    const cmd = `gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
+    // cd で一時ディレクトリを指すのは、hook がリポジトリ独自テンプレートを先に探すため。
+    // 指さないと実行時の cwd が読まれ、このリポジトリの .github/ISSUE_TEMPLATE が骨格に
+    // なって、skill 直下の templates/bug.md を見るこの test の前提が崩れる。
+    const cmd = `cd ${dirname(bodyPath)} && gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
     const { out, stdout } = runHook(cmd);
     assert.ok(out, `stdout が JSON として parse できる (実際: ${JSON.stringify(stdout)})`);
     assert.equal(
@@ -198,7 +204,10 @@ test("T-009 Bug のタイトルで feature の節構成を持つ本文を起票�
 
 test("T-010 タイトルの型が指す骨格に沿う本文の起票は deny されずに通る", () => {
   withBodyFile(validBugBody, (bodyPath) => {
-    const cmd = `gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
+    // cd で一時ディレクトリを指すのは、hook がリポジトリ独自テンプレートを先に探すため。
+    // 指さないと実行時の cwd が読まれ、このリポジトリの .github/ISSUE_TEMPLATE が骨格に
+    // なって、skill 直下の templates/bug.md を見るこの test の前提が崩れる。
+    const cmd = `cd ${dirname(bodyPath)} && gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
     const { out, stdout, status } = runHook(cmd);
     assert.equal(
       status,
@@ -211,4 +220,44 @@ test("T-010 タイトルの型が指す骨格に沿う本文の起票は deny �
       `タイトルの型が指す骨格に沿う本文は deny されない (実際: ${JSON.stringify(stdout)})`,
     );
   });
+});
+
+test("T-012 リポジトリに issue form があるとき、skill 直下でなくその form の label が骨格になる", () => {
+  const dir = mkdtempSync(join(tmpdir(), "issue-body-form-"));
+  try {
+    const formDir = join(dir, ".github", "ISSUE_TEMPLATE");
+    mkdirSync(formDir, { recursive: true });
+    writeFileSync(
+      join(formDir, "bug.yml"),
+      [
+        "name: Bug report",
+        "body:",
+        "  - type: markdown",
+        "    attributes:",
+        "      value: Thanks for filing",
+        "  - type: input",
+        "    attributes:",
+        "      label: Impact",
+        "    validations:",
+        "      required: true",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    // form の label だけを持ち、skill 直下 templates/bug.md の必須節 (What & Why ほか) は
+    // 1 つも持たない本文。form が骨格に選ばれていなければ missing_section で deny される。
+    const bodyPath = join(dir, "body.md");
+    writeFileSync(bodyPath, "## Impact\n\nLogin is down for everyone.\n", "utf8");
+
+    const cmd = `cd ${dir} && gh issue create --title "[Bug] Login is down" --body-file ${bodyPath}`;
+    const { out, stdout, status } = runHook(cmd);
+    assert.equal(status, 0, `form の label に沿う本文で hook が exit 0 で終わる (実際: ${stdout})`);
+    assert.notEqual(
+      out?.hookSpecificOutput?.permissionDecision,
+      "deny",
+      `form の label に沿う本文は deny されない (実際: ${JSON.stringify(stdout)})`,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/hooks/tests/issue-body-template.test.js
+++ b/hooks/tests/issue-body-template.test.js
@@ -155,3 +155,55 @@ test("T-008 骨格の必須節を欠く本文の起票に permissionDecision den
     );
   });
 });
+
+// bug.md の必須節 (What & Why / Steps to Reproduce / Expected vs Actual / Scope) の代わりに
+// feature.md の節構成 (What & Why / Acceptance Criteria / Scope / Testing Decisions) を持つ本文。
+const featureShapedBody = [
+  "## What & Why",
+  "",
+  "Add CSV export so users can analyze offline.",
+  "",
+  "## Acceptance Criteria",
+  "",
+  "- [ ] When user clicks Export, a .csv downloads",
+  "",
+  "## Scope",
+  "",
+  "- In scope: export flow",
+  "- Out of scope: import flow",
+  "",
+  "## Testing Decisions",
+  "",
+  "- Test the CSV serializer",
+  "",
+].join("\n");
+
+test("T-009 Bug のタイトルで feature の節構成を持つ本文を起票しようとすると deny が返る", () => {
+  withBodyFile(featureShapedBody, (bodyPath) => {
+    const cmd = `gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
+    const { out, stdout } = runHook(cmd);
+    assert.ok(out, `stdout が JSON として parse できる (実際: ${JSON.stringify(stdout)})`);
+    assert.equal(
+      out?.hookSpecificOutput?.permissionDecision,
+      "deny",
+      `タイトルが Bug でも本文が feature の節構成だと deny を返す (実際: ${JSON.stringify(stdout)})`,
+    );
+  });
+});
+
+test("T-010 タイトルの型が指す骨格に沿う本文の起票は deny されずに通る", () => {
+  withBodyFile(validBugBody, (bodyPath) => {
+    const cmd = `gh issue create --title "[Bug] Login fails for some users" --body-file ${bodyPath}`;
+    const { out, stdout, status } = runHook(cmd);
+    assert.equal(
+      status,
+      0,
+      `骨格に沿う本文の起票では hook が exit 0 で終わる (実際: ${JSON.stringify(stdout)})`,
+    );
+    assert.notEqual(
+      out?.hookSpecificOutput?.permissionDecision,
+      "deny",
+      `タイトルの型が指す骨格に沿う本文は deny されない (実際: ${JSON.stringify(stdout)})`,
+    );
+  });
+});

--- a/hooks/tests/issue-body-template.test.js
+++ b/hooks/tests/issue-body-template.test.js
@@ -91,12 +91,17 @@ const missingSectionBugBody = [
 ].join("\n");
 
 test("T-005 gh issue create 以外の Bash コマンドでは何も返さず素通しする", () => {
-  const { stdout } = runHook("gh issue list");
-  assert.equal(
-    stdout.trim(),
-    "",
-    `gh issue create 以外は無出力で終わる (実際: ${JSON.stringify(stdout)})`,
-  );
+  // 2 件目は起票でなく、引数の中に同じ語を持つだけのコマンド。このリポジトリの
+  // コミット e7db3385 が実際にこの subject を持つ。
+  const passThrough = ["gh issue list", 'git commit -m "fix: gh issue create hook"'];
+  for (const cmd of passThrough) {
+    const { stdout } = runHook(cmd);
+    assert.equal(
+      stdout.trim(),
+      "",
+      `gh issue create 以外は無出力で終わる (${cmd} で実際: ${JSON.stringify(stdout)})`,
+    );
+  }
 });
 
 test("T-006 タイトルに型プレフィックスが無い起票は理由を残して素通しする", () => {

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -104,7 +104,7 @@ Run this phase only when a /think plan draft exists; otherwise omit the section 
 ## Phase 4: Publishing
 
 1. Present the issue preview. Collect any inline tentative marks into a tentative block. Add no new content, mirror what the body already carries, and omit the block at zero items. Then confirm via AskUserQuestion: "Create this issue?" When there is no `## Plan` section and the extent puts it on the build workflow, add "hold the filing and draft a plan via `/think`" as an option
-2. Write the body to a temp file. Run `${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py ${CLAUDE_SKILL_DIR}/templates/<type>.md <title> <body-file>` and handle errors per Error Handling below. Once it exits 0, attach labels and run `gh issue create --title "<title>" --body-file <path>`. Capture the issue URL from its output
+2. Write the body to a temp file. Run `${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py <the skeleton chosen in Template source> <title> <body-file>` and handle errors per Error Handling below. Once it exits 0, attach labels and run `gh issue create --title "<title>" --body-file <path>`. Capture the issue URL from its output
 3. If split was approved in Phase 1, suggest running /slice with the published epic number. Do not launch it automatically
 4. For an issue that is not split, suggest the next step. Where a filed issue goes is decided by its extent: a fix confined to 1-3 files goes to `/fix <number>`; 4 or more files, or a new feature, goes to the build workflow with the number. When an issue bound for the build workflow has no Plan section, it gets a plan via `/think`, transferred by `/issue <number>`, before it is handed over, and `/qualify` inspects it before the hand-off. Launch none of them automatically
 
@@ -120,3 +120,4 @@ Run this phase only when a /think plan draft exists; otherwise omit the section 
 | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `missing_section:<name>` | Restore the dropped heading from the template skeleton and re-validate                                                                                            |
 | `type_mismatch:*`        | Treat the title's bracketed type as correct, re-select the template matching it, and rewrite the body from that template. Never resolve it by rewriting the title |
+| `unknown_section:<name>` | Drop the off-skeleton heading or fold it into one the skeleton carries. A filing whose skeleton is a `.yml` never sees this                                       |

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -62,7 +62,9 @@ Establish the issue's Why before drafting the body. One question per message, at
 
 ### Template source
 
-List `.md` files via `gh api "repos/{owner}/{repo}/contents/.github/ISSUE_TEMPLATE" --jq '.[].name'`. If a GitHub template whose filename or `name` contains the type exists, read its body and strip the leading frontmatter fields `name` / `about` / `labels` / `title` for the skeleton. Otherwise use `templates/<type>.md` directly under the skill directory.
+List the entries via `gh api "repos/{owner}/{repo}/contents/.github/ISSUE_TEMPLATE" --jq '.[].name'` and take the skeleton for the type in this order: `<type>.yml` (issue form) > `<type>.md` > `templates/<type>.md` directly under the skill directory. The repository's own template comes first because that is what a web-UI filing uses; a CLI filing that ignores it leaves two shapes of the same issue type in one tracker.
+
+For a `.yml`, each `body` entry's `attributes.label` becomes a section name and only those with `validations.required` true are required. A form states the minimum the web UI makes someone fill in, so a CLI filing that adds sections to it is not deviating. For a `.md`, strip the leading frontmatter fields `name` / `about` / `labels` / `title` for the skeleton.
 
 ### Confidence marking
 

--- a/skills/issue/SKILL.md
+++ b/skills/issue/SKILL.md
@@ -102,10 +102,19 @@ Run this phase only when a /think plan draft exists; otherwise omit the section 
 ## Phase 4: Publishing
 
 1. Present the issue preview. Collect any inline tentative marks into a tentative block. Add no new content, mirror what the body already carries, and omit the block at zero items. Then confirm via AskUserQuestion: "Create this issue?" When there is no `## Plan` section and the extent puts it on the build workflow, add "hold the filing and draft a plan via `/think`" as an option
-2. Write the body to a temp file, attach labels, and run `gh issue create --title "<title>" --body-file <path>`. Capture the issue URL from its output
+2. Write the body to a temp file. Run `${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py ${CLAUDE_SKILL_DIR}/templates/<type>.md <title> <body-file>` and handle errors per Error Handling below. Once it exits 0, attach labels and run `gh issue create --title "<title>" --body-file <path>`. Capture the issue URL from its output
 3. If split was approved in Phase 1, suggest running /slice with the published epic number. Do not launch it automatically
 4. For an issue that is not split, suggest the next step. Where a filed issue goes is decided by its extent: a fix confined to 1-3 files goes to `/fix <number>`; 4 or more files, or a new feature, goes to the build workflow with the number. When an issue bound for the build workflow has no Plan section, it gets a plan via `/think`, transferred by `/issue <number>`, before it is handed over, and `/qualify` inspects it before the hand-off. Launch none of them automatically
 
 ### Labels
 
 `priority:*` is required, set to critical / high / medium / low by impact. For other labels, follow the repository's conventions.
+
+## Error Handling
+
+`${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py` reports `{errors, warnings, checks}` as JSON on stdout, and exits 1 when `errors` is non-empty. The `/issue <number>` route that transfers a plan into an existing issue replaces Phase 4's creation with `gh issue edit`, so this check does not run for it. Handle each error per the table below.
+
+| Error                    | Action                                                                                                                                                            |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `missing_section:<name>` | Restore the dropped heading from the template skeleton and re-validate                                                                                            |
+| `type_mismatch:*`        | Treat the title's bracketed type as correct, re-select the template matching it, and rewrite the body from that template. Never resolve it by rewriting the title |

--- a/skills/issue/scripts/validate-issue-body.py
+++ b/skills/issue/scripts/validate-issue-body.py
@@ -14,6 +14,11 @@ TYPE_PREFIX = re.compile(r"^\[([A-Za-z]+)\]")
 HEADING = re.compile(r"^## (.+?)\s*$", flags=re.MULTILINE)
 CODE_BLOCK = re.compile(r"```(?:markdown)?\n(.*?)```", flags=re.DOTALL)
 OPTIONAL_SUFFIX = re.compile(r"\s*\((?:optional|任意)\)\s*$")
+# Headings that stay out of errors despite being absent from the skeleton. An issue
+# carrying a transferred /think plan always has these two, and Phase 3 of
+# skills/issue/SKILL.md is what puts them there. The exemption stops at these two;
+# every other off-skeleton heading stays an unknown_section.
+ALLOWED_EXTRA = frozenset({"Plan", "Backlog candidates"})
 
 
 def skeleton_sections(template_text):
@@ -71,6 +76,13 @@ def main():
             results["checks"].append(f"section:{name}=ok")
         else:
             results["errors"].append(f"missing_section:{name}")
+
+    known = {name for name, _ in skeleton_sections(template_text)} | ALLOWED_EXTRA
+    extra = sorted(present - known)
+    for name in extra:
+        results["errors"].append(f"unknown_section:{name}")
+    if not extra:
+        results["checks"].append("unknown_section=none")
 
     print(json.dumps(results, indent=2))
     sys.exit(1 if results["errors"] else 0)

--- a/skills/issue/scripts/validate-issue-body.py
+++ b/skills/issue/scripts/validate-issue-body.py
@@ -43,6 +43,41 @@ def skeleton_sections(template_text):
     return sections
 
 
+def form_sections(form_text):
+    """(name, optional) pairs read from a GitHub issue form's (.yml) body entries.
+
+    The form turns each label into a heading when someone files through the web UI.
+    Taking those same labels as the skeleton for a CLI filing gives both routes the same
+    sections. Only an entry whose `validations.required` is true counts as required, and
+    a markdown entry carries no label so it drops out.
+
+    No YAML parser ships with the standard library. An issue form's body is a flat
+    `- type:` sequence with no nesting, so splitting on that separator and reading each
+    piece covers it.
+    """
+    body_start = re.search(r"^body:\s*$", form_text, flags=re.MULTILINE)
+    if body_start is None:
+        return []
+    entries = re.split(r"^\s*- type:\s*", form_text[body_start.end() :], flags=re.MULTILINE)[1:]
+    sections = []
+    for entry in entries:
+        if entry.split("\n", 1)[0].strip() == "markdown":
+            continue
+        label = re.search(r"^\s*label:\s*(.+?)\s*$", entry, flags=re.MULTILINE)
+        if label is None:
+            continue
+        name = label.group(1).strip().strip("\"'")
+        required = re.search(r"^\s*required:\s*true\s*$", entry, flags=re.MULTILINE) is not None
+        sections.append((name, not required))
+    return sections
+
+
+def template_sections(template_path, template_text):
+    if template_path.suffix in (".yml", ".yaml"):
+        return form_sections(template_text)
+    return skeleton_sections(template_text)
+
+
 def body_section_names(body_text):
     return {OPTIONAL_SUFFIX.sub("", name) for name in HEADING.findall(body_text)}
 
@@ -53,7 +88,8 @@ def main():
         sys.exit(1)
     template_path, title, body_path = sys.argv[1], sys.argv[2], sys.argv[3]
 
-    template_text = Path(template_path).read_text(encoding="utf-8")
+    template = Path(template_path)
+    template_text = template.read_text(encoding="utf-8")
     body_text = Path(body_path).read_text(encoding="utf-8")
 
     results = {"errors": [], "warnings": [], "checks": []}
@@ -69,7 +105,8 @@ def main():
     else:
         results["errors"].append("type_mismatch:title has no bracketed type prefix")
 
-    required = [name for name, optional in skeleton_sections(template_text) if not optional]
+    sections = template_sections(template, template_text)
+    required = [name for name, optional in sections if not optional]
     present = body_section_names(body_text)
     for name in required:
         if name in present:
@@ -77,12 +114,17 @@ def main():
         else:
             results["errors"].append(f"missing_section:{name}")
 
-    known = {name for name, _ in skeleton_sections(template_text)} | ALLOWED_EXTRA
-    extra = sorted(present - known)
-    for name in extra:
-        results["errors"].append(f"unknown_section:{name}")
-    if not extra:
-        results["checks"].append("unknown_section=none")
+    # A .yml lists a web form's minimum, not a closed set of sections. A CLI filing that
+    # adds to it is not deviating, so off-skeleton headings are only faulted for .md.
+    if template.suffix in (".yml", ".yaml"):
+        results["checks"].append("unknown_section=skipped (form template)")
+    else:
+        known = {name for name, _ in sections} | ALLOWED_EXTRA
+        extra = sorted(present - known)
+        for name in extra:
+            results["errors"].append(f"unknown_section:{name}")
+        if not extra:
+            results["checks"].append("unknown_section=none")
 
     print(json.dumps(results, indent=2))
     sys.exit(1 if results["errors"] else 0)

--- a/skills/issue/scripts/validate-issue-body.py
+++ b/skills/issue/scripts/validate-issue-body.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Usage: validate-issue-body.py <template-file> <title> <body-file>
+
+stdout: JSON { errors, warnings, checks }
+exit: 0 if no errors (warnings allowed), 1 if errors
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+TYPE_PREFIX = re.compile(r"^\[([A-Za-z]+)\]")
+HEADING = re.compile(r"^## (.+?)\s*$", flags=re.MULTILINE)
+CODE_BLOCK = re.compile(r"```(?:markdown)?\n(.*?)```", flags=re.DOTALL)
+OPTIONAL_SUFFIX = re.compile(r"\s*\((?:optional|任意)\)\s*$")
+
+
+def skeleton_sections(template_text):
+    """(name, optional) pairs read from the first code block under "## Template".
+
+    section_body's own stop-bound (next "^#{1,level} ") cannot be reused here:
+    the skeleton itself is markdown full of "## " headings inside the code
+    fence, so that bound would stop at the first of those instead of at
+    "## Guidelines". The code fence is self-delimiting, so this locates the
+    heading start only and lets CODE_BLOCK find the first fence after it.
+    """
+    heading_match = re.search(r"^## Template\s*$", template_text, flags=re.MULTILINE)
+    if heading_match is None:
+        return []
+    code_match = CODE_BLOCK.search(template_text[heading_match.end() :])
+    skeleton = code_match.group(1) if code_match else ""
+    sections = []
+    for name in HEADING.findall(skeleton):
+        optional = bool(OPTIONAL_SUFFIX.search(name))
+        bare = OPTIONAL_SUFFIX.sub("", name)
+        sections.append((bare, optional))
+    return sections
+
+
+def body_section_names(body_text):
+    return {OPTIONAL_SUFFIX.sub("", name) for name in HEADING.findall(body_text)}
+
+
+def main():
+    if len(sys.argv) < 4:
+        print("Usage: validate-issue-body.py <template-file> <title> <body-file>", file=sys.stderr)
+        sys.exit(1)
+    template_path, title, body_path = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    template_text = Path(template_path).read_text(encoding="utf-8")
+    body_text = Path(body_path).read_text(encoding="utf-8")
+
+    results = {"errors": [], "warnings": [], "checks": []}
+
+    title_match = TYPE_PREFIX.match(title)
+    template_type = Path(template_path).stem
+    if title_match:
+        title_type = title_match.group(1).lower()
+        if title_type != template_type:
+            results["errors"].append(f"type_mismatch:title={title_type} template={template_type}")
+        else:
+            results["checks"].append(f"type_match:{title_type}=ok")
+    else:
+        results["errors"].append("type_mismatch:title has no bracketed type prefix")
+
+    required = [name for name, optional in skeleton_sections(template_text) if not optional]
+    present = body_section_names(body_text)
+    for name in required:
+        if name in present:
+            results["checks"].append(f"section:{name}=ok")
+        else:
+            results["errors"].append(f"missing_section:{name}")
+
+    print(json.dumps(results, indent=2))
+    sys.exit(1 if results["errors"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/issue/scripts/validate-issue-body.py
+++ b/skills/issue/scripts/validate-issue-body.py
@@ -14,21 +14,20 @@ TYPE_PREFIX = re.compile(r"^\[([A-Za-z]+)\]")
 HEADING = re.compile(r"^## (.+?)\s*$", flags=re.MULTILINE)
 CODE_BLOCK = re.compile(r"```(?:markdown)?\n(.*?)```", flags=re.DOTALL)
 OPTIONAL_SUFFIX = re.compile(r"\s*\((?:optional|任意)\)\s*$")
+FORM_SUFFIXES = (".yml", ".yaml")
 # Headings that stay out of errors despite being absent from the skeleton. An issue
 # carrying a transferred /think plan always has these two, and Phase 3 of
-# skills/issue/SKILL.md is what puts them there. The exemption stops at these two;
-# every other off-skeleton heading stays an unknown_section.
+# skills/issue/SKILL.md is what puts them there.
 ALLOWED_EXTRA = frozenset({"Plan", "Backlog candidates"})
 
 
 def skeleton_sections(template_text):
     """(name, optional) pairs read from the first code block under "## Template".
 
-    section_body's own stop-bound (next "^#{1,level} ") cannot be reused here:
-    the skeleton itself is markdown full of "## " headings inside the code
-    fence, so that bound would stop at the first of those instead of at
-    "## Guidelines". The code fence is self-delimiting, so this locates the
-    heading start only and lets CODE_BLOCK find the first fence after it.
+    Reading up to the next heading is not available here: the skeleton itself is
+    markdown full of "## " headings inside the code fence, so that bound stops at the
+    first of those instead of at "## Guidelines". The code fence closes itself, so this
+    locates the heading start only and looks for the first fence after it.
     """
     heading_match = re.search(r"^## Template\s*$", template_text, flags=re.MULTILINE)
     if heading_match is None:
@@ -48,8 +47,7 @@ def form_sections(form_text):
 
     The form turns each label into a heading when someone files through the web UI.
     Taking those same labels as the skeleton for a CLI filing gives both routes the same
-    sections. Only an entry whose `validations.required` is true counts as required, and
-    a markdown entry carries no label so it drops out.
+    sections. Only an entry whose `validations.required` is true counts as required.
 
     No YAML parser ships with the standard library. An issue form's body is a flat
     `- type:` sequence with no nesting, so splitting on that separator and reading each
@@ -72,12 +70,6 @@ def form_sections(form_text):
     return sections
 
 
-def template_sections(template_path, template_text):
-    if template_path.suffix in (".yml", ".yaml"):
-        return form_sections(template_text)
-    return skeleton_sections(template_text)
-
-
 def body_section_names(body_text):
     return {OPTIONAL_SUFFIX.sub("", name) for name in HEADING.findall(body_text)}
 
@@ -95,7 +87,7 @@ def main():
     results = {"errors": [], "warnings": [], "checks": []}
 
     title_match = TYPE_PREFIX.match(title)
-    template_type = Path(template_path).stem
+    template_type = template.stem
     if title_match:
         title_type = title_match.group(1).lower()
         if title_type != template_type:
@@ -105,7 +97,8 @@ def main():
     else:
         results["errors"].append("type_mismatch:title has no bracketed type prefix")
 
-    sections = template_sections(template, template_text)
+    is_form = template.suffix in FORM_SUFFIXES
+    sections = form_sections(template_text) if is_form else skeleton_sections(template_text)
     required = [name for name, optional in sections if not optional]
     present = body_section_names(body_text)
     for name in required:
@@ -116,7 +109,7 @@ def main():
 
     # A .yml lists a web form's minimum, not a closed set of sections. A CLI filing that
     # adds to it is not deviating, so off-skeleton headings are only faulted for .md.
-    if template.suffix in (".yml", ".yaml"):
+    if is_form:
         results["checks"].append("unknown_section=skipped (form template)")
     else:
         known = {name for name, _ in sections} | ALLOWED_EXTRA

--- a/skills/issue/tests/validate-issue-body.test.js
+++ b/skills/issue/tests/validate-issue-body.test.js
@@ -1,0 +1,170 @@
+// skills/issue/scripts/validate-issue-body.py を実 subprocess として起動し、CLI 契約
+// (引数 -> stdout JSON -> exit code) を固定する。workflows/audit/tests/audit.seam.test.js と
+// 同じく実スクリプトを spawnSync で通し、python の test discover には乗せない。
+//
+// CLI 契約 (validate-outcome.py の def section_body と同じ形で節を切り出す):
+//   Usage: validate-issue-body.py <template-file> <title> <body-file>
+//   stdout: JSON { errors, warnings, checks }
+//   exit: 0 if no errors (warnings allowed), 1 if errors
+//
+// 骨格は <template-file> の "## Template" 見出し配下、最初のコードブロックから読む。
+// "## Template" と "## Guidelines" 自体は骨格に含めない。見出し末尾が "(optional)" の節は
+// 任意節として missing_section の対象から外す。照合は集合で行い、本文側の節の並び順は見ない。
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = join(here, "..", "..", "..");
+const script = join(root, "skills", "issue", "scripts", "validate-issue-body.py");
+const bugTemplate = join(root, "skills", "issue", "templates", "bug.md");
+const choreTemplate = join(root, "skills", "issue", "templates", "chore.md");
+const featureTemplate = join(root, "skills", "issue", "templates", "feature.md");
+
+// 本文は一時ファイルへ書き出してから渡す。validate-outcome.py 側もファイルパス引数なので、
+// 呼び出し側 (/issue の Phase 4 検証) が渡す実際の形に揃える。
+const runValidate = (templatePath, title, bodyText) => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-issue-body-"));
+  try {
+    const bodyPath = join(dir, "body.md");
+    writeFileSync(bodyPath, bodyText, "utf8");
+    const res = spawnSync("python3", [script, templatePath, title, bodyPath], {
+      encoding: "utf8",
+    });
+    let out;
+    try {
+      out = JSON.parse(res.stdout);
+    } catch {
+      out = null;
+    }
+    return { status: res.status, out, stderr: res.stderr };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+test("T-001 骨格の必須節が本文に無いとき missing_section をその節名つきで返す", () => {
+  const body = [
+    "## What & Why",
+    "",
+    "Login fails for some users.",
+    "",
+    "## Steps to Reproduce",
+    "",
+    "1. Open app",
+    "2. Log in",
+    "",
+    "## Scope",
+    "",
+    "- In scope: login flow",
+    "- Out of scope: signup flow",
+    "",
+  ].join("\n");
+  const { status, out } = runValidate(bugTemplate, "[Bug] Login fails for some users", body);
+  assert.ok(out, "stdout が JSON として parse できる");
+  assert.equal(status, 1, "errors がある run は exit 1 で終わる");
+  assert.ok(
+    out.errors.includes("missing_section:Expected vs Actual"),
+    `errors に missing_section:Expected vs Actual が節名つきで載る (実際: ${JSON.stringify(out.errors)})`,
+  );
+});
+
+test("T-002 骨格に無い Plan と Backlog candidates は errors にならない", () => {
+  const body = [
+    "## What & Why",
+    "",
+    "Login fails for some users.",
+    "",
+    "## Steps to Reproduce",
+    "",
+    "1. Open app",
+    "2. Log in",
+    "",
+    "## Expected vs Actual",
+    "",
+    "- Expected: 200 OK",
+    "- Actual: 500 error",
+    "",
+    "## Scope",
+    "",
+    "- In scope: login flow",
+    "- Out of scope: signup flow",
+    "",
+    "## Plan",
+    "",
+    "- Step 1",
+    "",
+    "## Backlog candidates",
+    "",
+    "- Follow-up idea",
+    "",
+  ].join("\n");
+  const { status, out } = runValidate(bugTemplate, "[Bug] Login fails for some users", body);
+  assert.ok(out, "stdout が JSON として parse できる");
+  assert.equal(status, 0, "骨格の必須節が揃っていれば exit 0 で終わる");
+  assert.deepEqual(
+    out.errors,
+    [],
+    `骨格に無い Plan / Backlog candidates は errors に載らない (実際: ${JSON.stringify(out.errors)})`,
+  );
+});
+
+test("T-003 タイトルの型と渡したテンプレートが食い違うとき type_mismatch を返す", () => {
+  const body = [
+    "## What & Why",
+    "",
+    "Login fails for some users.",
+    "",
+    "## Acceptance Criteria",
+    "",
+    "- [ ] When user logs in, session persists",
+    "",
+    "## Scope",
+    "",
+    "- In scope: login flow",
+    "- Out of scope: signup flow",
+    "",
+    "## Testing Decisions",
+    "",
+    "- Cover the session persistence path",
+    "",
+  ].join("\n");
+  // title は [Bug] だが渡したテンプレートは feature.md なので型が食い違う。
+  const { status, out } = runValidate(featureTemplate, "[Bug] Login fails for some users", body);
+  assert.ok(out, "stdout が JSON として parse できる");
+  assert.equal(status, 1, "type_mismatch がある run は exit 1 で終わる");
+  assert.ok(
+    out.errors.some((e) => e.startsWith("type_mismatch:")),
+    `errors に type_mismatch が載る (実際: ${JSON.stringify(out.errors)})`,
+  );
+});
+
+test("T-004 本文の節の並びが骨格と違っても errors にならない", () => {
+  const body = [
+    "## Scope",
+    "",
+    "- In scope: dependency bump",
+    "- Out of scope: unrelated refactor",
+    "",
+    "## Changes",
+    "",
+    "- Update package.json",
+    "",
+    "## What & Why",
+    "",
+    "Bump the dependency to close a known issue.",
+    "",
+  ].join("\n");
+  const { status, out } = runValidate(choreTemplate, "[Chore] Bump dependency", body);
+  assert.ok(out, "stdout が JSON として parse できる");
+  assert.equal(status, 0, "節の並びが骨格と違っても揃っていれば exit 0 で終わる");
+  assert.deepEqual(
+    out.errors,
+    [],
+    `並び順の違いは errors にならない (実際: ${JSON.stringify(out.errors)})`,
+  );
+});

--- a/skills/issue/tests/validate-issue-body.test.js
+++ b/skills/issue/tests/validate-issue-body.test.js
@@ -113,6 +113,42 @@ test("T-002 骨格に無い Plan と Backlog candidates は errors にならな�
   );
 });
 
+test("T-011 必須節が揃っていても骨格に無い節を持つ本文は unknown_section を返す", () => {
+  // 必須節を欠く本文は T-001 が見る。ここは必須節が全部あるため missing_section では
+  // 止まらず、余計な節を見る経路だけが働く。#286 の `## Changes` がこの形にあたる。
+  const body = [
+    "## What & Why",
+    "",
+    "Login fails for some users.",
+    "",
+    "## Steps to Reproduce",
+    "",
+    "1. Open app",
+    "",
+    "## Expected vs Actual",
+    "",
+    "- Expected: 200 OK",
+    "- Actual: 500 error",
+    "",
+    "## Scope",
+    "",
+    "- In scope: login flow",
+    "",
+    "## Changes",
+    "",
+    "- Rewrote the session handler",
+    "",
+  ].join("\n");
+  const { status, out } = runValidate(bugTemplate, "[Bug] Login fails for some users", body);
+  assert.ok(out, "stdout が JSON として parse できる");
+  assert.equal(status, 1, "骨格外の節を持つ本文は exit 1 で終わる");
+  assert.deepEqual(
+    out.errors,
+    ["unknown_section:Changes"],
+    `骨格に無い Changes が節名つきで errors に載る (実際: ${JSON.stringify(out.errors)})`,
+  );
+});
+
 test("T-003 タイトルの型と渡したテンプレートが食い違うとき type_mismatch を返す", () => {
   const body = [
     "## What & Why",


### PR DESCRIPTION
## What & Why

起票される issue の本文が、タイトルの型が指すテンプレートの節構成を持つ。外れた本文は `gh issue create` の時点で止まり、起票されない。

これまでは骨格に従うことを求める散文があるだけで、従ったかを検査する手段が無かった。`## 背景` のような骨格に無い節を作る形態と、`[Bug]` なのに `feature.md` の節で書く形態の 2 通りの逸脱が実際の issue で起きていた (#286 #287 #290、#323 #324 #325 #326)。

## Review focus

- `hooks/issue-body-template.sh:14-16` の fast-exit `case` は、コマンド文字列に `gh issue create` という部分文字列を含むだけで発火する。`gh issue create` そのものでない Bash コマンド (このブランチの `e7db3385` の commit subject のような文字列を含む `git commit` など) にも誤って反応しうる
- `skills/issue/scripts/validate-issue-body.py` と `.ja` 側は実行ビットが無く (100644)、`SKILL.md` からの裸呼び出し経路 (`${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py ...`) では失敗する。hook 側は `python3` を明示して呼ぶため影響を受けない
- hook は `settings.json` の PreToolUse Bash に未配線。配線は sandbox の書き込み拒否対象で専用の update-config skill が経路になるため、この PR のスコープに含めていない

## Changes

- `hooks/issue-body-template.sh` を新設し、`gh issue create` の `--title` と `--body-file` を取り出して `validate-issue-body.py` に渡し、節構成が骨格と食い違うときだけ `permissionDecision: deny` を返す
- タイトルに型プレフィックスが無い、`--body-file` を使わずインライン `--body` で渡す、対応する `templates/<type>.md` が無い、のいずれも検査対象外として素通しする

## Design Decisions

- 検査は決定論的なスクリプト (`validate-issue-body.py`) に置き、hook は入力の取り出しと deny/approve の分岐だけを担う。節構成の照合基準を hook と skill の 2 か所に持たせない
- 骨格の節の並び順は検査しない。並びが違っても errors にしない (T-004)。Plan/Backlog candidates など骨格に無い節も許容する (T-002)。求めるのは骨格の必須節が揃っていることで、順序や追加節までは縛らない

## How to Test

1. `node --test 'skills/issue/tests/*.test.js' 'hooks/tests/*.test.js'` を実行する
2. 21 件全て pass することを確認する


---

_build workflow が自動生成した検証記録。深いレビューは含まない。開くかは下の status 行で判断する。_

Closes #292

<details>
<summary><code>verify tests=pass gates=pass</code> · <code>scope-deviations 0</code> · <code>missing-tests 0</code> · <code>conformance 2 (1 high)</code> · <code>structure 1</code></summary>

**実機確認 (merge 前に実施)**
- [ ] `settings.json` の PreToolUse Bash に `hooks/issue-body-template.sh` を配線する。`settings.json` は sandbox の書き込み拒否対象で、専用の update-config skill が変更経路になっているため、実装 agent には委ねない
- [ ] 実際に `/issue` を 1 回走らせ、生成された本文が骨格の節構成を持つことと、hook が起票を止めないことを確認する。skill の生成経路そのものは自動テストで再現できないため、実行して観察する

**前提 (veto 対象)**
- 依存する既存ファイルは `## Plan` の Preconditions を参照
- 原因は「骨格に従うことを求める散文はあるが、従ったかを検査する手段が無い」ことにある。形態 2 の 4 件で確認した。`.github/ISSUE_TEMPLATE` には `bug.yml` と `feature.yml` しか無く、`.md` を列挙する手順は該当なしで `templates/bug.md` へフォールバックするが、そのファイルを読まずに書いても検査が無いため通った
- 逸脱は同一実行者の連続発生に限らない。形態 1 と形態 2 は別セッションで、外れ方も違う
- `/slice` も `skills/issue/templates/feature.md` を骨格に `gh issue create --body-file` で起票するため、hook の対象に入る

**Issue 適合性 (独立レビュー)**
- `[high] wrong` fast-exit の `case` と後続の正規表現は、実際の `gh issue create` 呼び出しに限らず、コマンド文字列中に "gh issue create" という部分文字列を含むだけの Bash コマンドにもマッチしてしまう。例えば `echo '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"fix: gh issue create hook\""}}' | hooks/issue-body-template.sh` (issue 作成とは無関係な単なる `git commit`) を実行すると、本来求められる無言の pass-through ではなく空でない `{"decision":"approve",...}` が返ることを再現確認しており、これは仮定の話ではなく、このブランチのコミット e7db3385 の subject line にまさにこの文字列が含まれているため、hook を配線すればプロジェクト自身のコミット履歴に対して誤発火する。
  `hooks/issue-body-template.sh:14-33 (fast-exit case + `[[ "$command_str" =~ gh[[:space:]]+issue[[:space:]]+create ]]`)` · spec: T-005 gh issue create 以外の Bash コマンドでは何も返さず素通しする
- `[low] missing` spec は、翻訳された見出しや余分な見出し (例: `## 背景`) に対してこのチェックが表出すべきトークンとして `unknown_section` を挙げているが、スクリプトはそのトークンを一切出力しない — skills/issue と hooks 全体を `unknown_section` で grep しても該当なし。ブロックという結果自体は間接的に発生する (必須の英語見出しが存在しないため `missing_section:<name>` が発火する) ものの、spec が記述する具体的なエラー語彙は実装されていない。
  `skills/issue/scripts/validate-issue-body.py:59-73 (results only ever carries `missing_section:*` and `type_mismatch:*`)` · spec: 見出しの翻訳 (`## What & Why` の位置に `## 背景` を書く) は SKILL.md の「Template-derived headings stay in English」に反する。今回の検査はこれを unknown_section として捕まえるが、規約そのものの周知は別に要る

**参照モジュールからの構造逸脱**
- `[convention]` 参照スクリプトは、SKILL.md が `python3` prefix 無しでそのまま呼び出せるよう実行ビット (100755) を持つことを前提としているが、validate-issue-body.py とその .ja mirror は 100644 でコミットされており、skills/issue/SKILL.md:105 も (`${CLAUDE_SKILL_DIR}/scripts/validate-issue-body.py ...`) と裸で呼び出しているため、実行ビットが無いと失敗する。hooks/issue-body-template.sh は `python3 "$VALIDATOR"` と明示的に呼ぶことでこれを回避しており、影響を受けるのは SKILL.md 経由の呼び出し経路のみである。
  `skills/issue/scripts/validate-issue-body.py:1 (git mode 100644); .ja/skills/issue/scripts/validate-issue-body.py:1 (git mode 100644)` · ref: skills/outcome/scripts/validate-outcome.py (git mode 100755) invoked bare via skills/outcome/SKILL.md:15 `${CLAUDE_SKILL_DIR}/scripts/validate-outcome.py .claude/OUTCOME.md`

**異常 (Red 未確認)**
- U-004 (no-red): U-004 が目指す挙動 (body のセクション構造が title-type の骨格と一致しない場合に hook が `gh issue create` を拒否する) は、既に前段の unit で hooks/issue-body-template.sh と skills/issue/scripts/validate-issue-body.py により実装済みであり、T-009 と T-010 は実装変更なしに実際の subprocess chain に対して pass する。
  node --test 'skills/issue/tests/*.test.js' 'hooks/tests/*.test.js' -> tests 21, pass 21, fail 0
  hooks/tests/issue-body-template.test.js:35-51 runHook spawns the real hooks/issue-body-template.sh via spawnSync with PreToolUse stdin JSON, no stub
  hooks/issue-body-template.sh:57 shells out to the real skills/issue/scripts/validate-issue-body.py against the real skills/issue/templates/${issue_type}.md
  hooks/tests/issue-body-template.test.js:161-192 T-009 featureShapedBody omits '## Steps to Reproduce' and '## Expected vs Actual' required by skills/issue/templates/bug.md, asserts permissionDecision === 'deny'
  hooks/tests/issue-body-template.test.js:194-209 T-010 uses validBugBody containing all four bug.md sections, asserts status === 0 and permissionDecision !== 'deny'
  skills/issue/templates/bug.md:9-24 lists required sections What & Why / Steps to Reproduce / Expected vs Actual / Scope, none marked (optional)
  git log --oneline -- hooks/issue-body-template.sh skills/issue/scripts/validate-issue-body.py -> e7db3385, 52df5117 (prior commits, no change made this run)

</details>
