### PR TITLE
plan skeleton に reference_module の path 行が無く build が停止する

### DIFF
--- a/.ja/skills/think/templates/plan.md
+++ b/.ja/skills/think/templates/plan.md
@@ -19,6 +19,7 @@ reference_module: {kind + reason を object で (kind: module/no-module/new-shap
 
 {kind が module 以外のときはこの小節を丸ごと省略する。}
 
+- path: {複製元を一意に指す path 1 つ (`src/foo/`)。下の files はその配下に並ぶ}
 - instances: {この形を既に共有する既存機能の数。2 以上なら「N 例目」と書く}
 - files: {複製する各ファイルとその役割 (`src/foo/list.tsx` 一覧画面)}
 - conventions: {後続 unit が維持する共有慣例 (合成する共有コンポーネント、フォーマット処理の置き場所、状態の渡し方)}

--- a/skills/think/templates/plan.md
+++ b/skills/think/templates/plan.md
@@ -19,6 +19,7 @@ reference_module: {kind + reason as an object (kind: module/no-module/new-shape)
 
 {Omit the whole subsection when kind is not module.}
 
+- path: {the one path that identifies the module to replicate (`src/foo/`); the files below sit under it}
 - instances: {how many existing features already share this shape; say "Nth instance" when 2 or more}
 - files: {each file to replicate, with its role (`src/foo/list.tsx` list screen)}
 - conventions: {shared conventions later units must keep (composed components, where formatting lives, how state is passed)}

--- a/skills/think/tests/plan-draft.test.js
+++ b/skills/think/tests/plan-draft.test.js
@@ -101,6 +101,32 @@ test("各言語のテンプレートが reference_module を kind と理由の�
   }
 });
 
+// 骨格が落としたフィールドは、そのとおり書いた plan が build の Load で invalid-plan
+// として止まってから初めて分かる。骨格と validate の要求を build.js 側から突き合わせる。
+test("kind が module のとき build.js が必須にするフィールドが骨格の参照モジュール小節にある", () => {
+  const buildJs = readFileSync(join(root, "workflows", "build.js"), "utf8");
+  const fieldMatch = buildJs.match(
+    /refModule\.kind === "module"[\s\S]{0,200}?String\(refModule\.(\w+)\s*\|\|/,
+  );
+  assert.ok(fieldMatch, "build.js の validate から kind module 限定必須フィールドの名前を読める");
+  const fieldName = fieldMatch[1];
+  const headings = { ja: "### 参照モジュール", en: "### Reference module" };
+  for (const [lang, path] of Object.entries(templates)) {
+    const doc = read(path);
+    const heading = headings[lang];
+    const start = doc.indexOf(heading);
+    assert.ok(start !== -1, `${lang}: ${heading} 見出しが存在する`);
+    const rest = doc.slice(start + heading.length);
+    const nextHeading = rest.search(/^#{2,3}[ \t]/m);
+    const section = nextHeading === -1 ? rest : rest.slice(0, nextHeading);
+    assert.match(
+      section,
+      new RegExp(`^- ${fieldName}:`, "m"),
+      `${lang}: 参照モジュール小節が ${fieldName} 行を持つ`,
+    );
+  }
+});
+
 test("各言語のテンプレートが Bug タスク用の root_cause 行を持つ", () => {
   for (const [lang, path] of Object.entries(templates)) {
     const doc = read(path);
@@ -350,7 +376,10 @@ test("テンプレートの実機確認見出しが build.js の抽出正規表�
 test("各言語が委譲した基準に引き取る機構を添えると定める", () => {
   const expected = {
     ja: { skill: /引き取る機構/, template: /この基準を引き取る機構/ },
-    en: { skill: /names the mechanism that takes it on/, template: /mechanism that takes this criterion on/ },
+    en: {
+      skill: /names the mechanism that takes it on/,
+      template: /mechanism that takes this criterion on/,
+    },
   };
   for (const [lang, re] of Object.entries(expected)) {
     assert.match(read(skills[lang]), re.skill, `${lang}: SKILL.md が機構を添える規則を持つ`);

--- a/skills/think/tests/plan-draft.test.js
+++ b/skills/think/tests/plan-draft.test.js
@@ -101,8 +101,9 @@ test("各言語のテンプレートが reference_module を kind と理由の�
   }
 });
 
-// 骨格が落としたフィールドは、そのとおり書いた plan が build の Load で invalid-plan
-// として止まってから初めて分かる。骨格と validate の要求を build.js 側から突き合わせる。
+// 骨格が落としたフィールドは、そのとおり書いた plan が Load で invalid-plan として
+// 止まってから初めて分かる。フィールド名を骨格側から書き写すと、validate が要求を
+// 変えたときにこの突合が追随しないので、build.js の validate を起点にする。
 test("kind が module のとき build.js が必須にするフィールドが骨格の参照モジュール小節にある", () => {
   const buildJs = readFileSync(join(root, "workflows", "build.js"), "utf8");
   const fieldMatch = buildJs.match(
@@ -118,9 +119,9 @@ test("kind が module のとき build.js が必須にするフィールドが骨
     assert.ok(start !== -1, `${lang}: ${heading} 見出しが存在する`);
     const rest = doc.slice(start + heading.length);
     const nextHeading = rest.search(/^#{2,3}[ \t]/m);
-    const section = nextHeading === -1 ? rest : rest.slice(0, nextHeading);
+    assert.notStrictEqual(nextHeading, -1, `${lang}: 参照モジュール見出しの後に別の見出しが続く`);
     assert.match(
-      section,
+      rest.slice(0, nextHeading),
       new RegExp(`^- ${fieldName}:`, "m"),
       `${lang}: 参照モジュール小節が ${fieldName} 行を持つ`,
     );


### PR DESCRIPTION
## What & Why

`skills/think/templates/plan.md` の Reference module skeleton は instances と files と conventions の 3 行しか示さないが、`workflows/build.js:169` は kind が module のとき path を必須にする。skeleton どおり書いた plan は Load で invalid-plan として止まり、書き手は run が停止してから不足に気づいていた。

skeleton に path 行を足し、あわせて build.js の validate から必須フィールド名を読み出す seam テストを追加した。validator が要求するフィールドが増えたとき、skeleton がそれを載せるまでテストが赤になる。

## Review focus

- 追加テストの正規表現 `refModule\.kind === "module"[\s\S]{0,200}?String\(refModule\.(\w+)\s*\|\|` が build.js の該当分岐を狙えているか。既存の root_cause seam テストと同じ、production のコードからフィールド名を読む形にした
- path 行の文言が skeleton の他の行と同じ粒度か

## Changes

- Reference module skeleton の先頭に path 行を足した (`.ja/` と英語側)
- kind が module のとき build.js が必須にするフィールドが skeleton にあることを確認する seam テストを足した

## Scope

- Not included: build.js の validate を緩めること。path は複製元を一意に指す情報で、files だけでは module の入口が定まらない
- Not included: kind が no-module/new-shape のときの reason。skeleton の 16 行目が `reference_module: {kind + reason as an object ...}` と書いており、reason の置き場は既にある。この経路に食い違いは無いことを確認した
- Not included: skills/think/SKILL.md。55 行目が `reference_module: { path, files, instances }` と書いており、path を既に求めている

## Design Decisions

- テストを skeleton の文字列に直接当てず、build.js の validate からフィールド名を読み出す形にした。skeleton と validator に共通の出典が無いことが今回の食い違いの原因なので、テストが両者を突き合わせる位置に立つ

## How to Test

1. `node --test "skills/think/tests/*.test.js"` を実行する
2. 19 件が pass する。追加テストは path 行を消すと赤になる

## Related

- Closes #330
