### PR TITLE
fix(build): fall back to the build: namespace only on name resolution

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -59,11 +59,17 @@ const anchor = (p) =>
   `すべての git / ファイル / ビルドコマンドを ${repo} のリポジトリから実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`;
 const guard = ` この step で最初の commit / push / ブランチ変更を行う前に \`cd ${repo} && git rev-parse --show-toplevel\` を実行し、出力が ${repo} であることを確認する。異なる場合は git を変更せず中断し、不一致を報告する。`;
 // plugin 配布では sibling が build: 名前空間、bundled が ~/.claude/plugins を解決する。
-// どちらも素の dev tree 形を先に試すので、dev tree はそのまま動く。
+// どちらも素の dev tree 形を先に試すので、dev tree はそのまま動く。退避は名前が解決
+// しないときに限る。入れ子が投げたエラーはそれ自体が真の失敗で、捨てると退避先の
+// 名前解決エラーが最終的な失敗として残る。
 const sibling = async (name, a) => {
   try {
     return await workflow(name, a);
-  } catch {
+  } catch (e) {
+    // 呼んだ名前ごと照合する。入れ子の失敗は子の stack を message に運ぶので、文言だけ
+    // で照合すると子が返した文字列に同じ語が混じったときに退避へ倒れる。
+    const unresolved = `workflow('${name}'): no workflow with that name`;
+    if (!String(e?.message ?? "").includes(unresolved)) throw e;
     return await workflow(`build:${name}`, a);
   }
 };

--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -59,15 +59,13 @@ const anchor = (p) =>
   `すべての git / ファイル / ビルドコマンドを ${repo} のリポジトリから実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`;
 const guard = ` この step で最初の commit / push / ブランチ変更を行う前に \`cd ${repo} && git rev-parse --show-toplevel\` を実行し、出力が ${repo} であることを確認する。異なる場合は git を変更せず中断し、不一致を報告する。`;
 // plugin 配布では sibling が build: 名前空間、bundled が ~/.claude/plugins を解決する。
-// どちらも素の dev tree 形を先に試すので、dev tree はそのまま動く。退避は名前が解決
-// しないときに限る。入れ子が投げたエラーはそれ自体が真の失敗で、捨てると退避先の
-// 名前解決エラーが最終的な失敗として残る。
+// どちらも素の dev tree 形を先に試すので、dev tree はそのまま動く。名前解決の失敗以外で
+// 退避すると、入れ子が投げた真の失敗を捨てて退避先の名前解決エラーだけが残る。入れ子の
+// 失敗は子の stack を message に運ぶので、文言でなく呼んだ名前ごと照合する。
 const sibling = async (name, a) => {
   try {
     return await workflow(name, a);
   } catch (e) {
-    // 呼んだ名前ごと照合する。入れ子の失敗は子の stack を message に運ぶので、文言だけ
-    // で照合すると子が返した文字列に同じ語が混じったときに退避へ倒れる。
     const unresolved = `workflow('${name}'): no workflow with that name`;
     if (!String(e?.message ?? "").includes(unresolved)) throw e;
     return await workflow(`build:${name}`, a);

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -62,10 +62,18 @@ const anchor = (p) =>
 const guard = ` Before the first commit / push / branch change in this step, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm the output is ${repo}. If it differs, abort without mutating git and report the mismatch.`;
 // As a plugin, sibling resolves the build: namespace and bundled resolves
 // ~/.claude/plugins. Both try the bare dev-tree form first, so the dev tree keeps working.
+// Fall back only when the name does not resolve. An error thrown inside the nested workflow
+// is the real failure, and swallowing it leaves the fallback's name-resolution error as the
+// one that surfaces.
 const sibling = async (name, a) => {
   try {
     return await workflow(name, a);
-  } catch {
+  } catch (e) {
+    // Match on the name as well. A nested failure carries the child's stack in its message,
+    // so matching the wording alone tips into the fallback whenever a string the child
+    // returned happens to carry the same words.
+    const unresolved = `workflow('${name}'): no workflow with that name`;
+    if (!String(e?.message ?? "").includes(unresolved)) throw e;
     return await workflow(`build:${name}`, a);
   }
 };

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -62,16 +62,13 @@ const anchor = (p) =>
 const guard = ` Before the first commit / push / branch change in this step, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm the output is ${repo}. If it differs, abort without mutating git and report the mismatch.`;
 // As a plugin, sibling resolves the build: namespace and bundled resolves
 // ~/.claude/plugins. Both try the bare dev-tree form first, so the dev tree keeps working.
-// Fall back only when the name does not resolve. An error thrown inside the nested workflow
-// is the real failure, and swallowing it leaves the fallback's name-resolution error as the
-// one that surfaces.
+// Falling back on anything but an unresolved name discards the nested workflow's own failure
+// and leaves the fallback's name-resolution error as the only one left. A nested failure
+// carries the child's stack in its message, so match on the name, not on the wording.
 const sibling = async (name, a) => {
   try {
     return await workflow(name, a);
   } catch (e) {
-    // Match on the name as well. A nested failure carries the child's stack in its message,
-    // so matching the wording alone tips into the fallback whenever a string the child
-    // returned happens to carry the same words.
     const unresolved = `workflow('${name}'): no workflow with that name`;
     if (!String(e?.message ?? "").includes(unresolved)) throw e;
     return await workflow(`build:${name}`, a);

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -1167,13 +1167,10 @@ test("code に commit: true / issue / untracked_baseline が渡り、戻り値 u
   assert.equal(result.unit_commits, 1, "戻り値 unit_commits に unit commit 件数が載る");
 });
 
-// 本番 runtime が未解決の名前に対して投げるメッセージ。sibling() の退避判定はこの
-// 文言に依存するので、stub 側も同じ形で投げる。
+// sibling() の退避判定は本番 runtime の文言に依存するので、stub も同じ形で投げる。
 const unknownWorkflowError = (name) =>
   new Error(`workflow('${name}'): no workflow with that name. Available: code`);
 
-// 入れ子の失敗まで捨てて build: 名前空間へ退避すると、最後に残る失敗は退避先の名前解決
-// エラーになり、読み手は build.js が存在しない workflow を呼んでいると読む。
 test("入れ子 workflow が投げた内部エラーは build: 名前空間への退避に置き換わらない", async () => {
   const names = [];
   const stubs = {
@@ -1184,20 +1181,11 @@ test("入れ子 workflow が投げた内部エラーは build: 名前空間へ�
       throw unknownWorkflowError(name);
     },
   };
-  await assert.rejects(runWorkflow(buildJs, { args, stubs }), (err) => {
-    assert.match(err.message, /retry cap/, "内部エラーが失敗理由として残る");
-    assert.doesNotMatch(
-      err.message,
-      /no workflow with that name/,
-      "名前解決エラーに置き換わらない",
-    );
-    return true;
-  });
+  await assert.rejects(runWorkflow(buildJs, { args, stubs }), /retry cap/);
   assert.deepEqual(names, ["code"], "内部エラーのあと build:code を呼ばない");
 });
 
-// 入れ子の失敗は子の stack を message に運ぶ。子が返した文字列に名前解決の文言が
-// 混じっても、呼んだ名前ごと照合していれば退避へ倒れない。
+// 入れ子の失敗は子の stack を message に運ぶので、同じ語が混じることがある。
 test("内部エラーの message に名前解決の文言が混じっても退避しない", async () => {
   const names = [];
   const stubs = {
@@ -1216,18 +1204,13 @@ test("内部エラーの message に名前解決の文言が混じっても退�
 // plugin 配布では素の名前が解決しない。退避が働く経路は名前解決の失敗だけに残す。
 test("素の名前が解決しないときは build: 名前空間へ退避して完走する", async () => {
   const names = [];
+  const base = makeStubs();
   const stubs = {
-    ...makeStubs(),
-    workflow: (name) => {
+    ...base,
+    workflow: (name, a) => {
       names.push(name);
       if (name !== "build:code") throw unknownWorkflowError(name);
-      return {
-        completed: ["U-001"],
-        anomalies: [],
-        commits: [{ unit: "U-001", subject: "feat: sample subject" }],
-        tests_pass: true,
-        gates_pass: true,
-      };
+      return base.workflow("code", a);
     },
   };
   const { result } = await runWorkflow(buildJs, { args, stubs });

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -1167,6 +1167,74 @@ test("code に commit: true / issue / untracked_baseline が渡り、戻り値 u
   assert.equal(result.unit_commits, 1, "戻り値 unit_commits に unit commit 件数が載る");
 });
 
+// 本番 runtime が未解決の名前に対して投げるメッセージ。sibling() の退避判定はこの
+// 文言に依存するので、stub 側も同じ形で投げる。
+const unknownWorkflowError = (name) =>
+  new Error(`workflow('${name}'): no workflow with that name. Available: code`);
+
+// 入れ子の失敗まで捨てて build: 名前空間へ退避すると、最後に残る失敗は退避先の名前解決
+// エラーになり、読み手は build.js が存在しない workflow を呼んでいると読む。
+test("入れ子 workflow が投げた内部エラーは build: 名前空間への退避に置き換わらない", async () => {
+  const names = [];
+  const stubs = {
+    ...makeStubs(),
+    workflow: (name) => {
+      names.push(name);
+      if (name === "code") throw new Error("code: StructuredOutput retry cap (5) exceeded");
+      throw unknownWorkflowError(name);
+    },
+  };
+  await assert.rejects(runWorkflow(buildJs, { args, stubs }), (err) => {
+    assert.match(err.message, /retry cap/, "内部エラーが失敗理由として残る");
+    assert.doesNotMatch(
+      err.message,
+      /no workflow with that name/,
+      "名前解決エラーに置き換わらない",
+    );
+    return true;
+  });
+  assert.deepEqual(names, ["code"], "内部エラーのあと build:code を呼ばない");
+});
+
+// 入れ子の失敗は子の stack を message に運ぶ。子が返した文字列に名前解決の文言が
+// 混じっても、呼んだ名前ごと照合していれば退避へ倒れない。
+test("内部エラーの message に名前解決の文言が混じっても退避しない", async () => {
+  const names = [];
+  const stubs = {
+    ...makeStubs(),
+    workflow: (name) => {
+      names.push(name);
+      if (name === "code")
+        throw new Error("code: agent answered `no workflow with that name` verbatim");
+      throw unknownWorkflowError(name);
+    },
+  };
+  await assert.rejects(runWorkflow(buildJs, { args, stubs }), /answered/);
+  assert.deepEqual(names, ["code"], "文言の混入では退避しない");
+});
+
+// plugin 配布では素の名前が解決しない。退避が働く経路は名前解決の失敗だけに残す。
+test("素の名前が解決しないときは build: 名前空間へ退避して完走する", async () => {
+  const names = [];
+  const stubs = {
+    ...makeStubs(),
+    workflow: (name) => {
+      names.push(name);
+      if (name !== "build:code") throw unknownWorkflowError(name);
+      return {
+        completed: ["U-001"],
+        anomalies: [],
+        commits: [{ unit: "U-001", subject: "feat: sample subject" }],
+        tests_pass: true,
+        gates_pass: true,
+      };
+    },
+  };
+  const { result } = await runWorkflow(buildJs, { args, stubs });
+  assert.deepEqual(names, ["code", "build:code"], "素の名前を先に試してから退避する");
+  assert.equal(result.stopped, undefined, "退避先が解決すれば build は完走する");
+});
+
 // 分岐点 sha を取れないまま unit commit を有効にすると、比較対象を失った Verify が
 // 無言で全 pass する。sha が使えないときは commit を止めて従来の HEAD 基準へ退避する。
 test("head が sha でないときは code の commit を false にし diff 基準を HEAD へ戻す", async () => {


### PR DESCRIPTION
## Why

`sibling()` の catch が例外の種類を見ないため、入れ子 workflow が内部で投げたエラーも捨てて `build:<name>` を呼び、退避先の名前解決エラーが最終的な失敗として残る。読み手はまず build.js が存在しない workflow を呼んでいると読み、真の失敗理由へたどり着くまでに 1 段よけいな調査が入る。

`workflow("code")` が名前解決できる dev tree では、catch へ入る経路は内部エラーだけになる。つまり dev tree でこの退避が働くのは常に誤診のときになる。

## What

退避を名前解決の失敗だけに絞った。判定は runtime が未解決の名前に対して投げる `workflow('<name>'): no workflow with that name` で、呼んだ名前ごと照合する。入れ子の失敗は子の stack を message に運ぶため、文言だけで照合すると子が返した文字列に同じ語が混じったときに退避へ倒れる。

判定文言は cli.js (2.1.226) の `workflow()` 実装を読んで確定した。名前未解決だけがこのメッセージを投げ、子 workflow の内部失敗は stack 文字列をそのまま投げる。

## Verification

`workflows/build/tests/build.behavior.test.js` に 3 本追加した。

- 入れ子が投げた内部エラーが `build:` 名前空間への退避に置き換わらない
- 内部エラーの message に名前解決の文言が混じっても退避しない
- 素の名前が解決しないときは `build:` 名前空間へ退避して完走する

`node --test "workflows/**/tests/*.test.js"` で 189 pass / 0 fail。

## 判断してほしい点

判定は runtime のメッセージ文字列に依存する。文言が変われば plugin 経路の build が名前解決エラーで止まる (誤診には戻らず fail-close する)。`workflow()` は名前が解決するかを問う API を持たないため、例外での分岐以外の手が無い。この依存を許容するか、CLI 棚卸しチェックリストへ文言確認を足すかを判断してほしい。

Closes #339

https://claude.ai/code/session_01WA1A9cHyiAMpfN1VRw1wgw