### PR TITLE
shell テストが 6 passed のまま exit 1 を返す条件を直す

### DIFF
--- a/hooks/lifecycle/tests/failure-alert.test.sh
+++ b/hooks/lifecycle/tests/failure-alert.test.sh
@@ -22,9 +22,13 @@ if [[ ! -f "$SOUND_FILE" ]]; then
   PLACEHOLDER_SOUND="$SOUND_FILE"
 fi
 
+# A trailing `[[ ]] &&` would make the function return non-zero whenever the guard is false, and
+# a trap on EXIT hands that status to the script. An `if` keeps the exit code the body's.
 cleanup() {
   rm -rf "$TEST_TMPDIR"
-  [[ -n "$PLACEHOLDER_SOUND" ]] && rm -f "$PLACEHOLDER_SOUND"
+  if [[ -n "$PLACEHOLDER_SOUND" ]]; then
+    rm -f "$PLACEHOLDER_SOUND"
+  fi
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## What & Why

`failure-alert.test.sh` はテストが 6 passed で終わりながら exit 1 を返す。cleanup 関数の最終行が `[[ -n "$PLACEHOLDER_SOUND" ]] && rm -f ...` で、guard が false のとき関数が非ゼロを返し、trap EXIT がその status をスクリプトへ渡していた。

## Review focus

- CI では再現しない。placeholder を作るのは `sounds/` が空のときだけで、gitignore された音声ファイルを持たない CI では guard が true になり `rm -f` が 0 を返す。音声ファイルを持つ手元でのみ落ちる
- `04073cb9` (CI を通すための修正) で入れた欠陥

## Changes

- cleanup の条件分岐を `if` へ書き換え、終了コードを本体のものに保つ

## How to Test

1. `bash hooks/lifecycle/tests/failure-alert.test.sh >/dev/null 2>&1; echo $?` を実行する
2. 0 が返る
3. `sounds/DHVMagellanHorn_Heavy.mp3` を退避して同じコマンドを実行する
4. 0 が返る
5. `find hooks -name '*.test.sh' -print0 | xargs -0 -r -n1 bash` を実行する
6. 非ゼロで終わらない

https://claude.ai/code/session_01YUg4cv9LGW926ApjNTPRSA
