### PR TITLE
fix(reflection): write into the repository the session runs in

### DIFF
--- a/hooks/lifecycle/reflection-ask.sh
+++ b/hooks/lifecycle/reflection-ask.sh
@@ -18,6 +18,16 @@ command -v jq >/dev/null 2>&1 || exit 0
 SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null)
 [[ -z "$SESSION_ID" ]] && exit 0
 
+# The repository root, not the payload's cwd: a turn run from a subdirectory would grow a
+# second .claude/ there. Resolved before the mark is written, so a session that starts
+# outside git still gets asked once it moves into a repository.
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // ""' 2>/dev/null)
+[[ -z "$CWD" ]] && exit 0
+ROOT=$(cd "$CWD" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+[[ -z "$ROOT" ]] && exit 0
+TARGET="$ROOT/.claude/rules/CORRECTIONS.md"
+TRANSCRIPT=$(printf '%s' "$INPUT" | jq -r '.transcript_path // ""' 2>/dev/null)
+
 # One mark per session, not one shared record: the wiring lives in the global settings, so
 # every Claude Code process on this machine runs this hook and would overwrite the others.
 ASKED_DIR="${HOME}/.cache/claude-reflection-ask"
@@ -27,7 +37,10 @@ mkdir -p "$ASKED_DIR" 2>/dev/null
 touch "$MARK"
 find "$ASKED_DIR" -type f -mtime +7 -delete 2>/dev/null
 
-MSG="reflection-ask: このセッションで得た訂正・知見のうち、次回セッションに残す価値があるものを一つ .claude/rules/CORRECTIONS.md に追記する。残すものが無ければ何も書かない。"
+# An absolute path and a subagent: a relative path let an agent that could not resolve it
+# fall back to the global ~/.claude tree, and reading the session back to compose the entry
+# is what makes the turn wait.
+MSG="reflection-ask: このセッションで得た訂正・知見のうち、次回セッションに残す価値があるものを一つ書き残す。書くのは Agent tool の subagent 1 体に任せ、あなた自身は追記しない。subagent へ渡すのは transcript のパス ${TRANSCRIPT} と書き込み先 ${TARGET} の 2 つで、書き込み先はこの 1 つに限る。途中のディレクトリごと無ければ作り、残すものが無ければ何も書かない。"
 
 jq -n --arg m "$MSG" '{
   systemMessage: $m,

--- a/hooks/tests/test-reflection-ask.sh
+++ b/hooks/tests/test-reflection-ask.sh
@@ -13,8 +13,10 @@ trap 'rm -rf "$TEST_TMPDIR"' EXIT
 
 fresh_home() { mktemp -d "$TEST_TMPDIR/homeXXXXXX"; }
 
+# cwd defaults to this test directory, a subdirectory of the repository, so the default
+# path already exercises the root resolution rather than a lucky top-level run.
 make_stop_json() {
-  echo "{\"session_id\":\"${1:-test-session}\",\"hook_event_name\":\"Stop\",\"stop_hook_active\":false}"
+  echo "{\"session_id\":\"${1:-test-session}\",\"cwd\":\"${2:-$SCRIPT_DIR}\",\"transcript_path\":\"$TEST_TMPDIR/transcript.jsonl\",\"hook_event_name\":\"Stop\",\"stop_hook_active\":false}"
 }
 
 # HOME is overridden per test so the record of the last asked session starts absent,
@@ -22,7 +24,7 @@ make_stop_json() {
 # A `VAR=val cmd1 | cmd2` prefix scopes to cmd1 alone, so HOME is exported for the whole
 # subshell to reach $HOOK.
 run_hook() {
-  (export HOME="$FAKE_HOME"; make_stop_json "${1:-}" | "$HOOK") 2>/dev/null
+  (export HOME="$FAKE_HOME"; make_stop_json "${1:-}" "${2:-}" | "$HOOK") 2>/dev/null
 }
 
 test_second_call_in_same_session_is_silent() {
@@ -57,16 +59,49 @@ test_question_leaves_nothing_when_there_is_nothing() {
 
 test_additionalcontext_path_has_real_file() {
   echo "T-005: additionalContext が指すパスに実ファイルがある"
-  local FAKE_HOME output message path_ref repo_root path_found file_exists
+  local FAKE_HOME output message path_ref path_found file_exists
   FAKE_HOME=$(fresh_home)
   output=$(run_hook) || true
   message=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null) || true
-  path_ref=$(printf '%s' "$message" | grep -oE '\.claude/rules/[A-Za-z0-9_./-]+\.md' | head -n1) || true
+  path_ref=$(printf '%s' "$message" | grep -oE '/[A-Za-z0-9_./-]+/\.claude/rules/CORRECTIONS\.md' | head -n1) || true
   path_found=$([[ -n "$path_ref" ]] && echo yes || echo no)
-  assert_eq "additionalContext names a .claude/rules path" "yes" "$path_found"
-  repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
-  file_exists=$([[ -n "$path_ref" && -f "$repo_root/$path_ref" ]] && echo yes || echo no)
+  assert_eq "additionalContext names an absolute .claude/rules path" "yes" "$path_found"
+  file_exists=$([[ -n "$path_ref" && -f "$path_ref" ]] && echo yes || echo no)
   assert_eq "the named path exists as a real file" "yes" "$file_exists"
+}
+
+# The unresolved relative path is what put a Rust project's entry in the global tree.
+test_subdirectory_resolves_to_repository_root() {
+  echo "T-006: サブディレクトリの cwd でもリポジトリルートを指す"
+  local FAKE_HOME output message repo_root
+  FAKE_HOME=$(fresh_home)
+  repo_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  output=$(run_hook session-subdir "$SCRIPT_DIR") || true
+  message=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null) || true
+  assert_contains "names the repository root" "$repo_root/.claude/rules/CORRECTIONS.md" "$message"
+}
+
+test_outside_a_repository_is_silent() {
+  echo "T-007: リポジトリ外の cwd では何も返さない"
+  local FAKE_HOME outside output
+  FAKE_HOME=$(fresh_home)
+  outside=$(mktemp -d "$TEST_TMPDIR/outsideXXXXXX")
+  output=$(run_hook session-outside "$outside") || true
+  assert_empty "no message outside a repository" "$output"
+}
+
+test_write_is_delegated_to_a_subagent() {
+  echo "T-008: 追記を subagent へ委ね、呼ばれた側は自分で書かない"
+  local FAKE_HOME output message
+  FAKE_HOME=$(fresh_home)
+  output=$(run_hook) || true
+  message=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.additionalContext // empty' 2>/dev/null) || true
+  assert_contains "hands the write to a subagent" "subagent" "$message"
+  assert_contains "keeps the caller from writing" "あなた自身は追記しない" "$message"
+  assert_contains "passes the transcript path" "$TEST_TMPDIR/transcript.jsonl" "$message"
+  # scout had no .claude/rules at all, so naming the file alone leaves the creation of the
+  # directory to the subagent's judgment.
+  assert_contains "asks for the missing directories too" "途中のディレクトリごと無ければ作り" "$message"
 }
 
 test_script_never_launches_claude() {
@@ -87,6 +122,9 @@ test_second_call_in_same_session_is_silent
 test_new_session_returns_systemMessage
 test_question_leaves_nothing_when_there_is_nothing
 test_additionalcontext_path_has_real_file
+test_subdirectory_resolves_to_repository_root
+test_outside_a_repository_is_silent
+test_write_is_delegated_to_a_subagent
 test_script_never_launches_claude
 
 report_results


### PR DESCRIPTION
## Why

Stop hook のメッセージが相対パス `.claude/rules/CORRECTIONS.md` しか渡していなかった。そのパスに実ファイルを持たないリポジトリで走った agent は既知の CORRECTIONS.md を探し、`~/.claude/rules` へ書く。

実際に起きていた。`~/.claude/rules/CORRECTIONS.md` (untracked) に 2 件溜まっており、transcript の cwd で追うと由来は 2 つに分かれる。Rust プロジェクト (`~/GitHub/cli/scout`) と、一時ディレクトリで走った実験セッション群だった。scout 側には `.claude/rules` ディレクトリ自体が無く、書き先を解決できなかった agent がグローバルへ倒れている。

## What

payload の `cwd` から `git rev-parse --show-toplevel` でリポジトリルートを解決し、絶対パス 1 つだけを渡す。

- `cwd` がサブディレクトリでも新しい `.claude` ディレクトリを生やさない
- git 管理外では書き先が無いので何も返さず、mark も残さないのでリポジトリへ入った時点で尋ねる
- 途中のディレクトリごと無ければ作るよう明示する。scout のようにディレクトリから無い場合、ファイル名だけ渡すと subagent がまた既存の CORRECTIONS.md を探しに行く
- 追記そのものは Agent tool の subagent へ委ね、呼ばれた側は書かない。セッションを読み返して文面を組む間、ターンが止まらなくなる

worktree で走ったセッションは worktree 側の `.claude/rules` へ書く。`--show-toplevel` が worktree のパスを返すためで、作業中のブランチに閉じる挙動を選んだ。

## Verification

`hooks/tests/test-reflection-ask.sh` に T-006 から T-008 を追加し、既存テストの payload に `cwd` と `transcript_path` を足した。デフォルトの `cwd` をテストディレクトリ (サブディレクトリ) にしたので、既存テストも常にルート解決を通る。

18 passed、0 failed。

## 移送済み

cargo-machete の知見は `~/GitHub/cli/scout/.claude/rules/CORRECTIONS.md` へ移した。実験セッション由来の 1 件は cwd が一時ディレクトリで戻す先が無く、削除の判断を受けている。グローバル側 2 ファイルの削除は sandbox の書き込み拒否で手作業に残っている。

https://claude.ai/code/session_01WA1A9cHyiAMpfN1VRw1wgw