### PR TITLE
push と PR でテストを実行する CI を足す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
-          # Nothing here pushes, and a token left in .git/config travels with anything
-          # uploaded from the workspace.
+          # Nothing here pushes, and a token left in .git/config travels with an upload.
           persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -24,9 +23,8 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
-      # The tests exec the hooks directly and every hook opens with a zsh shebang, so bash
-      # alone cannot run them. has_japanese greps under en_US.UTF-8, which ubuntu-latest
-      # does not generate by default.
+      # The tests exec the hooks directly and each opens with a zsh shebang. has_japanese
+      # greps under en_US.UTF-8, which this image does not generate.
       - name: Install zsh and generate the locale
         run: |
           sudo apt-get update
@@ -46,8 +44,8 @@ jobs:
           "skills/**/tests/*.test.js"
           "workflows/**/tests/*.test.js"
 
-      # Discovery cannot recurse from the repository root: the test directories are not
-      # packages. Listing the files keeps new ones from being missed as they are added.
+      # Not unittest discovery: it cannot recurse from the root, where the test
+      # directories are not packages.
       - name: Python tests
         run: find agents hooks skills workflows -name '*_test.py' -print0 | xargs -0 -r -n1 python3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,60 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # Nothing here pushes, and a token left in .git/config travels with anything
+          # uploaded from the workspace.
+          persist-credentials: false
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      # The tests exec the hooks directly and every hook opens with a zsh shebang, so bash
+      # alone cannot run them. has_japanese greps under en_US.UTF-8, which ubuntu-latest
+      # does not generate by default.
+      - name: Install zsh and generate the locale
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zsh locales
+          sudo locale-gen en_US.UTF-8
+
+      # node_modules is not tracked; the lockfile is.
+      - name: Install textlint
+        working-directory: hooks/textlint
+        run: bun install --frozen-lockfile
+
+      - name: Node tests
+        run: >
+          node --test
+          "agents/**/tests/*.test.js"
+          "hooks/tests/*.test.js"
+          "skills/**/tests/*.test.js"
+          "workflows/**/tests/*.test.js"
+
+      # Discovery cannot recurse from the repository root: the test directories are not
+      # packages. Listing the files keeps new ones from being missed as they are added.
+      - name: Python tests
+        run: find agents hooks skills workflows -name '*_test.py' -print0 | xargs -0 -r -n1 python3
+
+      - name: Shell tests
+        run: |
+          for suite in hooks/tests/test-*.sh; do
+            case "$suite" in */test-helpers.sh) continue ;; esac
+            echo "--- $suite"
+            bash "$suite"
+          done

--- a/hooks/lib/notify.sh
+++ b/hooks/lib/notify.sh
@@ -1,6 +1,8 @@
 #!/bin/zsh
 
-SOUNDS_DIR="$HOME/.claude/sounds"
+# ${(%):-%x} is this file's own path. $0 names the caller in a sourced file, and
+# $HOME/.claude names only the installed harness, not a checkout run from elsewhere.
+SOUNDS_DIR="${${(%):-%x}:A:h:h:h}/sounds"
 
 play_sound() {
   local file="$SOUNDS_DIR/$1" vol="${2:-0.1}"

--- a/hooks/notify-stop-failure.sh
+++ b/hooks/notify-stop-failure.sh
@@ -4,7 +4,8 @@
 set +e
 
 command -v jq &>/dev/null || exit 0
-source "$HOME/.claude/hooks/lib/notify.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/notify.sh"
 
 play_sound "DHVMagellanHorn_Heavy.mp3"
 

--- a/hooks/notify-stop.sh
+++ b/hooks/notify-stop.sh
@@ -6,7 +6,8 @@
 set +e
 
 [[ -n "${CLAUDE_CODE_IS_SUBAGENT:-}" ]] && exit 0
-source "$HOME/.claude/hooks/lib/notify.sh"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/notify.sh"
 
 INPUT=$(cat)
 

--- a/hooks/textlint-fix.sh
+++ b/hooks/textlint-fix.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/japanese-detect.sh"
 
-# Resolved from this script's own location rather than $HOME/.claude: the tests run the
-# hook out of a checkout wherever CI places it, and a fixed path finds no config there.
+# Not $HOME/.claude, which names the installed harness alone: a checkout run from
+# anywhere else finds no config there.
 TEXTLINT_DIR="$SCRIPT_DIR/textlint"
 TEXTLINT_CONFIG="$TEXTLINT_DIR/.textlintrc.json"
 

--- a/hooks/textlint-fix.sh
+++ b/hooks/textlint-fix.sh
@@ -3,11 +3,13 @@
 # Triggered on Write/Edit/MultiEdit for markdown files
 set -euo pipefail
 
-TEXTLINT_DIR="$HOME/.claude/hooks/textlint"
-TEXTLINT_CONFIG="$TEXTLINT_DIR/.textlintrc.json"
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/japanese-detect.sh"
+
+# Resolved from this script's own location rather than $HOME/.claude: the tests run the
+# hook out of a checkout wherever CI places it, and a fixed path finds no config there.
+TEXTLINT_DIR="$SCRIPT_DIR/textlint"
+TEXTLINT_CONFIG="$TEXTLINT_DIR/.textlintrc.json"
 
 input=$(cat)
 

--- a/hooks/textlint-lint.sh
+++ b/hooks/textlint-lint.sh
@@ -3,9 +3,6 @@
 # Returns the findings as additionalContext; checklist is issue/pr only
 set -euo pipefail
 
-TEXTLINT_DIR="$HOME/.claude/hooks/textlint"
-TEXTLINT_CONFIG="$TEXTLINT_DIR/.textlintrc.json"
-
 # Not a top-level decision / additionalContext pair: PreToolUse reads context only out of
 # hookSpecificOutput, so findings written at that level reach no one.
 advise() {
@@ -19,6 +16,11 @@ advise() {
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/japanese-detect.sh"
+
+# Resolved from this script's own location rather than $HOME/.claude: the tests run the
+# hook out of a checkout wherever CI places it, and a fixed path finds no config there.
+TEXTLINT_DIR="$SCRIPT_DIR/textlint"
+TEXTLINT_CONFIG="$TEXTLINT_DIR/.textlintrc.json"
 
 # $'...', not '...': jq --arg passes the string through as written, so an unexpanded `\n`
 # arrives as two characters and collapses the table into one line.

--- a/hooks/textlint-lint.sh
+++ b/hooks/textlint-lint.sh
@@ -17,8 +17,8 @@ advise() {
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 source "$SCRIPT_DIR/lib/japanese-detect.sh"
 
-# Resolved from this script's own location rather than $HOME/.claude: the tests run the
-# hook out of a checkout wherever CI places it, and a fixed path finds no config there.
+# Not $HOME/.claude, which names the installed harness alone: a checkout run from
+# anywhere else finds no config there.
 TEXTLINT_DIR="$SCRIPT_DIR/textlint"
 TEXTLINT_CONFIG="$TEXTLINT_DIR/.textlintrc.json"
 


### PR DESCRIPTION
## What & Why

壊れたテストを含む PR がマージされても何も反対しなかった。テストは 3 つのコマンドで全て走るが、どれを走らせるかは毎回作業者の判断に委ねられていた。OUTCOME の Behavior は agent が迂回できないゲートを求めている。

CI を足した最初の実行が、hook 5 つのパス依存を検出した。ローカルでは展開先が `~/.claude` と一致するため通り、別の場所から走らせて初めて壊れる。CI が無かったから見えなかった欠陥で、この issue が解こうとした状態そのものになった。

## Review focus

- ubuntu-latest に足している 2 つ。zsh と en_US.UTF-8 ロケール
- `hooks/lib/notify.sh` が自身のパスを `${(%):-%x}` で取る部分。source される側では `$0` が呼び出し元を指す
- python テストの列挙。`find` で拾い、ファイルが増えても取りこぼさない

## Changes

- `.github/workflows/test.yml` を追加した。node 314 assertion、python 7 ファイル、shell 3 スイートを走らせる
- textlint hook 2 つが `$HOME/.claude/hooks/textlint` から設定を読んでいたのを、スクリプト自身の位置からに変えた。CI の 1 回目はこれで 3 assertion が落ちた
- notify hook 3 つが同じ形の固定パスを持っていた。こちらは失敗しても exit 0 で返るため、通知が鳴らなくなっても何も出ない
- action を SHA でピン留めし、checkout の `persist-credentials` を false にした。zizmor の指摘に従う

## Scope

- Not included: `plugins/` 配下のテスト。外部から取得した資材
- Not included: `lifecycle/statusline.sh` の `$HOME/.claude/cache` と `BACKLOG.md`。こちらはユーザーのデータの置き場所で、`$HOME` が正しい
- Not included: 既存の `label-from-issue.yml`。zizmor がパースできず、別の作業単位になる

## Design Decisions

- python は `find` でファイルを渡す。リポジトリ全体を対象にした `unittest discover` はパッケージ構造が無いため 0 件になり、ディレクトリ列挙はテストが増えたとき更新を忘れる
- textlint は lockfile から入れる。`hooks/textlint/node_modules` は git 管理外で、`package.json` と `bun.lock` だけが追跡されている
- notify hook の修正はテストを伴わない。音声再生を CI で検証する手段が無く、別の HOME で実行して `play_sound` が定義されることを手で確かめた

## How to Test

1. この PR の Actions で Test job が通ることを確認する
2. `HOME=/tmp/other zsh hooks/notify-stop.sh < /dev/null` を実行する。`command not found` が出ない

## Related

- Closes #352
