### PR TITLE
conformance finding の粒度を 1 件 1 逸脱にする

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -751,8 +751,6 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
   },
   findings: {
     type: "array",
-    description:
-      "1 要素につき逸脱 1 件。別の reference や location を持つ指摘は、detail の 2 文目でなく別の finding にする",
     items: obj(["category", "location", "reference", "detail"], {
       category: {
         type: "string",
@@ -768,7 +766,7 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
       detail: {
         type: "string",
         description:
-          "レビュアーが判断できるよう、この finding が指す 1 件の逸脱を 3 文以内、1 文 1 主張で書く。根拠の所在は location と reference が持つ",
+          "レビュアーが判断できるよう、参照モジュールと何が違うかを 3 文以内、1 文 1 主張で書く。根拠の所在は location と reference が持つ",
       },
     }),
   },
@@ -781,8 +779,6 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
   },
   findings: {
     type: "array",
-    description:
-      "1 要素につき逸脱 1 件。別の spec_line や location を持つ指摘は、detail の 2 文目でなく別の finding にする",
     items: obj(["category", "severity", "spec_line", "location", "detail"], {
       category: {
         type: "string",
@@ -806,7 +802,7 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
       detail: {
         type: "string",
         description:
-          "レビュアーが判断できるよう、この finding が指す 1 件の逸脱を 3 文以内、1 文 1 主張で書く。根拠の所在は location と spec_line が持つ",
+          "レビュアーが判断できるよう、何が spec と食い違うかを 3 文以内、1 文 1 主張で書く。根拠の所在は location と spec_line が持つ",
       },
     }),
   },
@@ -888,7 +884,8 @@ const [diff, testPresence, conformance, structure] = await parallel([
               `レビュー対象は、分岐点 ${diffBase} 以降にこの build が生んだ変更すべて (commit 済みも未 commit も含む) ` +
               `なので、\`git diff ${diffBase}\` と \`git status --porcelain\` が示す未追跡ファイルを使う。main...HEAD は使わない。` +
               `判定の前に参照モジュールのファイルを読み、参照モジュールが実際に行っていることだけを報告する。` +
-              `従っていない慣例を発明しない。`,
+              `従っていない慣例を発明しない。` +
+              `finding 1 件につき逸脱は 1 件。別の reference や location を持つ指摘は、detail の 2 文目でなく別の finding にする。`,
           ),
           {
             label: "structure",

--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -751,6 +751,8 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
   },
   findings: {
     type: "array",
+    description:
+      "1 要素につき逸脱 1 件。別の reference や location を持つ指摘は、detail の 2 文目でなく別の finding にする",
     items: obj(["category", "location", "reference", "detail"], {
       category: {
         type: "string",
@@ -766,7 +768,7 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
       detail: {
         type: "string",
         description:
-          "レビュアーが逸脱を判断できるよう、参照モジュールと何が違うかを 2 文以内で書く。根拠の所在は location と reference が持つ",
+          "レビュアーが判断できるよう、この finding が指す 1 件の逸脱を 3 文以内、1 文 1 主張で書く。根拠の所在は location と reference が持つ",
       },
     }),
   },
@@ -779,6 +781,8 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
   },
   findings: {
     type: "array",
+    description:
+      "1 要素につき逸脱 1 件。別の spec_line や location を持つ指摘は、detail の 2 文目でなく別の finding にする",
     items: obj(["category", "severity", "spec_line", "location", "detail"], {
       category: {
         type: "string",
@@ -802,7 +806,7 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
       detail: {
         type: "string",
         description:
-          "レビュアーが逸脱を判断できるよう、何が spec と食い違うかを 2 文以内で書く。根拠の所在は location と spec_line が持つ",
+          "レビュアーが判断できるよう、この finding が指す 1 件の逸脱を 3 文以内、1 文 1 主張で書く。根拠の所在は location と spec_line が持つ",
       },
     }),
   },
@@ -860,7 +864,8 @@ const [diff, testPresence, conformance, structure] = await parallel([
         `起点 issue に対する conformance review。spec は GitHub issue #${issueNumber} で、` +
           `\`gh issue view ${issueNumber}\` で読む。レビュー対象は、分岐点 ${diffBase} 以降にこの build が生んだ変更 ` +
           `すべて (commit 済みも未 commit も含む) なので、\`git diff ${diffBase}\` と \`git status --porcelain\` が示す ` +
-          `未追跡ファイルを使う。main...HEAD は使わない。`,
+          `未追跡ファイルを使う。main...HEAD は使わない。` +
+          `finding 1 件につき逸脱は 1 件。別の spec_line や location を持つ指摘は、detail の 2 文目でなく別の finding にする。`,
       ),
       {
         label: "conformance",

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -781,8 +781,6 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
   },
   findings: {
     type: "array",
-    description:
-      "One deviation per element. An observation with its own reference or location is a separate finding, not a second sentence inside detail",
     items: obj(["category", "location", "reference", "detail"], {
       category: {
         type: "string",
@@ -798,7 +796,7 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
       detail: {
         type: "string",
         description:
-          "the single deviation this finding is about, in at most 3 sentences with one claim each, so a reviewer can judge it. location / reference carry where the evidence lives",
+          "what differs from the reference module, in at most 3 sentences with one claim each, so a reviewer can judge the deviation. location / reference carry where the evidence lives",
       },
     }),
   },
@@ -811,8 +809,6 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
   },
   findings: {
     type: "array",
-    description:
-      "One deviation per element. An observation with its own spec_line or location is a separate finding, not a second sentence inside detail",
     items: obj(["category", "severity", "spec_line", "location", "detail"], {
       category: {
         type: "string",
@@ -836,7 +832,7 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
       detail: {
         type: "string",
         description:
-          "the single deviation this finding is about, in at most 3 sentences with one claim each, so a reviewer can judge it. location / spec_line carry where the evidence lives",
+          "what diverges from the spec, in at most 3 sentences with one claim each, so a reviewer can judge the deviation. location / spec_line carry where the evidence lives",
       },
     }),
   },
@@ -895,7 +891,7 @@ const [diff, testPresence, conformance, structure] = await parallel([
           `read it with \`gh issue view ${issueNumber}\`. The implementation to review is everything this build ` +
           `produced since its branch point ${diffBase}, committed and uncommitted alike, so use \`git diff ${diffBase}\` ` +
           `plus the untracked files shown by \`git status --porcelain\`; do not use main...HEAD. ` +
-          `Report one deviation per finding: an observation with its own spec_line or location is a separate finding, not a second sentence in detail.`,
+          `Report one deviation per finding: an observation with its own spec_line or location becomes its own finding, not a second sentence in detail.`,
       ),
       {
         label: "conformance",
@@ -919,7 +915,8 @@ const [diff, testPresence, conformance, structure] = await parallel([
               `committed and uncommitted alike, so use \`git diff ${diffBase}\` plus the untracked files shown by ` +
               `\`git status --porcelain\`; do not use main...HEAD. ` +
               `Read the reference module's files before judging, and report only what it actually does; ` +
-              `do not invent conventions it does not follow.`,
+              `do not invent conventions it does not follow. ` +
+              `Report one deviation per finding: an observation with its own reference or location becomes its own finding, not a second sentence in detail.`,
           ),
           {
             label: "structure",

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -781,6 +781,8 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
   },
   findings: {
     type: "array",
+    description:
+      "One deviation per element. An observation with its own reference or location is a separate finding, not a second sentence inside detail",
     items: obj(["category", "location", "reference", "detail"], {
       category: {
         type: "string",
@@ -796,7 +798,7 @@ const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
       detail: {
         type: "string",
         description:
-          "what differs from the reference module, in at most 2 sentences, so a reviewer can judge the deviation. location / reference carry where the evidence lives",
+          "the single deviation this finding is about, in at most 3 sentences with one claim each, so a reviewer can judge it. location / reference carry where the evidence lives",
       },
     }),
   },
@@ -809,6 +811,8 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
   },
   findings: {
     type: "array",
+    description:
+      "One deviation per element. An observation with its own spec_line or location is a separate finding, not a second sentence inside detail",
     items: obj(["category", "severity", "spec_line", "location", "detail"], {
       category: {
         type: "string",
@@ -832,7 +836,7 @@ const CONFORMANCE_SCHEMA = obj(["spec_found", "findings"], {
       detail: {
         type: "string",
         description:
-          "what diverges from the spec, in at most 2 sentences, so a reviewer can judge the deviation. location / spec_line carry where the evidence lives",
+          "the single deviation this finding is about, in at most 3 sentences with one claim each, so a reviewer can judge it. location / spec_line carry where the evidence lives",
       },
     }),
   },
@@ -890,7 +894,8 @@ const [diff, testPresence, conformance, structure] = await parallel([
         `Conformance review against the originating issue. The spec is GitHub issue #${issueNumber}: ` +
           `read it with \`gh issue view ${issueNumber}\`. The implementation to review is everything this build ` +
           `produced since its branch point ${diffBase}, committed and uncommitted alike, so use \`git diff ${diffBase}\` ` +
-          `plus the untracked files shown by \`git status --porcelain\`; do not use main...HEAD.`,
+          `plus the untracked files shown by \`git status --porcelain\`; do not use main...HEAD. ` +
+          `Report one deviation per finding: an observation with its own spec_line or location is a separate finding, not a second sentence in detail.`,
       ),
       {
         label: "conformance",


### PR DESCRIPTION
## What & Why

PR body の Issue 適合性セクションで、1 件の finding が 1 つの逸脱だけを指すようになる。レビュアーは severity と件数から、どれを独立に確認するかを決められる。

thkt/scout#373 の finding は 1 件が 490 字あり、うち 128 字は「別件として」で始まる独立した指摘だった。schema は detail を「2 文以内」と縛るだけで、1 件にいくつの逸脱を入れてよいかを言っていない。文数の上限は、2 つの逸脱を 1 文へ詰め込ませる方向に働く。

## Review focus

- 粒度規則の置き場所。reviewer-conformance の agent 定義は長さと粒度のどちらも持たないので、build の出力契約は schema が単独で所有する。reviewer-reuse は汎用 reviewer で/audit からも走るため触っていない
- 文数の上限を残したこと。上限を粒度規則だけに置き換えると、1 つの逸脱を説明する文が無制限になる

## Changes

- conformance と structure の findings 配列に「1 要素 1 逸脱」を課す
- detail の上限を「2 文以内」から「3 文以内、1 文 1 主張」にする
- conformance prompt 本体にも同じ規則を置く。schema の array description より prompt 本体の方が確実に読まれる

## Scope

- Not included: 効果の実データ検証。conformance の再現には scout を #373 の分岐点へ戻す必要があり、translate-tail のときのような単発の再実行では確認できない
- Not included: structure 側の確認。同じ schema 文言を共有していて同じ壊れ方をするため揃えたが、#373 の structure finding は 0 件だった
- Not included: 表示形式の変更。1 件が 1 主張になってから判断する

## Design Decisions

- status 行の conformance カウントは増える方向に振れる。3 件が 5 件になっても非ゼロであることは変わらないので、tail_header の「逸脱件数が非ゼロなら見る」という案内は保たれる

## How to Test

1. `node --test workflows/build/tests/build.behavior.test.js workflows/build/tests/handoff-contract.test.js` を実行し、54 件 pass することを確認
2. 次に build を回したとき、PR body の Issue 適合性セクションで 1 件の finding が 1 つの逸脱を指しているかを見る
