### PR TITLE
hook が渡すテキストを、読み手がいる時点に合わせる

### DIFF
--- a/.ja/skills/fix/SKILL.md
+++ b/.ja/skills/fix/SKILL.md
@@ -61,7 +61,7 @@ Obvious は RCA と regression test 生成の双方を省くため、誤修正�
 
 ## Non-obvious
 
-1. `Skill("use-context-root-cause-analysis")` を起動して 5 Whys を実行する。Finding ID または Finding 直接入力経由なら、finding の file:line と summary を 5 Whys の起点として渡す。Symptom/Root cause/Pattern を出力する。
+1. `Skill("use-context-root-cause-analysis")` を起動して 5 Whys を実行する。Finding ID または Finding 直接入力経由なら、finding の file:line と summary を 5 Whys の起点として渡す。Symptom/Root cause/Pattern を出力する。Issue Handoff 経由で issue 本文が原因を file:line まで特定しているときは 5 Whys を省き、その原因を Root cause として引き継いで Pattern だけ判定する。
 2. `Task(subagent_type: generator-test)` で regression test を生成する。渡すのは symptom、再現手順、step 1 の root cause
 3. regression test が Red であることを確認
 4. 修正を適用

--- a/.ja/skills/pr/SKILL.md
+++ b/.ja/skills/pr/SKILL.md
@@ -22,7 +22,7 @@ argument-hint: "[issue reference or context]"
 commit なし、Git リポジトリでない、gh 認証失敗のいずれかを検出したら、エラーを報告して中止する。
 
 1. base ブランチを検出 (§ Base ブランチ検出)
-2. base ブランチを AskUserQuestion で選択する。選択肢は main/develop/検出済み
+2. base ブランチを AskUserQuestion で選択する。選択肢は main, develop, 検出結果。検出結果が main か develop と一致するときは選択肢が重複するので、聞かずに検出結果を使う
 3. § 分析ソースの各コマンドを並列実行する
 4. UI 変更を検出 (§ UI 変更検出)
 5. テンプレートを選ぶ (§ PR テンプレート)

--- a/hooks/auto-package-manager.sh
+++ b/hooks/auto-package-manager.sh
@@ -18,7 +18,7 @@ esac
 
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 
-# Only process package manager commands (bash builtin parameter expansion — no fork)
+# Only process package manager commands. Bash builtin parameter expansion, no fork
 FIRST_TOKEN="${COMMAND%% *}"
 case "$FIRST_TOKEN" in
   npm|npx|pnpm|yarn|bun|bunx) ;;

--- a/hooks/auto-package-manager.sh
+++ b/hooks/auto-package-manager.sh
@@ -101,7 +101,7 @@ jq -n \
     hookSpecificOutput: {
       hookEventName: "PreToolUse",
       permissionDecision: "allow",
-      permissionDecisionReason: ($from + " → ni"),
+      permissionDecisionReason: ("auto-package-manager: " + $from + " → ni"),
       updatedInput: {
         command: $cmd
       }

--- a/hooks/ja-prose-guard.sh
+++ b/hooks/ja-prose-guard.sh
@@ -95,9 +95,9 @@ fi
 
 prose_lines=$(printf '%s\n' "$prose" | grep -c . || true)
 
-# stdout の JSON で返す。exit 0 の stderr は誰にも表示されないので、警告がそこに
-# 出るだけでは退行を止められない。systemMessage が人間に、additionalContext が
-# 書き換えた本人に届く。
+# Returned as JSON on stdout. Stderr from a hook that exits 0 reaches no one, so a warning
+# written there cannot stop the regression. systemMessage reaches the human, and
+# additionalContext reaches whoever rewrote the file.
 msg="ja-prose-guard: .ja/ は canonical で prose は日本語 (MIRROR.md)。$file_path のコメント / docstring ${prose_lines} 行に日本語が 1 文字もない。英語で書き直していないか確認する。過去訳は git log --oneline -- \"$file_path\" から取れる。"
 
 jq -n --arg m "$msg" '{

--- a/hooks/ja-prose-guard.sh
+++ b/hooks/ja-prose-guard.sh
@@ -98,7 +98,7 @@ prose_lines=$(printf '%s\n' "$prose" | grep -c . || true)
 # stdout の JSON で返す。exit 0 の stderr は誰にも表示されないので、警告がそこに
 # 出るだけでは退行を止められない。systemMessage が人間に、additionalContext が
 # 書き換えた本人に届く。
-msg=".ja/ は canonical で prose は日本語 (MIRROR.md)。$file_path のコメント / docstring ${prose_lines} 行に日本語が 1 文字もない。英語で書き直していないか確認する。過去訳は git log --oneline -- \"$file_path\" から取れる。"
+msg="ja-prose-guard: .ja/ は canonical で prose は日本語 (MIRROR.md)。$file_path のコメント / docstring ${prose_lines} 行に日本語が 1 文字もない。英語で書き直していないか確認する。過去訳は git log --oneline -- \"$file_path\" から取れる。"
 
 jq -n --arg m "$msg" '{
   systemMessage: $m,

--- a/hooks/lifecycle/recall-index.sh
+++ b/hooks/lifecycle/recall-index.sh
@@ -40,7 +40,7 @@ fi
 touch "$LAST"
 
 # Detach so the embed pass never delays the prompt. SQLite WAL serializes concurrent writers,
-# so parallel session starts are safe without an explicit lock (verified: WAL checkpoints clean).
+# so parallel session starts are safe without an explicit lock.
 ( "$RECALL" index >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/lifecycle/statusline.sh
+++ b/hooks/lifecycle/statusline.sh
@@ -91,7 +91,6 @@ render_context() {
     percentage=$(printf "%.0f" "$CONTEXT_USED_PCT")
     remaining=$((100 - percentage))
 
-    # Cache hit rate
     local cache_hit_pct=0 has_cache=0
     if [[ "${CACHE_READ:-}" =~ ^[0-9]+$ ]] && [[ "${CACHE_CREATION:-}" =~ ^[0-9]+$ ]]; then
         local cache_total=$((CACHE_READ + CACHE_CREATION))

--- a/hooks/security/npm-safe-install.sh
+++ b/hooks/security/npm-safe-install.sh
@@ -37,7 +37,7 @@ if [[ -f "$NPMRC" ]] && grep -q '^ignore-scripts=true' "$NPMRC" 2>/dev/null; the
   exit 0
 fi
 
-REASON="~/.npmrc に ignore-scripts=true が未設定です。サプライチェーン攻撃対策として必須です。echo 'ignore-scripts=true' >> ~/.npmrc を実行後に再試行してください。"
+REASON="npm-safe-install: ~/.npmrc に ignore-scripts=true が無く、依存の install script が任意のコードを実行できる。echo 'ignore-scripts=true' >> ~/.npmrc を実行してから再試行する。"
 jq -n --arg reason "$REASON" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",

--- a/hooks/security/rm-to-trash.sh
+++ b/hooks/security/rm-to-trash.sh
@@ -18,7 +18,7 @@ COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
 
 # Match rm/rmdir/unlink/shred at line start or after shell separators
 if printf '%s' "$COMMAND" | grep -qE '(^|[;&|`$(]|&&|\|\|)[[:space:]]*(rm|rmdir|unlink|shred)([[:space:]]|$)'; then
-  REASON="削除は \`mv <file> ~/.Trash/ && git add <file>\` を使う。sandbox が \`mv ~/.Trash/\` を弾いたら dangerouslyDisableSandbox: true でリトライ、他の sandbox エラーはユーザーに報告。"
+  REASON="rm-to-trash: 削除は \`mv <file> ~/.Trash/ && git add <file>\` を使う。sandbox が \`mv ~/.Trash/\` を弾いたら dangerouslyDisableSandbox: true でリトライし、他の sandbox エラーはユーザーに報告する。"
   jq -n --arg reason "$REASON" '{
     hookSpecificOutput: {
       hookEventName: "PreToolUse",

--- a/hooks/textlint-fix.sh
+++ b/hooks/textlint-fix.sh
@@ -9,7 +9,6 @@ TEXTLINT_CONFIG="$TEXTLINT_DIR/.textlintrc.json"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/japanese-detect.sh"
 
-# Read hook JSON from stdin
 input=$(cat)
 
 # Fast-exit: skip jq fork unless input references a .md file path
@@ -29,29 +28,24 @@ if [[ -z "$file_path" ]]; then
   exit 0
 fi
 
-# Only process .md files
 case "$file_path" in
   *.md) ;;
   *) exit 0 ;;
 esac
 
-# Verify file exists
 if [[ ! -f "$file_path" ]]; then
   exit 0
 fi
 
-# Skip non-Japanese files
 if ! has_japanese < "$file_path"; then
   exit 0
 fi
 
-# Verify textlint config exists
 if [[ ! -f "$TEXTLINT_CONFIG" ]]; then
   echo "textlint-fix: config not found at $TEXTLINT_CONFIG" >&2
   exit 0
 fi
 
-# Determine runtime: bun > npx
 # Array, not string: zsh does not word-split "$runner", so "bun x" would run as one command name
 if command -v bun &>/dev/null; then
   runner=(bun x)
@@ -59,7 +53,6 @@ else
   runner=(npx)
 fi
 
-# Run textlint --fix
 cd "$TEXTLINT_DIR" || exit 0
 "${runner[@]}" textlint --fix --config "$TEXTLINT_CONFIG" "$file_path" >/dev/null 2>&1 || true
 

--- a/hooks/textlint-lint.sh
+++ b/hooks/textlint-lint.sh
@@ -22,7 +22,7 @@ source "$SCRIPT_DIR/lib/japanese-detect.sh"
 
 # $'...', not '...': jq --arg passes the string through as written, so an unexpanded `\n`
 # arrives as two characters and collapses the table into one line.
-STRUCTURE_CHECKLIST=$'## 構造レビュー（ワークスロップ防止）\n\nbody を送信する前に、以下を確認してください：\n\n| チェック | 問い |\n|---|---|\n| 筆者の判断 | 筆者自身の結論が1〜3行で冒頭に書かれているか？AI出力が主役になっていないか |\n| 半分にできるか | この文書は半分にできるか？できないなら何が重要か分かっていない可能性がある |\n| 事実と意見の区別 | 事実・推測・提案にラベルが貼られ、分離されているか |\n| アクションの明確さ | 読み手に求める行動が具体的か（「ご確認ください」ではなく「Xを判断してください」） |\n| 読み手の認知負荷 | この文書は読み手の負荷を下げているか、仕事を押し付けていないか |\n\n問題がある項目のみ body を修正してください。'
+STRUCTURE_CHECKLIST=$'## 構造レビュー\n\nこの body は作成済み。下表から外れる項目があれば gh issue edit か gh pr edit で直す。\n\n| チェック | 問い |\n|---|---|\n| 筆者の判断 | 筆者自身の結論が冒頭 1-3 行にあるか。AI の出力が主役になっていないか |\n| 分量 | 半分に削れるか。削れるなら、何を伝えるかを絞り切れていない |\n| 事実と意見 | 事実、推測、提案が分けて書かれているか |\n| 読み手の行動 | 求める行動が具体的か。「ご確認ください」でなく「X を判断する」の形か |\n| 読み手の負担 | 読み手が判断に使う時間を減らしているか。調べ直す作業を渡していないか |\n\n外れる項目が無ければ何もしない。'
 
 input=$(cat)
 
@@ -105,7 +105,7 @@ if [[ -f "$TEXTLINT_CONFIG" ]] && printf '%s' "$body" | has_japanese $ja_thresho
 
   if [[ -n "$lint_output" ]]; then
     lint_clean=$(printf '%s\n' "$lint_output" | grep -v "^$tmpfile$" | sed "s|$tmpfile|$target_label|g")
-    lint_section=$(printf '## textlint 校正結果\n\n以下の指摘を確認し、必要に応じて %s テキストを修正してください。\n\n%s\n\n' "$target_label" "$lint_clean")
+    lint_section=$(printf '## textlint 校正結果\n\nこの %s は作成済み。以下の指摘のうち直す価値があるものを編集で反映する。\n\n%s\n\n' "$target_label" "$lint_clean")
   fi
 fi
 

--- a/skills/fix/SKILL.md
+++ b/skills/fix/SKILL.md
@@ -61,7 +61,7 @@ Obvious skips both RCA and regression test generation, so it is limited to findi
 
 ## Non-obvious
 
-1. Run 5 Whys via `Skill("use-context-root-cause-analysis")`. If via Finding ID or Direct Finding Input, pass the finding's file:line and summary as the 5 Whys starting point. Output Symptom / Root cause / Pattern.
+1. Run 5 Whys via `Skill("use-context-root-cause-analysis")`. If via Finding ID or Direct Finding Input, pass the finding's file:line and summary as the 5 Whys starting point. Output Symptom / Root cause / Pattern. When an Issue Handoff body already names the cause down to a file:line, skip the 5 Whys, carry that cause as the Root cause, and judge only the Pattern.
 2. `Task(subagent_type: generator-test)` for the regression test. Pass symptom, repro steps, and the root cause from step 1
 3. Verify regression test is Red
 4. Apply fix

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -22,7 +22,7 @@ Read `language` from `~/.claude/settings.json` and translate the PR body into th
 If there are no commits, the directory is not a git repository, or gh auth fails, report the error and abort.
 
 1. Detect the base branch (§ Base Branch Detection)
-2. Select the base branch via AskUserQuestion. The options are main / develop / detected
+2. Select the base branch via AskUserQuestion. The options are main, develop, and the detected one. When the detected branch is main or develop, two options collapse into one, so take the detected branch without asking
 3. Run the § Analysis Sources commands in parallel
 4. Detect UI changes (§ UI Change Detection)
 5. Select the template (§ PR Template)


### PR DESCRIPTION
この PR の base は `fix/pretooluse-hook-output` (PR #345)。#345 がマージされると base は main に切り替わる。

## What & Why

構造レビューチェックリストは body を「送信する前に」確認するよう書かれていた。しかし PreToolUse の additionalContext は tool の実行後、tool result の隣へ届く。起票が済んだ後に読まれるテキストが、まだ送信していない時点を指していた。#345 で届くようになったことで、この食い違いが表に出た。

あわせて hook が返すテキストの書き方の揺れと、コードの再説明になっていたコメントを整理した。

## Review focus

- `hooks/textlint-lint.sh` の STRUCTURE_CHECKLIST と lint_section。文言が届く時点と合っているか
- deny 理由の prefix を 7 hook に揃えた点。停止したコマンドがどの hook で止まったか名乗る
- `hooks/textlint-fix.sh` はコメント 7 行の削除のみで、コードは 1 行も変えていない

## Changes

- チェックリストと校正結果の書き出しを「作成済み」から始め、直し方として gh issue edit を指す形にした
- 敬体で書かれていた npm-safe-install の理由を言い切り形へ揃えた。日本語 prompt の規約が言い切り形
- 全 deny 理由に hook 名の prefix を付けた。従来は issue-body-template だけが名乗っていた
- MARKDOWN.md が禁じる全角括弧、行末コロン、列挙に読めるスラッシュをチェックリストから外した
- 直下のコードを言い換えただけのコメントを削除した。textlint-fix に 7 行、statusline と recall-index に 1 行ずつ
- ja-prose-guard の日本語コメント 1 ブロックを英語へ。hooks/に .ja ミラーは無く、英語が局所の書き方

## Scope

- Not included: `hooks/herdr-agent-state.sh`。herdr が管理し、再インストールで上書きされると冒頭に書かれているため触っていない
- Not included: #346 が扱う `--body-file` の抽出経路

## Design Decisions

- `/pr` step 2 の base 選択は、検出結果が main か develop と一致するとき聞かない形にした。今回その質問は 3 択のうち 2 つが同じ main を指していた。代償として、この PR のように base が main でないケースを質問で拾えなくなる
- `/fix` の Non-obvious パスは、issue 本文が原因を file:line まで特定しているとき 5 Whys を省く形にした。#334 の本文が該当し、5 Whys は報告者が書いた内容を導き直すだけになる

## How to Test

1. `bash hooks/tests/test-textlint-lint.sh` を実行する。25 passed で終わる
2. `bash hooks/tests/test-textlint-fix.sh` を実行する。8 passed で終わる
3. `node --test "hooks/tests/**/*.test.js"` を実行する。12 passed で終わる
4. `git commit --dry-run -m "これは検証用のテキストです。設定を変更することができます。"` を実行する。届く校正結果が「この commit message は作成済み。」で始まる
