### PR TITLE
textlint-lint が --body-file の指す本文を読むようにする

### DIFF
--- a/hooks/tests/test-textlint-lint.sh
+++ b/hooks/tests/test-textlint-lint.sh
@@ -8,10 +8,14 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/test-helpers.sh"
 HOOK="$SCRIPT_DIR/../textlint-lint.sh"
 
+# A body textlint always flags: it carries the redundant することができます and clears the
+# 50-character bar has_japanese sets. Raising either threshold moves both together.
+LINTED_BODY='この機能はユーザーが設定を変更することができます。この説明は日本語判定の五十文字閾値を超えるための追加の文章です。'
+
 test_issue_create_advisory() {
   echo "T-006: gh issue create with problematic body returns textlint findings"
   # ≥50 Japanese chars (has_japanese threshold) with a deterministic finding (redundant expression)
-  local body='この機能はユーザーが設定を変更することができます。この説明は日本語判定の五十文字閾値を超えるための追加の文章です。'
+  local body="$LINTED_BODY"
   local cmd="gh issue create --title \"test\" --body \"$body\""
   local json
   json=$(make_bash_json "$cmd")
@@ -43,7 +47,7 @@ test_tmpdir_trailing_slash() {
   echo "T-019: TMPDIR が末尾スラッシュ付きでも一時ファイルのパスが指摘に残らない"
   # macOS が渡す TMPDIR は末尾スラッシュ付き。走らせる環境の TMPDIR が既にその形の場合が
   # あるので 2 つ足し、剥ぎ取りが 1 つで止まらないことまで見る。
-  local body='この機能はユーザーが設定を変更することができます。この説明は日本語判定の五十文字閾値を超えるための追加の文章です。'
+  local body="$LINTED_BODY"
   local cmd="gh issue create --title \"test\" --body \"$body\""
   local json
   json=$(make_bash_json "$cmd")
@@ -63,7 +67,7 @@ test_non_gh_command_skipped() {
 
 test_pr_create_advisory() {
   echo "T-010: gh pr create with problematic body returns advisory"
-  local body='この機能はユーザーが設定を変更することができます。この説明は日本語判定の五十文字閾値を超えるための追加の文章です。'
+  local body="$LINTED_BODY"
   local cmd="gh pr create --title \"test\" --body \"$body\""
   local json
   json=$(make_bash_json "$cmd")
@@ -145,8 +149,78 @@ test_english_body_structure_only() {
   assert_contains "returns hookSpecificOutput" "additionalContext" "$output"
 }
 
+with_body_file() {
+  local dir body_path
+  dir=$(mktemp -d "${TMPDIR:-/tmp}/textlint-bodyfile-XXXXXX")
+  body_path="$dir/body.md"
+  printf '%s\n' "$LINTED_BODY" > "$body_path"
+  printf '%s' "$body_path"
+}
+
+test_issue_create_body_file() {
+  echo "T-020: gh issue create の --body-file が指す本文が校正される"
+  # /issue も /pr も --body-file で起票する。この経路を読まないと、実際に走る形の起票が
+  # 一度も校正されない。
+  local body_path
+  body_path=$(with_body_file)
+  local cmd="gh issue create --title \"test\" --body-file $body_path"
+  local json
+  json=$(make_bash_json "$cmd")
+  local output
+  output=$(echo "$json" | "$HOOK" 2>/dev/null) || true
+  assert_contains "has textlint findings" "textlint 校正結果" "$output"
+  assert_contains "has structure checklist" "構造レビュー" "$output"
+  rm -rf "$(dirname "$body_path")"
+}
+
+test_pr_create_body_file() {
+  echo "T-021: gh pr create の --body-file が指す本文が校正される"
+  local body_path
+  body_path=$(with_body_file)
+  local cmd="gh pr create --title \"test\" --body-file $body_path"
+  local json
+  json=$(make_bash_json "$cmd")
+  local output
+  output=$(echo "$json" | "$HOOK" 2>/dev/null) || true
+  assert_contains "has textlint findings" "textlint 校正結果" "$output"
+  rm -rf "$(dirname "$body_path")"
+}
+
+test_quoted_body_file() {
+  echo "T-023: 引用符で囲まれた --body-file のパスも読む"
+  # 空白を含むパスは引用符付きで渡される。抽出の分岐がその形を先に拾えないと、
+  # 塞がっていたときと同じ静かな素通しになる。
+  local root dir body_path
+  root=$(mktemp -d "${TMPDIR:-/tmp}/textlint-quoted-XXXXXX")
+  dir="$root/with space"
+  mkdir -p "$dir"
+  body_path="$dir/body.md"
+  printf '%s\n' "$LINTED_BODY" > "$body_path"
+  local json
+  json=$(make_bash_json "gh issue create --title \"test\" --body-file \"$body_path\"")
+  local output
+  output=$(echo "$json" | "$HOOK" 2>/dev/null) || true
+  assert_contains "has textlint findings" "textlint 校正結果" "$output"
+  rm -rf "$root"
+}
+
+test_relative_body_file_skipped() {
+  echo "T-022: --body-file が相対パスのときは校正しない"
+  # hook はコマンドが走る cwd を持たないので、相対パスの指す先を決められない。
+  # issue-body-template がリテラルの絶対パスを強制していて、そちらが実際に走る形になる。
+  local json
+  json=$(make_bash_json 'gh issue create --title "test" --body-file body.md')
+  local output
+  output=$(echo "$json" | "$HOOK" 2>/dev/null) || true
+  assert_empty "no output for a relative --body-file" "$output"
+}
+
 echo "=== textlint-lint.sh tests ==="
 test_issue_create_advisory
+test_issue_create_body_file
+test_pr_create_body_file
+test_quoted_body_file
+test_relative_body_file_skipped
 test_issue_create_clean
 test_tmpdir_trailing_slash
 test_non_gh_command_skipped

--- a/hooks/tests/test-textlint-lint.sh
+++ b/hooks/tests/test-textlint-lint.sh
@@ -8,9 +8,10 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/test-helpers.sh"
 HOOK="$SCRIPT_DIR/../textlint-lint.sh"
 
-# A body textlint always flags: it carries the redundant することができます and clears the
-# 50-character bar has_japanese sets. Raising either threshold moves both together.
 LINTED_BODY='この機能はユーザーが設定を変更することができます。この説明は日本語判定の五十文字閾値を超えるための追加の文章です。'
+
+TEST_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/textlint-lint-tests-XXXXXX")
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
 test_issue_create_advisory() {
   echo "T-006: gh issue create with problematic body returns textlint findings"
@@ -150,19 +151,16 @@ test_english_body_structure_only() {
 }
 
 with_body_file() {
-  local dir body_path
-  dir=$(mktemp -d "${TMPDIR:-/tmp}/textlint-bodyfile-XXXXXX")
-  body_path="$dir/body.md"
-  printf '%s\n' "$LINTED_BODY" > "$body_path"
-  printf '%s' "$body_path"
+  local dir="$TEST_TMPDIR/${1:-plain}"
+  mkdir -p "$dir"
+  printf '%s\n' "$LINTED_BODY" > "$dir/body.md"
+  printf '%s' "$dir/body.md"
 }
 
 test_issue_create_body_file() {
   echo "T-020: gh issue create の --body-file が指す本文が校正される"
-  # /issue も /pr も --body-file で起票する。この経路を読まないと、実際に走る形の起票が
-  # 一度も校正されない。
   local body_path
-  body_path=$(with_body_file)
+  body_path=$(with_body_file issue)
   local cmd="gh issue create --title \"test\" --body-file $body_path"
   local json
   json=$(make_bash_json "$cmd")
@@ -170,44 +168,34 @@ test_issue_create_body_file() {
   output=$(echo "$json" | "$HOOK" 2>/dev/null) || true
   assert_contains "has textlint findings" "textlint 校正結果" "$output"
   assert_contains "has structure checklist" "構造レビュー" "$output"
-  rm -rf "$(dirname "$body_path")"
 }
 
 test_pr_create_body_file() {
   echo "T-021: gh pr create の --body-file が指す本文が校正される"
   local body_path
-  body_path=$(with_body_file)
+  body_path=$(with_body_file pr)
   local cmd="gh pr create --title \"test\" --body-file $body_path"
   local json
   json=$(make_bash_json "$cmd")
   local output
   output=$(echo "$json" | "$HOOK" 2>/dev/null) || true
   assert_contains "has textlint findings" "textlint 校正結果" "$output"
-  rm -rf "$(dirname "$body_path")"
 }
 
 test_quoted_body_file() {
   echo "T-023: 引用符で囲まれた --body-file のパスも読む"
-  # 空白を含むパスは引用符付きで渡される。抽出の分岐がその形を先に拾えないと、
-  # 塞がっていたときと同じ静かな素通しになる。
-  local root dir body_path
-  root=$(mktemp -d "${TMPDIR:-/tmp}/textlint-quoted-XXXXXX")
-  dir="$root/with space"
-  mkdir -p "$dir"
-  body_path="$dir/body.md"
-  printf '%s\n' "$LINTED_BODY" > "$body_path"
+  local body_path
+  body_path=$(with_body_file "with space")
   local json
   json=$(make_bash_json "gh issue create --title \"test\" --body-file \"$body_path\"")
   local output
   output=$(echo "$json" | "$HOOK" 2>/dev/null) || true
   assert_contains "has textlint findings" "textlint 校正結果" "$output"
-  rm -rf "$root"
 }
 
 test_relative_body_file_skipped() {
   echo "T-022: --body-file が相対パスのときは校正しない"
-  # hook はコマンドが走る cwd を持たないので、相対パスの指す先を決められない。
-  # issue-body-template がリテラルの絶対パスを強制していて、そちらが実際に走る形になる。
+  # 相対パスを解決しないのは漏れでなく判断。hook はコマンドが走る cwd を持たない。
   local json
   json=$(make_bash_json 'gh issue create --title "test" --body-file body.md')
   local output

--- a/hooks/textlint-lint.sh
+++ b/hooks/textlint-lint.sh
@@ -59,9 +59,8 @@ if [[ "$mode" == "ghcreate" ]]; then
   if [[ -n "$body" ]]; then
     body=$(printf '%b' "$body")
   else
-    # A relative path stays unread. The hook holds none of the shell state that would
-    # resolve it, and issue-body-template denies a filing whose path is not literal and
-    # absolute, so that is the shape reaching this line.
+    # A relative path stays unread: the hook holds none of the shell state that would
+    # resolve it, and issue-body-template already forces a filing to write an absolute one.
     body_file=$(printf '%s\n' "$command_str" | sed -nE "s/.*--body-file[[:space:]]+('([^']*)'|\"([^\"]*)\"|([^ ]+)).*/\2\3\4/p" | head -1) || true
     if [[ "$body_file" == /* && -f "$body_file" ]]; then
       body=$(<"$body_file")

--- a/hooks/textlint-lint.sh
+++ b/hooks/textlint-lint.sh
@@ -58,6 +58,14 @@ if [[ "$mode" == "ghcreate" ]]; then
   # The extracted body still carries \n escape sequences from the flattened command; expand them
   if [[ -n "$body" ]]; then
     body=$(printf '%b' "$body")
+  else
+    # A relative path stays unread. The hook holds none of the shell state that would
+    # resolve it, and issue-body-template denies a filing whose path is not literal and
+    # absolute, so that is the shape reaching this line.
+    body_file=$(printf '%s\n' "$command_str" | sed -nE "s/.*--body-file[[:space:]]+('([^']*)'|\"([^\"]*)\"|([^ ]+)).*/\2\3\4/p" | head -1) || true
+    if [[ "$body_file" == /* && -f "$body_file" ]]; then
+      body=$(<"$body_file")
+    fi
   fi
 else
   # Commit messages are usually multiline heredocs; @tsv flattens newlines, so re-extract raw


### PR DESCRIPTION
## What & Why

textlint-lint は本文を `--body` からしか読まない。一方 `/issue` Phase 4 と `/pr` 手順 11 はどちらも `--body-file` で起票する。そのため textlint の校正結果と構造レビューチェックリストは、issue と PR の起票時に一度も届いていなかった。修正前は両方の形で hook の出力長が 0 になる。

## Review focus

- `hooks/textlint-lint.sh` の抽出分岐。`--body` が空のときだけ `--body-file` を見る
- 相対パスを読まない判断。テスト T-022 が仕様として固定する
- テストの本文リテラルを `LINTED_BODY` に集約した部分は流し読みでよい

## Changes

- `--body` が空のとき `--body-file` の指す絶対パスを読む。引用符付きのパスも対象 (T-023)
- 相対パスは読まない。hook はコマンドが走る shell の状態を持たず、issue-body-template がリテラルの絶対パスを強制しているため、実際に走る形は絶対パスになる
- 5 つのテストが重複して持っていた本文を `LINTED_BODY` にまとめた。textlint が指摘する冗長表現と `has_japanese` の 50 文字閾値は 1 組の条件で、片方を変えると全テストが動く

## Scope

- Not included: `hooks/lib/` への共通化。issue-body-template と共有できるのは sed 1 行で、切り出しのコストが重複を上回る
- Not included: 構造レビューチェックリストの内容が今も妥当かの見直し

## Design Decisions

- 相対パス解決を入れなかった。入れるには issue-body-template が持つ状態つきスキャナ相当を要する。advisory な hook にその複雑さを持ち込む理由は無い。代償として、絶対パスでない起票では校正が走らない

## How to Test

1. `bash hooks/tests/test-textlint-lint.sh` を実行する。30 passed で終わる
2. `bash hooks/tests/test-textlint-fix.sh` を実行する。8 passed で終わる
3. `node --test "hooks/tests/**/*.test.js" "skills/issue/tests/*.test.js"` を実行する。28 passed で終わる

## Related

- Closes #346
