### PR TITLE
CI が root の依存をインストールしてからテストを走らせる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,11 @@ jobs:
           sudo apt-get install -y zsh locales
           sudo locale-gen en_US.UTF-8
 
-      # node_modules is not tracked; the lockfile is.
+      # node_modules is not tracked; the lockfiles are. The root install is what puts
+      # oxlint on PATH for the static-gate tests, which reach for it through npx.
+      - name: Install
+        run: npm ci
+
       - name: Install textlint
         working-directory: hooks/textlint
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## What & Why

静的 gate のテスト 2 件が `npx oxlint` を呼ぶ。runner に `node_modules` が無いため `npx` が pin より新しい版を取りに行き、`oxlint: not found` で落ちていた。ローカルは `node_modules` があるので通り、CI だけが赤くなる。

PR #354 で CI を入れたときの欠落で、`hooks/textlint` の install だけがあり root の install が無かった。

## Review focus

- `npm ci` を textlint の install より前に置いた点。`package-lock.json` は追跡済み

## How to Test

1. この PR の Actions で Test job が通ることを確認する。前回は Node tests が 313 pass 2 fail で終わっていた

## Related

- PR #354 で入れた workflow の修正
