### PR TITLE
docs(workflows): record when a workflow script is resolved

### DIFF
--- a/.ja/rules/conventions/WORKFLOWS.md
+++ b/.ja/rules/conventions/WORKFLOWS.md
@@ -47,3 +47,11 @@ workflow script は注入引数を持つ 1 つの関数本体として評価さ�
 テストは通常の ES module として実行されるので、この制約が掛かるのは script 本体だけ。`workflows/_lib/run-workflow.js` のようにテストから import する共有ハーネスは置ける。テスト側は `vm.compileFunction` に `parsingContext` を渡して本番と同じグローバル集合を再現する。
 
 script が読めるグローバルは注入引数 `agent`/`workflow`/`parallel`/`pipeline`/`phase`/`log`/`args` と、本番が別途供給する `budget`/`console`/`setTimeout`/`clearTimeout` に限られる。`crypto`/`fetch`/`process`/`Buffer`/`require`/`structuredClone`/`TextEncoder`/`URL`/`queueMicrotask` は存在せず、参照すると `ReferenceError` になる。`Date.now()`、`Math.random()`、引数なし `new Date()` は resume を理由に挙げる Error に差し替わり、引数つき `new Date()` と `Math.floor` は影響を受けない。文字列からのコード生成 (`eval`、`new Function`) も無効で `EvalError` になる。ハーネスは `budget` を注入しないので、`budget` を読む script はテストだけが赤くなる。
+
+## script の解決タイミング
+
+`Workflow({name: "..."})` はセッション開始時点の script を実行する。同じセッションで `workflows/<name>.js` を編集しても、name で呼ぶ限り編集前の版が走る。編集後の版を走らせるには `Workflow({scriptPath: "<絶対パス>"})` を渡す。
+
+そのため、自分が直した workflow を name で確かめると、直っていない結果が返る。返り値に新しいフィールドを足す修正なら欠落から気づけるが、返り値の形を変えない修正では古い版が走った手がかりが残らない。編集した session 内での確認は scriptPath で行う。
+
+ただし scriptPath が効くのは最上位の呼び出しに限る。script 内の入れ子呼び出し (`build.js` が code を呼ぶ形) は名前で解決するため、`code.js` を直して build 越しに確かめると、やはりセッション開始時点の `code.js` が走る。入れ子側で scriptPath を渡す形も `CLAUDE_WORKFLOW_NAME_ONLY` が立つセッションでは拒否される。入れ子で走る script を直したときは、その script を最上位から scriptPath で直接走らせて確かめる。

--- a/.ja/rules/conventions/WORKFLOWS.md
+++ b/.ja/rules/conventions/WORKFLOWS.md
@@ -52,6 +52,6 @@ script が読めるグローバルは注入引数 `agent`/`workflow`/`parallel`/
 
 `Workflow({name: "..."})` はセッション開始時点の script を実行する。同じセッションで `workflows/<name>.js` を編集しても、name で呼ぶ限り編集前の版が走る。編集後の版を走らせるには `Workflow({scriptPath: "<絶対パス>"})` を渡す。
 
-そのため、自分が直した workflow を name で確かめると、直っていない結果が返る。返り値に新しいフィールドを足す修正なら欠落から気づけるが、返り値の形を変えない修正では古い版が走った手がかりが残らない。編集した session 内での確認は scriptPath で行う。
+そのため、直した workflow を name で確かめると直っていない結果が返り、返り値の形を変えない修正では古い版が走った手がかりも残らない。
 
 ただし scriptPath が効くのは最上位の呼び出しに限る。script 内の入れ子呼び出し (`build.js` が code を呼ぶ形) は名前で解決するため、`code.js` を直して build 越しに確かめると、やはりセッション開始時点の `code.js` が走る。入れ子側で scriptPath を渡す形も `CLAUDE_WORKFLOW_NAME_ONLY` が立つセッションでは拒否される。入れ子で走る script を直したときは、その script を最上位から scriptPath で直接走らせて確かめる。

--- a/rules/conventions/WORKFLOWS.md
+++ b/rules/conventions/WORKFLOWS.md
@@ -52,6 +52,6 @@ The globals a script can read are the injected parameters `agent`, `workflow`, `
 
 `Workflow({name: "..."})` runs the script as it stood at session start. Editing `workflows/<name>.js` within that session leaves the pre-edit version running for every call made by name. To run the edited version, pass `Workflow({scriptPath: "<absolute path>"})`.
 
-Checking a workflow you just fixed by its name therefore returns the unfixed result. A fix that adds a field to the return value shows up as a missing field, while a fix that leaves the return shape unchanged leaves no trace that the old version ran. Verify within the editing session through scriptPath.
+Checking a workflow you just fixed by its name therefore returns the unfixed result, and a fix that leaves the return shape unchanged leaves no trace that the old version ran.
 
 scriptPath reaches the top-level call alone. A nested call inside a script (`build.js` calling code) resolves by name, so fixing `code.js` and checking it through build still runs the `code.js` from session start. Passing scriptPath on the nested side is rejected in a session where `CLAUDE_WORKFLOW_NAME_ONLY` is set. When the script you fixed runs nested, run that script directly from the top level through scriptPath.

--- a/rules/conventions/WORKFLOWS.md
+++ b/rules/conventions/WORKFLOWS.md
@@ -47,3 +47,11 @@ A workflow script is evaluated as one function body carrying injected parameters
 Tests run as ordinary ES modules, so the constraint binds the script body alone. A shared harness imported from tests, such as `workflows/_lib/run-workflow.js`, can be placed. The test side reproduces production's global set by passing a `parsingContext` to `vm.compileFunction`.
 
 The globals a script can read are the injected parameters `agent`, `workflow`, `parallel`, `pipeline`, `phase`, `log`, `args`, plus `budget`, `console`, `setTimeout`, and `clearTimeout`, which production supplies separately. `crypto`, `fetch`, `process`, `Buffer`, `require`, `structuredClone`, `TextEncoder`, `URL`, and `queueMicrotask` do not exist, and referencing any of them throws `ReferenceError`. `Date.now()`, `Math.random()`, and argument-less `new Date()` are replaced with an Error citing resume as the reason, while `new Date()` called with arguments and `Math.floor` are unaffected. Code generation from strings (`eval`, `new Function`) is disabled and raises `EvalError`. The harness does not inject `budget`, so a script that reads it goes red in tests alone.
+
+## Script resolution timing
+
+`Workflow({name: "..."})` runs the script as it stood at session start. Editing `workflows/<name>.js` within that session leaves the pre-edit version running for every call made by name. To run the edited version, pass `Workflow({scriptPath: "<absolute path>"})`.
+
+Checking a workflow you just fixed by its name therefore returns the unfixed result. A fix that adds a field to the return value shows up as a missing field, while a fix that leaves the return shape unchanged leaves no trace that the old version ran. Verify within the editing session through scriptPath.
+
+scriptPath reaches the top-level call alone. A nested call inside a script (`build.js` calling code) resolves by name, so fixing `code.js` and checking it through build still runs the `code.js` from session start. Passing scriptPath on the nested side is rejected in a session where `CLAUDE_WORKFLOW_NAME_ONLY` is set. When the script you fixed runs nested, run that script directly from the top level through scriptPath.


### PR DESCRIPTION
## Why

同一セッションで workflow script を修正しても、`Workflow({name: "..."})` はセッション開始時点の版を実行する。修正した本人が動作を確かめると、直したはずの挙動が直っていない結果が返り、正しい実装を疑って書き換える方向へ進む余地がある。`rules/conventions/WORKFLOWS.md` はこの挙動に触れていなかった。

## What

`## script の解決タイミング` を追加した。

- name 指定はセッション開始時点の script を実行する
- 編集後の版は `Workflow({scriptPath: "<絶対パス>"})` で走らせる
- 返り値の形を変えない修正では古い版が走った手がかりが残らない
- scriptPath が効くのは最上位の呼び出しに限る。build から code を呼ぶような入れ子は名前で解決するため、入れ子で走る script は最上位から直接走らせて確かめる

## Verification

文書のみの変更。`.ja/` を canonical として編集し、英語側を同一コミットでミラーした (DR-0073)。

Closes #341

https://claude.ai/code/session_01WA1A9cHyiAMpfN1VRw1wgw