### PR TITLE
fix(dr): resolve each id the DR-0096 Confirmation cites

### DIFF
--- a/docs/decisions/0096-fence-untrusted-findings-in-four-audit-stages.md
+++ b/docs/decisions/0096-fence-untrusted-findings-in-four-audit-stages.md
@@ -42,7 +42,16 @@ Option A を採用する。Verify と Integrate は実害が薄いが、fence �
 
 ### Confirmation
 
-`workflows/audit.js` の Challenge/Verify/Integrate/Snapshot の 4 呼び出しが `fenced(...)` を経由していることをコードレビューで確認する。`node --test workflows/audit/tests/*.test.js` で、base marker と同じ文字列を `summary` に仕込んでも marker が伸びて payload のどこにも出現しないこと (T-029)、marker と衝突しない payload では run をまたいでも marker が base のまま変わらないこと (T-030)、1 つの fence の BEGIN と END が同じ marker を使うこと (T-003) を確認する。Snapshot 段の agent 起動が `generator-snapshot` を渡すこと (T-006) を確認する。
+`workflows/audit.js` の Challenge/Verify/Integrate/Snapshot の 4 呼び出しが `fenced(...)` を経由していることをコードレビューで確認する。
+
+`node --test workflows/audit/tests/audit.degradation.test.js workflows/audit/tests/audit.effort.test.js` を走らせ、下表の 4 件が緑であることを確認する。T-NNN が一意なのはファイル単位までなので、対象を 2 ファイルへ絞ると出力の id が 1 件に定まる。`audit.effort.test.js` は id を持たない運用なので、テスト名で指す。
+
+| ファイル                    | テスト                                                                                           |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `audit.degradation.test.js` | T-029 base marker と同じ文字列を summary に仕込むと marker が伸びて payload のどこにも出現しない |
+| `audit.degradation.test.js` | T-030 marker と衝突しない payload では marker が base のまま変わらない                           |
+| `audit.degradation.test.js` | T-003 1つの fence の BEGIN と END が同じ marker を使う                                           |
+| `audit.effort.test.js`      | Snapshot 段の agent 起動は agentType に generator-snapshot を渡す                                |
 
 ## More Information
 


### PR DESCRIPTION
## Why

DR-0096 の Confirmation が挙げる T-006 は、指す先に届かない。「Snapshot 段の agent 起動が `generator-snapshot` を渡すこと (T-006)」と書くが、その主張を検証するのは `audit.effort.test.js:74` の id を持たないテストになる。T-006 を名乗るのは `audit.degradation.test.js:45` と `audit.seam.test.js:171` の別々の 2 件で、どちらも別の性質を検証している。読み手は書かれたとおりに確認できない。

## 実測

audit のテストファイル全体で id を数えると、ファイル跨ぎで 12 種類 (T-001 から T-011、T-020、T-021) が重複する。#320 が定めたのはファイル単位の一意性なので、id だけでは 1 件に絞れない。

`audit.effort.test.js` は 4 テストとも T-NNN を持たない。id を付ける運用のファイルと、付けない運用のファイルが混在している。

## What

参照側を #320 の単位に合わせ、ファイル名を併記する形にした。audit テスト全体で id を一意にする案は取らない。12 種の再採番が必要で、#320 の最小変更方針に反する。

- degradation の 3 件はファイル名 + id で指す
- id を持たない effort の 1 件はテスト名で指す
- 走らせるコマンドを対象 2 ファイルへ絞る。全ファイル一括だと出力に T-003 が 2 件出て、どちらか判別できない

## Verification

Confirmation の手順を実際になぞった。

```
node --test workflows/audit/tests/audit.degradation.test.js workflows/audit/tests/audit.effort.test.js
```

出力に 4 件が過不足なく出て、すべて緑になる。id の重複は出ない。

## Base

このブランチは #320 (PR #365) の上に積んでいる。DR の T-029 と T-030 への更新が #365 に含まれるため。#365 がマージされれば base は main に切り替わる。

Closes #324

https://claude.ai/code/session_01WA1A9cHyiAMpfN1VRw1wgw