### PR TITLE
feat(hooks): block tree-rewriting git from running sandboxed in ~/.claude

### DIFF
--- a/.ja/docs/HOOKS.md
+++ b/.ja/docs/HOOKS.md
@@ -13,17 +13,17 @@ Rust バイナリは sentinels プラグインとしても配布するが、現�
 
 ## イベント マップ
 
-| イベント           | Matcher              | フック                                                                               |
-| ------------------ | -------------------- | ------------------------------------------------------------------------------------ |
-| PreToolUse         | Bash                 | auto-package-manager, security/npm-safe-install, security/rm-to-trash, textlint-lint |
-| PreToolUse         | Write/Edit/MultiEdit | rust-pre-edit, guardrails                                                            |
-| PreToolUse         | EnterPlanMode        | deny (計画は /think へ誘導)                                                          |
-| PostToolUse        | Write/Edit/MultiEdit | rust-post-edit, textlint-fix, assay, formatter, gates                                |
-| PostToolUse        | Bash                 | gates post-bash                                                                      |
-| SessionStart       | \*                   | lifecycle/recall-index, herdr-agent-state                                            |
-| Stop / StopFailure | -                    | notify-stop / notify-stop-failure                                                    |
-| Notification       | permission_prompt 等 | 通知サウンド (afplay)                                                                |
-| statusLine         | -                    | lifecycle/statusline                                                                 |
+| イベント           | Matcher              | フック                                                                                                                                |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| PreToolUse         | Bash                 | auto-package-manager, security/npm-safe-install, security/rm-to-trash, security/git-sandbox-guard, textlint-lint, issue-body-template |
+| PreToolUse         | Write/Edit/MultiEdit | rust-pre-edit, guardrails                                                                                                             |
+| PreToolUse         | EnterPlanMode        | deny (計画は /think へ誘導)                                                                                                           |
+| PostToolUse        | Write/Edit/MultiEdit | rust-post-edit, textlint-fix, assay, formatter, gates                                                                                 |
+| PostToolUse        | Bash                 | gates post-bash                                                                                                                       |
+| SessionStart       | \*                   | lifecycle/recall-index, herdr-agent-state                                                                                             |
+| Stop / StopFailure | -                    | notify-stop / notify-stop-failure                                                                                                     |
+| Notification       | permission_prompt 等 | 通知サウンド (afplay)                                                                                                                 |
+| statusLine         | -                    | lifecycle/statusline                                                                                                                  |
 
 ## シェル hooks
 
@@ -41,10 +41,11 @@ Rust バイナリは sentinels プラグインとしても配布するが、現�
 
 ### security/
 
-| Hook                | イベント         | 失敗モード  | 用途                                                   |
-| ------------------- | ---------------- | ----------- | ------------------------------------------------------ |
-| npm-safe-install.sh | PreToolUse(Bash) | fail-closed | ignore-scripts なしのパッケージ インストールをブロック |
-| rm-to-trash.sh      | PreToolUse(Bash) | fail-closed | rm/rmdir/unlink/shred を `mv ~/.Trash/` へ誘導         |
+| Hook                 | イベント         | 失敗モード  | 用途                                                         |
+| -------------------- | ---------------- | ----------- | ------------------------------------------------------------ |
+| npm-safe-install.sh  | PreToolUse(Bash) | fail-closed | ignore-scripts なしのパッケージ インストールをブロック       |
+| rm-to-trash.sh       | PreToolUse(Bash) | fail-closed | rm/rmdir/unlink/shred を `mv ~/.Trash/` へ誘導               |
+| git-sandbox-guard.sh | PreToolUse(Bash) | fail-closed | ~/.claude で作業ツリーを書き換える git を sandbox 内で止める |
 
 ### lifecycle/
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -13,17 +13,17 @@ The Rust binaries are also distributed as sentinels plugins, but plugin registra
 
 ## Event Map
 
-| Event              | Matcher                | Hooks                                                                                |
-| ------------------ | ---------------------- | ------------------------------------------------------------------------------------ |
-| PreToolUse         | Bash                   | auto-package-manager, security/npm-safe-install, security/rm-to-trash, textlint-lint |
-| PreToolUse         | Write/Edit/MultiEdit   | rust-pre-edit, guardrails                                                            |
-| PreToolUse         | EnterPlanMode          | deny (planning is routed to /think)                                                  |
-| PostToolUse        | Write/Edit/MultiEdit   | rust-post-edit, textlint-fix, assay, formatter, gates                                |
-| PostToolUse        | Bash                   | gates post-bash                                                                      |
-| SessionStart       | \*                     | lifecycle/recall-index, herdr-agent-state                                            |
-| Stop / StopFailure | -                      | notify-stop / notify-stop-failure                                                    |
-| Notification       | permission_prompt etc. | Notification sound (afplay)                                                          |
-| statusLine         | -                      | lifecycle/statusline                                                                 |
+| Event              | Matcher                | Hooks                                                                                                                                 |
+| ------------------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| PreToolUse         | Bash                   | auto-package-manager, security/npm-safe-install, security/rm-to-trash, security/git-sandbox-guard, textlint-lint, issue-body-template |
+| PreToolUse         | Write/Edit/MultiEdit   | rust-pre-edit, guardrails                                                                                                             |
+| PreToolUse         | EnterPlanMode          | deny (planning is routed to /think)                                                                                                   |
+| PostToolUse        | Write/Edit/MultiEdit   | rust-post-edit, textlint-fix, assay, formatter, gates                                                                                 |
+| PostToolUse        | Bash                   | gates post-bash                                                                                                                       |
+| SessionStart       | \*                     | lifecycle/recall-index, herdr-agent-state                                                                                             |
+| Stop / StopFailure | -                      | notify-stop / notify-stop-failure                                                                                                     |
+| Notification       | permission_prompt etc. | Notification sound (afplay)                                                                                                           |
+| statusLine         | -                      | lifecycle/statusline                                                                                                                  |
 
 ## Shell Hooks
 
@@ -41,10 +41,11 @@ The Rust binaries are also distributed as sentinels plugins, but plugin registra
 
 ### security/
 
-| Hook                | Event            | Failure Mode | Purpose                                       |
-| ------------------- | ---------------- | ------------ | --------------------------------------------- |
-| npm-safe-install.sh | PreToolUse(Bash) | fail-closed  | Block package installs without ignore-scripts |
-| rm-to-trash.sh      | PreToolUse(Bash) | fail-closed  | Route rm/rmdir/unlink/shred to `mv ~/.Trash/` |
+| Hook                 | Event            | Failure Mode | Purpose                                                     |
+| -------------------- | ---------------- | ------------ | ----------------------------------------------------------- |
+| npm-safe-install.sh  | PreToolUse(Bash) | fail-closed  | Block package installs without ignore-scripts               |
+| rm-to-trash.sh       | PreToolUse(Bash) | fail-closed  | Route rm/rmdir/unlink/shred to `mv ~/.Trash/`               |
+| git-sandbox-guard.sh | PreToolUse(Bash) | fail-closed  | Stop tree-rewriting git from running sandboxed in ~/.claude |
 
 ### lifecycle/
 

--- a/hooks/security/git-sandbox-guard.sh
+++ b/hooks/security/git-sandbox-guard.sh
@@ -4,11 +4,10 @@
 # The sandbox denies Bash writes under agents/ rules/ skills/ hooks/ commands/ workflows/
 # even when settings.json lists them in sandbox.filesystem.allowWrite. git moves HEAD
 # anyway, so the tree is left with HEAD on one commit and those directories on another,
-# and the next pull refuses to run because the tree reads as dirty. Recovering takes a
-# reset plus a per-file checkout, which is why this is worth blocking up front.
+# and the next pull refuses to run because the tree reads as dirty.
 #
-# Failure mode: fail-closed. A command line shlex cannot close hides where its git call
-# sits, so it is not cleared.
+# Failure mode: fail-closed. A line shlex cannot tokenize hides where its git call sits,
+# so it is not cleared.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -38,22 +37,19 @@ read -r ESCAPED CWD < <(printf '%s' "$INPUT" | jq -r '[(.tool_input.dangerouslyD
 # The caller already turned the sandbox off, so the writes this guard protects will land.
 [[ "$ESCAPED" == "true" ]] && exit 0
 
-# Only the repository whose files the sandbox protects. Another repository checked out
-# under a different path writes freely and needs no guard.
+# A repository checked out anywhere else writes freely, so only this one needs the guard.
 TOPLEVEL=$(git -C "${CWD:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)
 [[ "$TOPLEVEL" == "$HOME/.claude" ]] || exit 0
-
-COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
-
-RETRY='dangerouslyDisableSandbox: true を付けて同じコマンドを実行し直す。それも拒否されたら、ユーザーに `! <コマンド>` での実行を依頼する。'
 
 if ! command -v python3 >/dev/null 2>&1; then
   deny "git-sandbox-guard: python3 が無くコマンドを解析できず、作業ツリーを書き換える git かどうかを判定できない。python3 を用意する。"
   exit 0
 fi
 
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
+
 # Not a regex over the raw string: it cannot tell where a token sits, so `git pull` inside
-# a commit message would read as a pull, and `git -C other/repo pull` would read as one here.
+# a commit message would read as a pull.
 if printf '%s' "$COMMAND" | LIB_DIR="$SCRIPT_DIR/../lib" python3 -c '
 import os
 import sys
@@ -68,10 +64,12 @@ REWRITES = frozenset({
 })
 
 # git own options that swallow the token after them, which would otherwise read as the
-# subcommand.
+# subcommand. -C names another repository, which this guard still denies rather than
+# resolve: the escape hatch is one flag away and the miss would be silent.
 VALUED_GIT_FLAGS = frozenset({"-C", "-c", "--git-dir", "--work-tree", "--namespace"})
 
-# Creating a branch leaves every file where it is.
+# checkout takes -b / -B and switch takes -c / -C. Creating a branch leaves every file
+# where it is.
 BRANCH_CREATE = frozenset({"-b", "-B", "-c", "-C"})
 
 # soft and mixed stop at the index. Only these three carry the change into the tree.
@@ -91,12 +89,12 @@ def rewrites_tree(tokens):
     subcommand, rest = args[index], args[index + 1 :]
     if subcommand not in REWRITES:
         return False
-    if subcommand in ("checkout", "switch") and any(a in BRANCH_CREATE for a in rest):
-        return False
-    if subcommand == "reset" and not any(a in RESET_WRITES for a in rest):
-        return False
-    if subcommand == "stash" and rest and rest[0] in STASH_READS:
-        return False
+    if subcommand in ("checkout", "switch"):
+        return not any(a in BRANCH_CREATE for a in rest)
+    if subcommand == "reset":
+        return any(a in RESET_WRITES for a in rest)
+    if subcommand == "stash":
+        return not (rest and rest[0] in STASH_READS)
     return True
 
 
@@ -106,5 +104,5 @@ except ValueError:
     hit = True
 sys.exit(0 if hit else 1)
 '; then
-  deny "git-sandbox-guard: このリポジトリで作業ツリーを書き換える git は sandbox 内で走らせない。agents/ rules/ skills/ hooks/ commands/ workflows/ への書き込みが拒否され、HEAD だけ進んで作業ツリーと食い違う。${RETRY}"
+  deny "git-sandbox-guard: このリポジトリで作業ツリーを書き換える git は sandbox 内で走らせない。agents/ rules/ skills/ hooks/ commands/ workflows/ への書き込みが拒否され、HEAD だけ進んで作業ツリーと食い違う。dangerouslyDisableSandbox: true を付けて同じコマンドを実行し直す。それも拒否されたら、ユーザーに \`! <コマンド>\` での実行を依頼する。"
 fi

--- a/hooks/security/git-sandbox-guard.sh
+++ b/hooks/security/git-sandbox-guard.sh
@@ -1,0 +1,110 @@
+#!/bin/zsh
+# PreToolUse hook: stop tree-rewriting git commands from running sandboxed in ~/.claude.
+#
+# The sandbox denies Bash writes under agents/ rules/ skills/ hooks/ commands/ workflows/
+# even when settings.json lists them in sandbox.filesystem.allowWrite. git moves HEAD
+# anyway, so the tree is left with HEAD on one commit and those directories on another,
+# and the next pull refuses to run because the tree reads as dirty. Recovering takes a
+# reset plus a per-file checkout, which is why this is worth blocking up front.
+#
+# Failure mode: fail-closed. A command line shlex cannot close hides where its git call
+# sits, so it is not cleared.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+deny() {
+  jq -n --arg reason "$1" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: $reason
+    }
+  }'
+}
+
+INPUT=$(cat)
+
+# Fast-exit before forking jq: only a line mentioning git can reach a denial.
+case "$INPUT" in
+  *git*) ;;
+  *) exit 0 ;;
+esac
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+read -r ESCAPED CWD < <(printf '%s' "$INPUT" | jq -r '[(.tool_input.dangerouslyDisableSandbox // false | tostring), (.cwd // "")] | @tsv') || true
+
+# The caller already turned the sandbox off, so the writes this guard protects will land.
+[[ "$ESCAPED" == "true" ]] && exit 0
+
+# Only the repository whose files the sandbox protects. Another repository checked out
+# under a different path writes freely and needs no guard.
+TOPLEVEL=$(git -C "${CWD:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)
+[[ "$TOPLEVEL" == "$HOME/.claude" ]] || exit 0
+
+COMMAND=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""')
+
+RETRY='dangerouslyDisableSandbox: true を付けて同じコマンドを実行し直す。それも拒否されたら、ユーザーに `! <コマンド>` での実行を依頼する。'
+
+if ! command -v python3 >/dev/null 2>&1; then
+  deny "git-sandbox-guard: python3 が無くコマンドを解析できず、作業ツリーを書き換える git かどうかを判定できない。python3 を用意する。"
+  exit 0
+fi
+
+# Not a regex over the raw string: it cannot tell where a token sits, so `git pull` inside
+# a commit message would read as a pull, and `git -C other/repo pull` would read as one here.
+if printf '%s' "$COMMAND" | LIB_DIR="$SCRIPT_DIR/../lib" python3 -c '
+import os
+import sys
+
+sys.path.insert(0, os.environ["LIB_DIR"])
+import command_scan
+
+# Subcommands that write tracked files in the working tree.
+REWRITES = frozenset({
+    "checkout", "switch", "restore", "pull", "merge", "rebase", "revert",
+    "cherry-pick", "stash", "am", "apply", "clean", "reset",
+})
+
+# git own options that swallow the token after them, which would otherwise read as the
+# subcommand.
+VALUED_GIT_FLAGS = frozenset({"-C", "-c", "--git-dir", "--work-tree", "--namespace"})
+
+# Creating a branch leaves every file where it is.
+BRANCH_CREATE = frozenset({"-b", "-B", "-c", "-C"})
+
+# soft and mixed stop at the index. Only these three carry the change into the tree.
+RESET_WRITES = frozenset({"--hard", "--merge", "--keep"})
+
+# Reading the stash writes nothing.
+STASH_READS = frozenset({"list", "show", "drop", "clear"})
+
+
+def rewrites_tree(tokens):
+    args = tokens[1:]
+    index = 0
+    while index < len(args) and args[index].startswith("-"):
+        index += 2 if args[index] in VALUED_GIT_FLAGS else 1
+    if index >= len(args):
+        return False
+    subcommand, rest = args[index], args[index + 1 :]
+    if subcommand not in REWRITES:
+        return False
+    if subcommand in ("checkout", "switch") and any(a in BRANCH_CREATE for a in rest):
+        return False
+    if subcommand == "reset" and not any(a in RESET_WRITES for a in rest):
+        return False
+    if subcommand == "stash" and rest and rest[0] in STASH_READS:
+        return False
+    return True
+
+
+try:
+    hit = any(c[0] == "git" and rewrites_tree(c) for c in command_scan.commands(sys.stdin.read()))
+except ValueError:
+    hit = True
+sys.exit(0 if hit else 1)
+'; then
+  deny "git-sandbox-guard: このリポジトリで作業ツリーを書き換える git は sandbox 内で走らせない。agents/ rules/ skills/ hooks/ commands/ workflows/ への書き込みが拒否され、HEAD だけ進んで作業ツリーと食い違う。${RETRY}"
+fi

--- a/hooks/security/git-sandbox-guard.sh
+++ b/hooks/security/git-sandbox-guard.sh
@@ -1,5 +1,6 @@
 #!/bin/zsh
-# PreToolUse hook: stop tree-rewriting git commands from running sandboxed in ~/.claude.
+# PreToolUse hook: stop tree-rewriting git commands from running sandboxed in the Claude
+# config directory.
 #
 # The sandbox denies Bash writes under agents/ rules/ skills/ hooks/ commands/ workflows/
 # even when settings.json lists them in sandbox.filesystem.allowWrite. git moves HEAD
@@ -37,9 +38,13 @@ read -r ESCAPED CWD < <(printf '%s' "$INPUT" | jq -r '[(.tool_input.dangerouslyD
 # The caller already turned the sandbox off, so the writes this guard protects will land.
 [[ "$ESCAPED" == "true" ]] && exit 0
 
+# The config directory is what the sandbox protects, and CLAUDE_CONFIG_DIR relocates it.
+# Compared as a physical path because rev-parse reports one.
+GUARDED_ROOT=$(cd "${CLAUDE_CONFIG_DIR:-$HOME/.claude}" 2>/dev/null && pwd -P) || exit 0
+
 # A repository checked out anywhere else writes freely, so only this one needs the guard.
 TOPLEVEL=$(git -C "${CWD:-$PWD}" rev-parse --show-toplevel 2>/dev/null || true)
-[[ "$TOPLEVEL" == "$HOME/.claude" ]] || exit 0
+[[ "$TOPLEVEL" == "$GUARDED_ROOT" ]] || exit 0
 
 if ! command -v python3 >/dev/null 2>&1; then
   deny "git-sandbox-guard: python3 が無くコマンドを解析できず、作業ツリーを書き換える git かどうかを判定できない。python3 を用意する。"

--- a/hooks/tests/test-git-sandbox-guard.sh
+++ b/hooks/tests/test-git-sandbox-guard.sh
@@ -11,9 +11,24 @@ HOOK="$SCRIPT_DIR/../security/git-sandbox-guard.sh"
 # The value alone, so the assertion survives jq switching between -c and pretty output.
 DENY_MARK='"deny"'
 
-GUARDED_CWD="$HOME/.claude"
-# Not a git repository, so the toplevel lookup finds no match and the guard stands down.
-UNGUARDED_CWD="${TMPDIR:-/tmp}"
+TEST_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/git-sandbox-guard-tests-XXXXXX")
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+
+# The guard reads the config directory from CLAUDE_CONFIG_DIR, so a fixture repository
+# stands in for it and the suite passes wherever the checkout lives. pwd -P because
+# rev-parse reports a physical path and macOS hands out a symlinked TMPDIR.
+fixture_repo() {
+  local dir="$TEST_TMPDIR/$1"
+  mkdir -p "$dir"
+  git init -q "$dir"
+  (cd "$dir" && pwd -P)
+}
+
+GUARDED_CWD=$(fixture_repo config)
+# A second repository, to show the guard keys on which repository it is rather than on
+# whether the path is a repository at all.
+UNGUARDED_CWD=$(fixture_repo other)
+export CLAUDE_CONFIG_DIR="$GUARDED_CWD"
 
 # The shared helper carries no cwd or sandbox flag, both of which this hook branches on.
 make_guard_json() {
@@ -75,7 +90,7 @@ test_escaped_call_passes() {
 
 test_other_repository_passes() {
   echo "T-004: 別のリポジトリは対象外"
-  assert_allowed "pull outside the guarded repo" 'git pull' "$UNGUARDED_CWD"
+  assert_allowed "pull in another repository" 'git pull' "$UNGUARDED_CWD"
 }
 
 test_quoted_text_is_not_a_call() {

--- a/hooks/tests/test-git-sandbox-guard.sh
+++ b/hooks/tests/test-git-sandbox-guard.sh
@@ -22,16 +22,20 @@ make_guard_json() {
     '{"tool_name":"Bash","cwd":$cwd,"tool_input":{"command":$cmd,"dangerouslyDisableSandbox":$escaped}}'
 }
 
+run_hook() {
+  make_guard_json "$@" | "$HOOK" 2>/dev/null || true
+}
+
 assert_denied() {
-  local name="$1" cmd="$2" output
-  output=$(make_guard_json "$cmd" | "$HOOK" 2>/dev/null) || true
-  assert_contains "$name" "$DENY_MARK" "$output"
+  local name="$1"
+  shift
+  assert_contains "$name" "$DENY_MARK" "$(run_hook "$@")"
 }
 
 assert_allowed() {
-  local name="$1" cmd="$2" output
-  output=$(make_guard_json "$cmd" | "$HOOK" 2>/dev/null) || true
-  assert_not_contains "$name" "$DENY_MARK" "$output"
+  local name="$1"
+  shift
+  assert_not_contains "$name" "$DENY_MARK" "$(run_hook "$@")"
 }
 
 test_tree_rewriting_is_denied() {
@@ -66,16 +70,12 @@ test_index_only_and_branch_create_pass() {
 
 test_escaped_call_passes() {
   echo "T-003: sandbox を外した呼び出しは通す"
-  local output
-  output=$(make_guard_json 'git pull' "$GUARDED_CWD" true | "$HOOK" 2>/dev/null) || true
-  assert_not_contains "escaped pull" "$DENY_MARK" "$output"
+  assert_allowed "escaped pull" 'git pull' "$GUARDED_CWD" true
 }
 
 test_other_repository_passes() {
   echo "T-004: 別のリポジトリは対象外"
-  local output
-  output=$(make_guard_json 'git pull' "$UNGUARDED_CWD" | "$HOOK" 2>/dev/null) || true
-  assert_not_contains "pull outside the guarded repo" "$DENY_MARK" "$output"
+  assert_allowed "pull outside the guarded repo" 'git pull' "$UNGUARDED_CWD"
 }
 
 test_quoted_text_is_not_a_call() {

--- a/hooks/tests/test-git-sandbox-guard.sh
+++ b/hooks/tests/test-git-sandbox-guard.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Integration tests for security/git-sandbox-guard.sh (PreToolUse hook)
+# The hook is exec'd directly (shebang zsh) — running it under bash masks
+# zsh-specific behavior
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/test-helpers.sh"
+HOOK="$SCRIPT_DIR/../security/git-sandbox-guard.sh"
+
+# The value alone, so the assertion survives jq switching between -c and pretty output.
+DENY_MARK='"deny"'
+
+GUARDED_CWD="$HOME/.claude"
+# Not a git repository, so the toplevel lookup finds no match and the guard stands down.
+UNGUARDED_CWD="${TMPDIR:-/tmp}"
+
+# The shared helper carries no cwd or sandbox flag, both of which this hook branches on.
+make_guard_json() {
+  local cmd="$1" cwd="${2:-$GUARDED_CWD}" escaped="${3:-false}"
+  jq -nc --arg cmd "$cmd" --arg cwd "$cwd" --argjson escaped "$escaped" \
+    '{"tool_name":"Bash","cwd":$cwd,"tool_input":{"command":$cmd,"dangerouslyDisableSandbox":$escaped}}'
+}
+
+assert_denied() {
+  local name="$1" cmd="$2" output
+  output=$(make_guard_json "$cmd" | "$HOOK" 2>/dev/null) || true
+  assert_contains "$name" "$DENY_MARK" "$output"
+}
+
+assert_allowed() {
+  local name="$1" cmd="$2" output
+  output=$(make_guard_json "$cmd" | "$HOOK" 2>/dev/null) || true
+  assert_not_contains "$name" "$DENY_MARK" "$output"
+}
+
+test_tree_rewriting_is_denied() {
+  echo "T-001: 作業ツリーを書き換える git は止める"
+  assert_denied "checkout a branch" 'git checkout main'
+  assert_denied "checkout a path" 'git checkout -- agents/x.md'
+  assert_denied "switch a branch" 'git switch main'
+  assert_denied "pull" 'git pull'
+  assert_denied "pull with args" 'git pull --ff-only origin main'
+  assert_denied "merge" 'git merge origin/main'
+  assert_denied "rebase" 'git rebase main'
+  assert_denied "reset --hard" 'git reset --hard origin/main'
+  assert_denied "revert" 'git revert HEAD'
+  assert_denied "cherry-pick" 'git cherry-pick abc1234'
+  assert_denied "stash pop" 'git stash pop'
+  assert_denied "restore" 'git restore agents/x.md'
+  assert_denied "clean" 'git clean -fd'
+}
+
+test_index_only_and_branch_create_pass() {
+  echo "T-002: ファイルを書かない git は通す"
+  assert_allowed "branch create" 'git checkout -b docs/foo'
+  assert_allowed "switch create" 'git switch -c docs/foo'
+  assert_allowed "reset mixed" 'git reset --mixed origin/main'
+  assert_allowed "reset soft" 'git reset --soft HEAD~1'
+  assert_allowed "stash list" 'git stash list'
+  assert_allowed "fetch" 'git fetch origin'
+  assert_allowed "status" 'git status --short'
+  assert_allowed "diff" 'git diff --stat'
+  assert_allowed "push" 'git push -u origin HEAD'
+}
+
+test_escaped_call_passes() {
+  echo "T-003: sandbox を外した呼び出しは通す"
+  local output
+  output=$(make_guard_json 'git pull' "$GUARDED_CWD" true | "$HOOK" 2>/dev/null) || true
+  assert_not_contains "escaped pull" "$DENY_MARK" "$output"
+}
+
+test_other_repository_passes() {
+  echo "T-004: 別のリポジトリは対象外"
+  local output
+  output=$(make_guard_json 'git pull' "$UNGUARDED_CWD" | "$HOOK" 2>/dev/null) || true
+  assert_not_contains "pull outside the guarded repo" "$DENY_MARK" "$output"
+}
+
+test_quoted_text_is_not_a_call() {
+  echo "T-005: 引用符の中の git はコマンドではない"
+  assert_allowed "pull inside a commit message" 'git commit -m "git pull を追加"'
+  assert_allowed "checkout inside an echo" 'echo "run git checkout main"'
+}
+
+test_unparsable_is_denied() {
+  echo "T-006: 閉じられない行は fail-closed"
+  assert_denied "unbalanced quote" 'git commit -m "unclosed'
+}
+
+test_non_git_passes() {
+  echo "T-007: git 以外は素通り"
+  assert_allowed "ls" 'ls -la'
+  assert_allowed "gh" 'gh pr list'
+}
+
+test_tree_rewriting_is_denied
+test_index_only_and_branch_create_pass
+test_escaped_call_passes
+test_other_repository_passes
+test_quoted_text_is_not_a_call
+test_unparsable_is_denied
+test_non_git_passes
+report_results


### PR DESCRIPTION
## What & Why

sandbox 内で `git pull` や `git checkout <branch>` を走らせると、`agents/` `rules/` `skills/` `hooks/` `commands/` `workflows/` への書き込みが拒否される。git は書き込みに失敗しても HEAD を進めるので、HEAD と作業ツリーが別のコミットを指したまま残る。次の pull は tree が dirty だと判断して中断する。このリポジトリで実際に起き、復旧に `git reset --mixed origin/main` と 28 ファイル分の `git checkout --` が要った。

設定では塞げない。`settings.json` の `sandbox.filesystem.allowWrite` に `~/.claude/workflows` が載っているのに、そこへの書き込みは拒否される。組み込みの deny が user 設定より優先されることを実測した。

## Review focus

- 拒否するサブコマンドの選び方。ファイルを書かない操作 (`checkout -b`、`reset --soft`、`reset --mixed`、`stash list`) を通す判定が `hooks/security/git-sandbox-guard.sh` の `rewrites_tree` にある
- fail-closed の範囲。shlex が閉じられない行は、git 呼び出しの位置が分からないので拒否する
- `if: "Bash(git *)"` を付けていない。`cd x && git pull` を取りこぼすため、hook 側の fast-exit で同じ節約をしている

## Changes

- PreToolUse(Bash) hook を追加。`tool_input.dangerouslyDisableSandbox` が true なら通し、cwd の git toplevel が `~/.claude` でなければ何もしない
- 判定は `hooks/lib/command_scan.py` を再利用し、トークンの位置で git 呼び出しを見つける。`git commit -m "git pull を追加"` はコマンドと読まない
- `docs/HOOKS.md` のイベントマップに、配線済みなのに漏れていた `issue-body-template` も併せて記載

## Scope

- Not included: `settings.json` への配線。gitignore 対象なのでコミットに入らない。このマシンでは適用と発火確認まで済んでおり、別マシンでは `docs/HOOKS.md` の表を見て手動で追加する
- Not included: 破損を検知する PostToolUse hook。予防が効いたので作らなかった

## Design Decisions

- 拒否したうえで `dangerouslyDisableSandbox: true` での再実行を指示する形にした。`hooks/security/rm-to-trash.sh` が `rm` に対して同じ形をとっている
- 実装前に未確定だったのは、hook payload の `tool_input` が sandbox フラグを運ぶかどうかだった。運ばなければ Bash からの git を一律禁止するしかなかったが、実機で escape 済みの再実行が通ったので、自律的な同期を保てる形に決まった
- `git checkout -b` を通す。ブランチ作成はファイルを書かず、sandbox 内で成功することを実測した

## How to Test

1. `bash hooks/tests/test-git-sandbox-guard.sh` を実行する
2. 29 assertion がすべて通る
3. `~/.claude` で `git checkout main` を sandbox 内から実行する
4. hook が拒否し、`dangerouslyDisableSandbox: true` を付けて再実行すると通る

https://claude.ai/code/session_011doXFpTHGkFrQtoF9trsnp
