### PR TITLE
reference module の files をパスのみに揃える

### DIFF
--- a/.ja/skills/think/templates/plan.md
+++ b/.ja/skills/think/templates/plan.md
@@ -21,7 +21,7 @@ reference_module: {kind + reason を object で (kind: module/no-module/new-shap
 
 - path: {複製元を一意に指す path 1 つ (`src/foo/`)。下の files はその配下に並ぶ}
 - instances: {この形を既に共有する既存機能の数。2 以上なら「N 例目」と書く}
-- files: {複製する各ファイルのパスのみ (`src/foo/list.tsx`, `src/foo/detail.tsx`)。役割の説明は conventions へ書く。build の Revalidate がこの各要素をパスとして実在確認するため、説明が混ざると plan-drift で止まる}
+- files: {複製する各ファイルのパスのみ (`src/foo/list.tsx`, `src/foo/detail.tsx`)。役割は conventions へ書く}
 - conventions: {後続 unit が維持する共有慣例 (合成する共有コンポーネント、フォーマット処理の置き場所、状態の渡し方)}
 
 ### 前提

--- a/.ja/skills/think/templates/plan.md
+++ b/.ja/skills/think/templates/plan.md
@@ -21,7 +21,7 @@ reference_module: {kind + reason を object で (kind: module/no-module/new-shap
 
 - path: {複製元を一意に指す path 1 つ (`src/foo/`)。下の files はその配下に並ぶ}
 - instances: {この形を既に共有する既存機能の数。2 以上なら「N 例目」と書く}
-- files: {複製する各ファイルとその役割 (`src/foo/list.tsx` 一覧画面)}
+- files: {複製する各ファイルのパスのみ (`src/foo/list.tsx`, `src/foo/detail.tsx`)。役割の説明は conventions へ書く。build の Revalidate がこの各要素をパスとして実在確認するため、説明が混ざると plan-drift で止まる}
 - conventions: {後続 unit が維持する共有慣例 (合成する共有コンポーネント、フォーマット処理の置き場所、状態の渡し方)}
 
 ### 前提

--- a/skills/think/templates/plan.md
+++ b/skills/think/templates/plan.md
@@ -21,7 +21,7 @@ reference_module: {kind + reason as an object (kind: module/no-module/new-shape)
 
 - path: {the one path that identifies the module to replicate (`src/foo/`); the files below sit under it}
 - instances: {how many existing features already share this shape; say "Nth instance" when 2 or more}
-- files: {each file to replicate, with its role (`src/foo/list.tsx` list screen)}
+- files: {path only, one per file (`src/foo/list.tsx`, `src/foo/detail.tsx`). Roles go in conventions. build's Revalidate checks each entry as a path, so a description mixed in stops the run as plan-drift}
 - conventions: {shared conventions later units must keep (composed components, where formatting lives, how state is passed)}
 
 ### Preconditions

--- a/skills/think/templates/plan.md
+++ b/skills/think/templates/plan.md
@@ -21,7 +21,7 @@ reference_module: {kind + reason as an object (kind: module/no-module/new-shape)
 
 - path: {the one path that identifies the module to replicate (`src/foo/`); the files below sit under it}
 - instances: {how many existing features already share this shape; say "Nth instance" when 2 or more}
-- files: {path only, one per file (`src/foo/list.tsx`, `src/foo/detail.tsx`). Roles go in conventions. build's Revalidate checks each entry as a path, so a description mixed in stops the run as plan-drift}
+- files: {path only, one per file (`src/foo/list.tsx`, `src/foo/detail.tsx`). Roles go in conventions}
 - conventions: {shared conventions later units must keep (composed components, where formatting lives, how state is passed)}
 
 ### Preconditions

--- a/skills/think/tests/plan-draft.test.js
+++ b/skills/think/tests/plan-draft.test.js
@@ -89,6 +89,18 @@ test("think SKILL.md の contract authoring 規則が選択 (引用ラダー) �
   assert.match(en, /SOURCING/, "en: SOURCING.md の規律参照");
 });
 
+test("各言語のテンプレートが reference module の files をパスのみと指示する", () => {
+  // build の Revalidate は files の各要素をそのままパスとして実在確認する
+  // (workflows/build.js の refModuleEntries)。役割の説明が混ざると plan-drift で止まる。
+  for (const [lang, path] of Object.entries(templates)) {
+    const line = read(path)
+      .split("\n")
+      .find((l) => l.startsWith("- files:") && l.includes("list.tsx"));
+    assert.ok(line, `${lang}: reference module の files 行がある`);
+    assert.match(line, /パスのみ|path only/, `${lang}: files 行がパスのみと指示する`);
+  }
+});
+
 test("各言語のテンプレートが reference_module を kind と理由の形で示す", () => {
   for (const [lang, path] of Object.entries(templates)) {
     const doc = read(path);


### PR DESCRIPTION
## What & Why

`/think` のテンプレートが reference module の `files` に「各ファイルとその役割」を書けと指示する一方、`workflows/build.js:474-479` は同じ配列の各要素をそのままパスとして実在確認する。テンプレートどおりに書いた plan は Revalidate で必ず `plan-drift` に落ちる。

#342 を build workflow に渡して実際に踏んだ。journal で確認したところ、extract は `path` を正しく剥がしつつ `files` には本文の行をバッククォートと説明ごと入れていた。

## Review focus

- テンプレートの `files` 行。役割を落とし、行き先を `conventions` と明示した部分
- 追加したテスト。テンプレートを元に戻すと落ちることを確認済み

## Changes

- `.ja` と英語のテンプレートで、reference module の `files` をパスのみに変えた
- `plan-draft.test.js` に、両言語のテンプレートがパスのみを指示することの確認を足した

## Scope

- Not included: extract プロンプトへの変換指示。extract の責務は本文の忠実なコピーで、そこに変換を入れると本文と抽出結果が食い違う経路が別に生まれる
- Not included: `Revalidate` 側でパスを抽出する案。本文の自由度は保てるが、抽出規則が増える

## Design Decisions

- 直す先をテンプレートにした。`units[].files` は最初からパスのみで、reference module の `files` だけが例外だった。schema (`build.js:302-306`) も「repo-root-relative」とパスを期待している

## How to Test

1. `node --test skills/think/tests/plan-draft.test.js` を実行する。20 tests pass で終わる

## Related

- #342 の該当行も同じ形に直した
