### PR TITLE
python テストの命名を既存 6 件に揃える

### DIFF
--- a/hooks/tests/command_scan_test.py
+++ b/hooks/tests/command_scan_test.py
@@ -1,6 +1,6 @@
 """Tests for hooks/lib/command_scan.py.
 
-Run: python3 hooks/tests/test_command_scan.py
+Run: python3 hooks/tests/command_scan_test.py
 """
 
 import sys


### PR DESCRIPTION
## What & Why

python テストの命名がこの repository で 1 件だけ割れていた。既存 6 件は `*_test.py` で終わり、昨日追加した 1 件だけが `test_` で始まる。差は見た目でなく、`python3 -m unittest discover -s <dir> -p "*_test.py"` がディレクトリ単位の実行方法として使われており、6 件を拾って 7 件目を飛ばす。

## Review focus

- リネームのみ。中身の差分は docstring の実行例 1 行

## How to Test

1. `python3 hooks/tests/command_scan_test.py` を実行する。16 tests OK で終わる
2. `python3 -m unittest discover -s hooks/tests -p "*_test.py"` を実行する。OK で終わる。リネーム前はこのコマンドが 0 件だった

## Related

- #352 で CI のテスト実行を扱う。この PR はその前提となる命名の統一
