### PR TITLE
コマンドの判断を語の有無から位置の解析へ移す

### DIFF
--- a/hooks/issue-body-template.sh
+++ b/hooks/issue-body-template.sh
@@ -44,66 +44,50 @@ if [[ -z "$command_str" ]]; then
 fi
 
 # `gh issue create` names a filing only where it leads a command. The same words turn up
-# inside commit messages (e7db3385 in this repository carries them), and a message body can
-# put them at the start of one of its own lines, so a split that counts every separator
-# would drag an unrelated git commit through the validator. Telling which separators sit
-# outside quotes takes a scanner that carries state, which sed cannot express.
-if ! segments=$(printf '%s' "$command_str" | python3 -c '
+# inside commit messages (e7db3385 in this repository carries them) and inside a heredoc
+# body a message is written through, so telling a filing from a mention takes a scan that
+# knows where a token sits. The flags come out of the filing itself, since a `git commit`
+# sharing the line carries its own --title-looking text.
+if ! parsed=$(printf '%s' "$command_str" | LIB_DIR="$SCRIPT_DIR/lib" python3 -c '
+import json
+import os
 import sys
 
-# `&&` and `||` split as two single characters, which only leaves an empty segment
-# between them.
-command = sys.stdin.read()
-segments, current, quote, escaped = [], [], None, False
-for ch in command:
-    if escaped:
-        current.append(ch)
-        escaped = False
-    elif ch == "\\" and quote != "\x27":
-        current.append(ch)
-        escaped = True
-    elif quote:
-        current.append(ch)
-        if ch == quote:
-            quote = None
-    elif ch in "\x27\"":
-        current.append(ch)
-        quote = ch
-    elif ch in ";|&\n":
-        segments.append("".join(current))
-        current = []
-    else:
-        current.append(ch)
-segments.append("".join(current))
-sys.stdout.write("".join(segment + "\x00" for segment in segments))
+sys.path.insert(0, os.environ["LIB_DIR"])
+import command_scan
+
+try:
+    found = list(command_scan.commands(sys.stdin.read()))
+except ValueError:
+    sys.exit(1)  # quoting that does not close hides where the filing would begin
+
+filing = next((c for c in found if command_scan.starts_with(c, ["gh", "issue", "create"])), None)
+directory = next((c for c in found if c[0] == "cd" and len(c) > 1), None)
+print(json.dumps({
+    "filing": filing is not None,
+    "title": command_scan.flag_value(filing, "--title") if filing else None,
+    "body_file": command_scan.flag_value(filing, "--body-file") if filing else None,
+    "repo_dir": directory[1] if directory else None,
+}))
 ' 2>/dev/null); then
-  # Losing the split leaves no segment identified as the filing, so the body goes
-  # uninspected the same way an unreadable body file leaves it uninspected.
-  deny "issue-body-template: コマンドの分割に失敗し起票を照合できない。python3 が動くか確認する"
+  # Without the scan nothing identifies the filing, so the body goes uninspected the same
+  # way an unreadable body file leaves it uninspected.
+  deny "issue-body-template: コマンドを解析できず起票を照合できない。python3 が動くか、引用符が閉じているかを確認する"
   exit 0
 fi
 
-create_segment=""
-repo_segment=""
-while IFS= read -r -d '' segment; do
-  if [[ -z "$create_segment" ]] && [[ "$segment" =~ '^[[:space:]]*gh[[:space:]]+issue[[:space:]]+create([[:space:]]|$)' ]]; then
-    create_segment="$segment"
-  elif [[ -z "$repo_segment" ]] && [[ "$segment" =~ '^[[:space:]]*cd[[:space:]]' ]]; then
-    repo_segment="$segment"
-  fi
-done <<< "$segments"
+# `|| true` on each read: a value that is absent comes through as an empty line, and the
+# command substitution strips it along with the trailing newline, so the reads that follow
+# hit EOF and return 1, which would end the hook under `set -e`.
+{
+  read -r is_filing || true
+  read -r title || true
+  read -r body_file || true
+  read -r repo_dir || true
+} <<< "$(printf '%s' "$parsed" | jq -r '(.filing | tostring), (.title // ""), (.body_file // ""), (.repo_dir // "")')"
 
-if [[ -z "$create_segment" ]]; then
+if [[ "$is_filing" != "true" ]]; then
   exit 0
-fi
-
-# The flags are read out of the filing segment rather than the whole command, since a
-# `git commit` sharing the command line carries its own `--title`-looking text. `head -1`
-# guards a quoted argument holding a newline, where sed prints one match per line, and
-# `|| true` keeps the SIGPIPE that `head` sends from ending the hook under `set -o pipefail`.
-title=$(printf '%s\n' "$create_segment" | sed -nE 's/.*--title "(([^"\\]|\\.)*)".*/\1/p' | head -1) || true
-if [[ -z "$title" ]]; then
-  title=$(printf '%s\n' "$create_segment" | sed -nE "s/.*--title '([^']*)'.*/\1/p" | head -1) || true
 fi
 
 if [[ -z "$title" ]] || ! [[ "$title" =~ "^\[([A-Za-z]+)\]" ]]; then
@@ -115,12 +99,9 @@ issue_type="${match[1]:l}"
 # The repository's own template wins: that is what the web UI files against, and a CLI
 # filing that ignores it would leave two shapes of the same issue type in one tracker.
 # The command's own `cd` names the repository when there is one; otherwise this hook
-# already runs where the tool call would. A relative --body-file is read against the same
-# directory, so this has to be settled before the body file is resolved.
-repo_dir=$(printf '%s\n' "$repo_segment" | sed -nE 's/^[[:space:]]*cd[[:space:]]+([^ &;|]+).*/\1/p' | head -1) || true
+# already runs where the tool call would.
 [[ -z "$repo_dir" ]] && repo_dir="$PWD"
 
-body_file=$(printf '%s\n' "$create_segment" | sed -nE "s/.*--body-file[[:space:]]+('([^']*)'|\"([^\"]*)\"|([^ ]+)).*/\2\3\4/p" | head -1) || true
 if [[ -z "$body_file" ]]; then
   deny "issue-body-template: 本文が --body のインライン指定で骨格と照合できない。本文を一時ファイルへ書き --body-file にリテラルの絶対パスで渡す"
   exit 0

--- a/hooks/issue-body-template.sh
+++ b/hooks/issue-body-template.sh
@@ -44,10 +44,9 @@ if [[ -z "$command_str" ]]; then
 fi
 
 # `gh issue create` names a filing only where it leads a command. The same words turn up
-# inside commit messages (e7db3385 in this repository carries them) and inside a heredoc
-# body a message is written through, so telling a filing from a mention takes a scan that
-# knows where a token sits. The flags come out of the filing itself, since a `git commit`
-# sharing the line carries its own --title-looking text.
+# inside commit messages (e7db3385 carries them) and inside the heredoc body one is
+# written through. The flags come out of the filing itself, since a `git commit` sharing
+# the line carries its own --title-looking text.
 if ! parsed=$(printf '%s' "$command_str" | LIB_DIR="$SCRIPT_DIR/lib" python3 -c '
 import json
 import os

--- a/hooks/lib/command_scan.py
+++ b/hooks/lib/command_scan.py
@@ -10,9 +10,8 @@ import os
 import re
 import shlex
 
-# A wrapper hands execution to the command that follows it, so the caller wants that
-# one rather than the wrapper. Anything taking a subcommand of its own (git, npm) is
-# deliberately absent: there the first token is the command.
+# Anything taking a subcommand of its own (git, npm) stays out: there the first token
+# already is the command.
 WRAPPERS = frozenset({"sudo", "env", "time", "nice", "xargs", "command", "exec", "nohup"})
 
 # A wrapper flag that takes a value swallows the token after it, which would otherwise
@@ -24,10 +23,9 @@ EXEC_FLAGS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
 
 SEPARATORS = frozenset({";", "|", "||", "&&", "&", "\n"})
 
-# shlex counts a newline as whitespace, which would join the lines on either side of it
-# into one command. Swapping it for a punctuation character keeps it a token of its own,
-# while a newline inside quotes stays part of its token, so a multi-line commit message
-# holds together instead of failing to close.
+# Not left as whitespace, which shlex would drop and join the lines on either side into
+# one command. As punctuation the newline stays a token, while one inside quotes stays
+# part of its token, so a multi-line commit message holds together.
 _NEWLINE = "\x00"
 _PUNCTUATION = "();<>|&" + _NEWLINE
 
@@ -38,13 +36,11 @@ def _without_heredocs(text):
     """Drop heredoc bodies, keeping the lines that are commands.
 
     Newlines separate commands, so a body left in place turns each of its lines into a
-    command of its own. That is how a commit message written through `<< 'EOF'` came to
-    be read as a filing.
+    command of its own.
 
-    The closing line has to be found before anything is dropped. Running before shlex
-    means quoting is still unresolved here, so `-m 'see << EOF'` looks the same as a real
-    marker; without a closing line it is quoted text, and dropping the rest of the input
-    for it would hide every command that follows.
+    The closing line is found before anything is dropped. Quoting is still unresolved at
+    this point, so `-m 'see << EOF'` reads the same as a real marker; without a closing
+    line it is quoted text, and dropping the rest for it would hide the commands after it.
     """
     lines = text.split("\n")
     kept = []

--- a/hooks/lib/command_scan.py
+++ b/hooks/lib/command_scan.py
@@ -1,0 +1,108 @@
+"""Command-position scanning shared by the PreToolUse hooks.
+
+A hook that decides on a Bash call needs to know which commands the line runs and
+what a flag on one of them is set to. Both answers come from where a token sits,
+which a regex over the raw string cannot tell: `rm` inside a sed script is not a
+deletion, and `gh issue create` inside a commit message is not a filing.
+"""
+
+import os
+import re
+import shlex
+
+# A wrapper hands execution to the command that follows it, so the caller wants that
+# one rather than the wrapper. Anything taking a subcommand of its own (git, npm) is
+# deliberately absent: there the first token is the command.
+WRAPPERS = frozenset({"sudo", "env", "time", "nice", "xargs", "command", "exec", "nohup"})
+
+# A wrapper flag that takes a value swallows the token after it, which would otherwise
+# read as the command being wrapped (`sudo -u root rm x` would resolve to root).
+VALUED_WRAPPER_FLAGS = frozenset({"-u", "-g", "-p", "-n", "-P", "-I", "-d", "-s", "-a", "-E", "-C"})
+
+# find runs whatever follows these, so the scan continues past them inside one command.
+EXEC_FLAGS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
+
+SEPARATORS = frozenset({";", "|", "||", "&&", "&"})
+
+_HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
+
+
+def _without_heredocs(text):
+    """Drop heredoc bodies, keeping the lines that are commands.
+
+    Newlines separate commands, so a heredoc body left in place turns each of its
+    lines into one. That is how a commit message written through `<< 'EOF'` came to
+    be read as a filing.
+    """
+    kept, closing = [], None
+    for line in text.split("\n"):
+        if closing is not None:
+            if line.strip() == closing:
+                closing = None
+            continue
+        kept.append(line)
+        match = _HEREDOC.search(line)
+        if match:
+            closing = match.group(2)
+    return "\n".join(kept)
+
+
+def _tokens(line):
+    lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    return list(lexer)
+
+
+def commands(text):
+    """Yield each command as a token list, its first entry the executable name.
+
+    Raises ValueError on input shlex cannot close, which lets a fail-closed hook
+    deny rather than guess.
+    """
+    for line in _without_heredocs(text).split("\n"):
+        if not line.strip():
+            continue
+        current = []
+        for token in _tokens(line):
+            if token in SEPARATORS:
+                if current:
+                    yield from _resolve(current)
+                current = []
+                continue
+            current.append(token)
+        if current:
+            yield from _resolve(current)
+
+
+def _resolve(tokens):
+    """Emit the real command a token list runs, plus any it runs through -exec."""
+    index = 0
+    while index < len(tokens) and os.path.basename(tokens[index]) in WRAPPERS:
+        index += 1
+        while index < len(tokens) and tokens[index].startswith("-"):
+            index += 2 if tokens[index] in VALUED_WRAPPER_FLAGS else 1
+    if index >= len(tokens):
+        return
+    resolved = [os.path.basename(tokens[index])] + tokens[index + 1 :]
+    yield resolved
+
+    for position, token in enumerate(resolved):
+        if token in EXEC_FLAGS and position + 1 < len(resolved):
+            yield from _resolve(resolved[position + 1 :])
+            return
+
+
+def flag_value(tokens, flag):
+    """Return the value a flag carries, in either `--flag value` or `--flag=value`."""
+    prefix = flag + "="
+    for position, token in enumerate(tokens):
+        if token == flag:
+            return tokens[position + 1] if position + 1 < len(tokens) else None
+        if token.startswith(prefix):
+            return token[len(prefix) :]
+    return None
+
+
+def starts_with(tokens, prefix):
+    """Whether a command opens with the given token sequence."""
+    return len(tokens) >= len(prefix) and tokens[: len(prefix)] == list(prefix)

--- a/hooks/lib/command_scan.py
+++ b/hooks/lib/command_scan.py
@@ -22,7 +22,14 @@ VALUED_WRAPPER_FLAGS = frozenset({"-u", "-g", "-p", "-n", "-P", "-I", "-d", "-s"
 # find runs whatever follows these, so the scan continues past them inside one command.
 EXEC_FLAGS = frozenset({"-exec", "-execdir", "-ok", "-okdir"})
 
-SEPARATORS = frozenset({";", "|", "||", "&&", "&"})
+SEPARATORS = frozenset({";", "|", "||", "&&", "&", "\n"})
+
+# shlex counts a newline as whitespace, which would join the lines on either side of it
+# into one command. Swapping it for a punctuation character keeps it a token of its own,
+# while a newline inside quotes stays part of its token, so a multi-line commit message
+# holds together instead of failing to close.
+_NEWLINE = "\x00"
+_PUNCTUATION = "();<>|&" + _NEWLINE
 
 _HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
 
@@ -47,10 +54,10 @@ def _without_heredocs(text):
     return "\n".join(kept)
 
 
-def _tokens(line):
-    lexer = shlex.shlex(line, posix=True, punctuation_chars=True)
+def _tokens(text):
+    lexer = shlex.shlex(text.replace("\n", _NEWLINE), posix=True, punctuation_chars=_PUNCTUATION)
     lexer.whitespace_split = True
-    return list(lexer)
+    return [token.replace(_NEWLINE, "\n") for token in lexer]
 
 
 def commands(text):
@@ -59,19 +66,16 @@ def commands(text):
     Raises ValueError on input shlex cannot close, which lets a fail-closed hook
     deny rather than guess.
     """
-    for line in _without_heredocs(text).split("\n"):
-        if not line.strip():
+    current = []
+    for token in _tokens(_without_heredocs(text)):
+        if token in SEPARATORS:
+            if current:
+                yield from _resolve(current)
+            current = []
             continue
-        current = []
-        for token in _tokens(line):
-            if token in SEPARATORS:
-                if current:
-                    yield from _resolve(current)
-                current = []
-                continue
-            current.append(token)
-        if current:
-            yield from _resolve(current)
+        current.append(token)
+    if current:
+        yield from _resolve(current)
 
 
 def _resolve(tokens):

--- a/hooks/lib/command_scan.py
+++ b/hooks/lib/command_scan.py
@@ -37,20 +37,30 @@ _HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
 def _without_heredocs(text):
     """Drop heredoc bodies, keeping the lines that are commands.
 
-    Newlines separate commands, so a heredoc body left in place turns each of its
-    lines into one. That is how a commit message written through `<< 'EOF'` came to
+    Newlines separate commands, so a body left in place turns each of its lines into a
+    command of its own. That is how a commit message written through `<< 'EOF'` came to
     be read as a filing.
+
+    The closing line has to be found before anything is dropped. Running before shlex
+    means quoting is still unresolved here, so `-m 'see << EOF'` looks the same as a real
+    marker; without a closing line it is quoted text, and dropping the rest of the input
+    for it would hide every command that follows.
     """
-    kept, closing = [], None
-    for line in text.split("\n"):
-        if closing is not None:
-            if line.strip() == closing:
-                closing = None
-            continue
+    lines = text.split("\n")
+    kept = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
         kept.append(line)
+        index += 1
         match = _HEREDOC.search(line)
-        if match:
-            closing = match.group(2)
+        if not match:
+            continue
+        closing = match.group(2)
+        for end in range(index, len(lines)):
+            if lines[end].strip() == closing:
+                index = end + 1
+                break
     return "\n".join(kept)
 
 

--- a/hooks/security/rm-to-trash.sh
+++ b/hooks/security/rm-to-trash.sh
@@ -33,9 +33,8 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 0
 fi
 
-# Whether a token deletes anything depends on where it sits, which a regex over the raw
-# string cannot tell: it read the word inside a sed script as a deletion and let a
-# wrapped one (sudo, xargs, find -exec) through.
+# Not a regex over the raw string: it cannot tell where a token sits, so the word inside
+# a sed script read as a deletion while a wrapped one (sudo, xargs, find -exec) did not.
 if printf '%s' "$COMMAND" | LIB_DIR="$SCRIPT_DIR/../lib" python3 -c '
 import os
 import sys

--- a/hooks/security/rm-to-trash.sh
+++ b/hooks/security/rm-to-trash.sh
@@ -4,9 +4,21 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+deny() {
+  jq -n --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+}
+
 INPUT=$(cat)
 
-# Fast-exit: skip jq fork unless input mentions a destructive keyword
+# Fast-exit: skip the jq and python forks unless input mentions a destructive keyword
 case "$INPUT" in
   *rm*|*unlink*|*shred*) ;;
   *) exit 0 ;;
@@ -16,14 +28,27 @@ command -v jq >/dev/null 2>&1 || exit 0
 
 COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
 
-# Match rm/rmdir/unlink/shred at line start or after shell separators
-if printf '%s' "$COMMAND" | grep -qE '(^|[;&|`$(]|&&|\|\|)[[:space:]]*(rm|rmdir|unlink|shred)([[:space:]]|$)'; then
-  REASON="rm-to-trash: 削除は \`mv <file> ~/.Trash/ && git add <file>\` を使う。sandbox が \`mv ~/.Trash/\` を弾いたら dangerouslyDisableSandbox: true でリトライし、他の sandbox エラーはユーザーに報告する。"
-  jq -n --arg reason "$REASON" '{
-    hookSpecificOutput: {
-      hookEventName: "PreToolUse",
-      permissionDecision: "deny",
-      permissionDecisionReason: $reason
-    }
-  }'
+if ! command -v python3 >/dev/null 2>&1; then
+  deny "rm-to-trash: python3 が無くコマンドを解析できず、削除かどうかを判定できない。python3 を用意する"
+  exit 0
+fi
+
+# Whether a token deletes anything depends on where it sits, which a regex over the raw
+# string cannot tell: it read the word inside a sed script as a deletion and let a
+# wrapped one (sudo, xargs, find -exec) through.
+if printf '%s' "$COMMAND" | LIB_DIR="$SCRIPT_DIR/../lib" python3 -c '
+import os
+import sys
+
+sys.path.insert(0, os.environ["LIB_DIR"])
+import command_scan
+
+DESTRUCTIVE = {"rm", "rmdir", "unlink", "shred"}
+try:
+    hit = any(c[0] in DESTRUCTIVE for c in command_scan.commands(sys.stdin.read()))
+except ValueError:
+    hit = True  # an unparsable line hides where its commands are, so it is not cleared
+sys.exit(0 if hit else 1)
+'; then
+  deny "rm-to-trash: 削除は \`mv <file> ~/.Trash/ && git add <file>\` を使う。sandbox が \`mv ~/.Trash/\` を弾いたら dangerouslyDisableSandbox: true でリトライし、他の sandbox エラーはユーザーに報告する。"
 fi

--- a/hooks/tests/issue-body-template.test.js
+++ b/hooks/tests/issue-body-template.test.js
@@ -287,7 +287,7 @@ test("T-015 コマンドを分割できないときは骨格に沿う本文で�
     const broken = join(dir, "broken.sh");
     const prepared = spawnSync("sh", [
       "-c",
-      `sed "s/| python3 -c/| nonexistent-python3 -c/" ${hook} > ${broken} && chmod +x ${broken}`,
+      `sed "s/python3 -c/nonexistent-python3 -c/" ${hook} > ${broken} && chmod +x ${broken}`,
     ]);
     assert.equal(prepared.status, 0, `複製の用意が成功する (実際: ${prepared.stderr})`);
 
@@ -307,6 +307,25 @@ test("T-015 コマンドを分割できないときは骨格に沿う本文で�
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test("T-024 heredoc の本文に起票コマンドの語があっても deny しない", () => {
+  // コミットメッセージを heredoc で渡すと本文の各行がコマンド列として走査され、
+  // 行頭が gh issue create になる行を持つ git commit が止められていた。
+  const command = [
+    "cat > /tmp/claude/msg.txt << 'EOF'",
+    "fix(hooks): 何かを直す",
+    "",
+    "gh issue create --title x を本文で説明している行",
+    "EOF",
+    "git commit -F /tmp/claude/msg.txt",
+  ].join("\n");
+  const { stdout } = runHook(command);
+  assert.equal(
+    stdout.trim(),
+    "",
+    `heredoc 本文の起票語では何も返さない (実際: ${JSON.stringify(stdout)})`,
+  );
 });
 
 test("T-016 骨格の無い型のタイトルは照合できないため deny する", () => {

--- a/hooks/tests/test-rm-to-trash.sh
+++ b/hooks/tests/test-rm-to-trash.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Integration tests for security/rm-to-trash.sh (PreToolUse hook)
+# The hook is exec'd directly (shebang zsh) — running it under bash masks
+# zsh-specific behavior
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+HOOK="$SCRIPT_DIR/../security/rm-to-trash.sh"
+
+# The value alone, so the assertion survives jq switching between -c and pretty output.
+DENY_MARK='"deny"'
+
+# The rows come from the matrix measured in #349, where the regex answered 4 of 11.
+assert_denied() {
+  local name="$1" cmd="$2" output
+  output=$(make_bash_json "$cmd" | "$HOOK" 2>/dev/null) || true
+  assert_contains "$name" "$DENY_MARK" "$output"
+}
+
+assert_allowed() {
+  local name="$1" cmd="$2" output
+  output=$(make_bash_json "$cmd" | "$HOOK" 2>/dev/null) || true
+  assert_not_contains "$name" "$DENY_MARK" "$output"
+}
+
+test_direct_deletion() {
+  echo "T-001: コマンド先頭の削除は止める"
+  assert_denied "bare deletion" 'rm -rf /tmp/x'
+  assert_denied "rmdir" 'rmdir /tmp/x'
+  assert_denied "unlink" 'unlink /tmp/x'
+  assert_denied "shred" 'shred /tmp/x'
+}
+
+test_second_line_deletion() {
+  echo "T-002: 2 行目以降に置かれた削除も止める"
+  assert_denied "after a newline" 'cd /tmp
+rm -rf x'
+}
+
+test_wrapped_deletion() {
+  echo "T-003: ラッパー語ごしの削除も止める"
+  # 現行の正規表現はこの 4 行をすべて通していた。1 語挟むだけでコマンド先頭でなくなる。
+  assert_denied "sudo" 'sudo rm -rf /tmp/x'
+  assert_denied "env" 'env rm /tmp/x'
+  assert_denied "time" 'time rm -rf /tmp/x'
+  assert_denied "absolute path" '/bin/rm -rf /tmp/x'
+}
+
+test_indirect_deletion() {
+  echo "T-004: find と xargs 経由の削除も止める"
+  assert_denied "find -exec" 'find . -name "*.tmp" -exec rm {} \;'
+  assert_denied "xargs" 'find . -print0 | xargs -0 rm'
+}
+
+test_quoted_text_is_not_a_deletion() {
+  echo "T-005: 引用符の内側にある語は削除として扱わない"
+  # sed の置換パターンを削除と誤判定して、無関係な編集を止めていた。
+  assert_allowed "sed script" "sed -i '' 's|rm -rf x|y|g' f"
+  assert_allowed "commit message" "git commit -m 'remove rm calls from the test'"
+  assert_allowed "echoed text" "echo 'rm -rf danger' > note.txt"
+}
+
+test_heredoc_body_is_not_a_deletion() {
+  echo "T-006: heredoc の本文にある削除語では止めない"
+  assert_allowed "heredoc body" 'cat > /tmp/m.txt << '"'"'EOF'"'"'
+rm -rf /tmp/x
+EOF
+git commit -F /tmp/m.txt'
+}
+
+test_unparsable_input_is_denied() {
+  echo "T-007: 解析できないコマンドは止める側へ倒す"
+  # 閉じない引用符では、どこがコマンド位置なのか決められない。security hook なので
+  # 判断できないときは通さない。
+  assert_denied "unterminated quote" 'rm -rf "/tmp/x'
+}
+
+test_unrelated_command_skipped() {
+  echo "T-008: 削除語を含まないコマンドは何も返さない"
+  local output
+  output=$(make_bash_json 'git status' | "$HOOK" 2>/dev/null) || true
+  assert_empty "no output for git status" "$output"
+}
+
+echo "=== rm-to-trash.sh tests ==="
+test_direct_deletion
+test_second_line_deletion
+test_wrapped_deletion
+test_indirect_deletion
+test_quoted_text_is_not_a_deletion
+test_heredoc_body_is_not_a_deletion
+test_unparsable_input_is_denied
+test_unrelated_command_skipped
+
+report_results

--- a/hooks/tests/test-rm-to-trash.sh
+++ b/hooks/tests/test-rm-to-trash.sh
@@ -11,7 +11,7 @@ HOOK="$SCRIPT_DIR/../security/rm-to-trash.sh"
 # The value alone, so the assertion survives jq switching between -c and pretty output.
 DENY_MARK='"deny"'
 
-# The rows come from the matrix measured in #349, where the regex answered 4 of 11.
+# The rows come from the matrix measured in #349.
 assert_denied() {
   local name="$1" cmd="$2" output
   output=$(make_bash_json "$cmd" | "$HOOK" 2>/dev/null) || true
@@ -40,7 +40,6 @@ rm -rf x'
 
 test_wrapped_deletion() {
   echo "T-003: ラッパー語ごしの削除も止める"
-  # 現行の正規表現はこの 4 行をすべて通していた。1 語挟むだけでコマンド先頭でなくなる。
   assert_denied "sudo" 'sudo rm -rf /tmp/x'
   assert_denied "env" 'env rm /tmp/x'
   assert_denied "time" 'time rm -rf /tmp/x'
@@ -55,7 +54,6 @@ test_indirect_deletion() {
 
 test_quoted_text_is_not_a_deletion() {
   echo "T-005: 引用符の内側にある語は削除として扱わない"
-  # sed の置換パターンを削除と誤判定して、無関係な編集を止めていた。
   assert_allowed "sed script" "sed -i '' 's|rm -rf x|y|g' f"
   assert_allowed "commit message" "git commit -m 'remove rm calls from the test'"
   assert_allowed "echoed text" "echo 'rm -rf danger' > note.txt"

--- a/hooks/tests/test_command_scan.py
+++ b/hooks/tests/test_command_scan.py
@@ -35,6 +35,13 @@ class TestCommands(unittest.TestCase):
         text = "cat <<-END\nrm -rf /\nEND\necho done"
         self.assertEqual(self.names(text), ["cat", "echo"])
 
+    def test_quotes_spanning_lines_hold_together(self):
+        """T-015 引用符が行をまたいでも 1 トークンにまとめる"""
+        # 複数行のコミットメッセージがこの形。行ごとに切ってから字句解析すると、
+        # どの行でも引用符が閉じず解析不能になる。
+        text = "git commit -m 'fix: 1 行目\n\ngh issue create を本文で説明する行'"
+        self.assertEqual(self.names(text), ["git"])
+
     def test_quoted_text_is_not_a_command(self):
         """T-005 引用符の内側にある語はコマンド位置に立たない"""
         self.assertEqual(self.names("git commit -m 'remove rm calls'"), ["git"])

--- a/hooks/tests/test_command_scan.py
+++ b/hooks/tests/test_command_scan.py
@@ -35,6 +35,12 @@ class TestCommands(unittest.TestCase):
         text = "cat <<-END\nrm -rf /\nEND\necho done"
         self.assertEqual(self.names(text), ["cat", "echo"])
 
+    def test_marker_without_a_closing_line_is_not_a_heredoc(self):
+        """T-016 終端行の無い << は引用符の中の語なので、後続の行を落とさない"""
+        # 落としてしまうと、この後に続く削除がスキャンに届かず security hook が素通しする。
+        self.assertEqual(self.names("git commit -m 'see << EOF\nfor details'\nrm -rf x"), ["git", "rm"])
+        self.assertEqual(self.names("echo '<< END'\nrm -rf x"), ["echo", "rm"])
+
     def test_quotes_spanning_lines_hold_together(self):
         """T-015 引用符が行をまたいでも 1 トークンにまとめる"""
         # 複数行のコミットメッセージがこの形。行ごとに切ってから字句解析すると、

--- a/hooks/tests/test_command_scan.py
+++ b/hooks/tests/test_command_scan.py
@@ -1,0 +1,96 @@
+"""Tests for hooks/lib/command_scan.py.
+
+Run: python3 hooks/tests/test_command_scan.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+
+import command_scan  # noqa: E402
+
+
+class TestCommands(unittest.TestCase):
+    def names(self, text):
+        return [c[0] for c in command_scan.commands(text)]
+
+    def test_splits_on_separators(self):
+        """T-001 セパレータごとに 1 コマンドへ切る"""
+        self.assertEqual(self.names("cd /tmp && rm -rf x"), ["cd", "rm"])
+        self.assertEqual(self.names("a; b | c"), ["a", "b", "c"])
+
+    def test_newline_is_a_separator(self):
+        """T-002 改行もコマンドの区切りとして数える"""
+        self.assertEqual(self.names("cd /tmp\nrm -rf x"), ["cd", "rm"])
+
+    def test_heredoc_body_is_not_scanned(self):
+        """T-003 heredoc の本文はコマンド列として読まない"""
+        text = "cat > /tmp/m.txt << 'EOF'\ngh issue create --title x\nEOF\ngit commit -F /tmp/m.txt"
+        self.assertEqual(self.names(text), ["cat", "git"])
+
+    def test_heredoc_with_dash_and_bare_delimiter(self):
+        """T-004 <<- と引用符なしのデリミタも本文として読み飛ばす"""
+        text = "cat <<-END\nrm -rf /\nEND\necho done"
+        self.assertEqual(self.names(text), ["cat", "echo"])
+
+    def test_quoted_text_is_not_a_command(self):
+        """T-005 引用符の内側にある語はコマンド位置に立たない"""
+        self.assertEqual(self.names("git commit -m 'remove rm calls'"), ["git"])
+        self.assertEqual(self.names("sed -i '' 's|rm -rf x|y|g' f"), ["sed"])
+
+    def test_wrappers_are_transparent(self):
+        """T-006 ラッパー語は透過して、その先の実コマンドを返す"""
+        self.assertEqual(self.names("sudo rm -rf /tmp/x"), ["rm"])
+        self.assertEqual(self.names("env rm /tmp/x"), ["rm"])
+        self.assertEqual(self.names("time rm -rf /tmp/x"), ["rm"])
+
+    def test_wrapper_flags_are_skipped(self):
+        """T-007 ラッパー語とコマンドの間のフラグを飛ばす"""
+        self.assertEqual(self.names("find . -print0 | xargs -0 rm"), ["find", "rm"])
+        self.assertEqual(self.names("sudo -u root rm x"), ["rm"])
+
+    def test_path_reduces_to_basename(self):
+        """T-008 絶対パスで書かれても実行ファイル名で返す"""
+        self.assertEqual(self.names("/bin/rm -rf /tmp/x"), ["rm"])
+
+    def test_find_exec_runs_a_command(self):
+        """T-009 find の -exec と -execdir が指す先もコマンドとして数える"""
+        self.assertEqual(self.names("find . -name '*.tmp' -exec rm {} \\;"), ["find", "rm"])
+        self.assertEqual(self.names("find . -execdir rm {} +"), ["find", "rm"])
+
+    def test_unparsable_input_raises(self):
+        """T-010 閉じない引用符は例外にする。呼び出し側が fail-closed を選べる"""
+        with self.assertRaises(ValueError):
+            list(command_scan.commands("echo 'unterminated"))
+
+
+class TestFlagValue(unittest.TestCase):
+    def test_reads_the_value_after_a_flag(self):
+        """T-011 フラグの次のトークンを値として返す"""
+        tokens = ["gh", "issue", "create", "--title", "[Bug] x", "--body-file", "/tmp/b.md"]
+        self.assertEqual(command_scan.flag_value(tokens, "--title"), "[Bug] x")
+        self.assertEqual(command_scan.flag_value(tokens, "--body-file"), "/tmp/b.md")
+
+    def test_reads_an_equals_form(self):
+        """T-012 --flag=value の形も読む"""
+        self.assertEqual(command_scan.flag_value(["gh", "--title=x"], "--title"), "x")
+
+    def test_returns_none_when_absent(self):
+        """T-013 フラグが無いときと値が続かないときは None"""
+        self.assertIsNone(command_scan.flag_value(["gh", "issue", "create"], "--title"))
+        self.assertIsNone(command_scan.flag_value(["gh", "--title"], "--title"))
+
+
+class TestStartsWith(unittest.TestCase):
+    def test_matches_a_leading_token_sequence(self):
+        """T-014 先頭のトークン列で照合する"""
+        cmd = ["gh", "issue", "create", "--title", "x"]
+        self.assertTrue(command_scan.starts_with(cmd, ["gh", "issue", "create"]))
+        self.assertFalse(command_scan.starts_with(cmd, ["gh", "pr", "create"]))
+        self.assertFalse(command_scan.starts_with(["gh", "issue"], ["gh", "issue", "create"]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What & Why

2 つの hook が、コマンド文字列に語が含まれるかどうかで判断していた。語がどの位置にあるかを正規表現は答えられないため、sed の置換パターンに入った削除語を削除と読み、heredoc に書いたコミットメッセージの行を起票と読んだ。どちらも今日 1 セッションで作業を止めている。

`hooks/lib/command_scan.py` が shlex で位置を答える。#349 で実測した 11 行と #350 の heredoc ケースを合わせた 12 パターンで、置き換え前の正規表現が 4 正解だったのに対し 12 正解になる。

## Review focus

- `command_scan._without_heredocs` の先読み。ここを誤ると security hook が素通しする
- `rm-to-trash` の解析不能時の扱い。引用符が閉じないコマンドは deny へ倒す
- `issue-body-template` から sed 抽出が 4 箇所消えた部分

## Changes

- `command_scan.py` を追加した。heredoc 本文の除去、改行を区切りとする分割、ラッパー語 (sudo, env, time, xargs) の透過、`find -exec` の追跡をする
- `rm-to-trash` を載せ替えた。このファイルにはテストが無かったので、#349 の表を 17 assertion のテストにした
- `issue-body-template` の手書きスキャナと sed 抽出を置き換えた。heredoc の回帰テスト (T-024) を追加した

## Scope

- Not included: `textlint-lint`、`auto-package-manager`、`npm-safe-install`。先頭トークンの前方一致で足り、位置の解析を必要としない
- Not included: `git clean` や `truncate` など、これまで対象にしていない破壊的コマンド

## Design Decisions

- heredoc の除去は終端行を先読みしてから行う。shlex の前段では引用符が未解決で、`-m 'see << EOF'` が本物のマーカーと区別できない。先読みせずに落とすと、後続の削除がスキャンに届かず素通しする
- heredoc をトークン列の側で扱う案は取らなかった。本文中のアポストロフィで shlex が引用符を閉じられず、解析全体が失敗する
- 改行は punctuation として字句解析に渡す。行ごとに切ってから解析すると、複数行のコミットメッセージで引用符が閉じない

## How to Test

1. `python3 hooks/tests/test_command_scan.py` を実行する。16 tests OK で終わる
2. `bash hooks/tests/test-rm-to-trash.sh` を実行する。17 passed で終わる
3. `node --test "hooks/tests/**/*.test.js"` を実行する。13 passed で終わる

`test_command_scan.py` はどの一括実行にも拾われない。`node --test` のグロブは `.test.js` だけを見て、`.sh` のスイートはファイル名を直接指定して走らせている。CI にもテスト実行の workflow は無い。手で叩かないと走らない状態が残る。

計測は次のとおり。`rm-to-trash` は削除語を含む行で 6.0ms から 42.3ms になる。含まない行は fast-exit のままで変わらない。`issue-body-template` は 47.1ms で、置き換え前から python3 を fork していたため増分はほぼ無い。

## Related

- Closes #349
- Closes #350
