### PR TITLE
fix(hooks): session ごとの closed display mode 設定をやめる

### DIFF
--- a/.claude/rules/CORRECTIONS.md
+++ b/.claude/rules/CORRECTIONS.md
@@ -12,11 +12,11 @@
 
 ## 外部ツールの実測挙動
 
-| 訂正・知見                                                                                                                                                                                                                                                                                                               | 対象                                              |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
-| `suppressOutput: true` は Stop hook の `additionalContext` を隠さない。掛かるのは stdout の生表示だけで、stop_hook_summary は additionalContext を無条件に「Stop hook feedback: 」として端末へ全文描画する (claude 2.1.233)。表示は注入本文を短くするしかない                                                            | `hooks/lifecycle/reflection_ask.py`               |
-| テストが `HOME` を一時ディレクトリへ差し替えて python3 を spawn すると、mise がグローバル config を not trusted と判定して shim が exit 1 になる (mise 2026.8.6)。失敗はテスト自身の assert 文言で出て実装の欠陥に見えるので、切り分けは `HOME=$(mktemp -d) python3 <script>` を直接叩いて mise の stderr を読む         | `workflows/audit/tests/audit.seam.test.js`        |
-| Amphetamine へ `start new session` を送ると、セッション継続中でも hold を同一秒で解放して張り直す。powerd の `delayDisplayOff` が TurnedOn の間に重なると画面が落ちて即ロックされる。気付く経路は `pmset -g log` の行末 `[System:]` から `PrevDisp` が消えているかの確認で、並行する `caffeinate -di` があれば維持される | `hooks/integrations/amphetamine_agent_session.py` |
+| 訂正・知見                                                                                                                                                                                                                                                                                                       | 対象                                              |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| `suppressOutput: true` は Stop hook の `additionalContext` を隠さない。掛かるのは stdout の生表示だけで、stop_hook_summary は additionalContext を無条件に「Stop hook feedback: 」として端末へ全文描画する (claude 2.1.233)。表示は注入本文を短くするしかない                                                    | `hooks/lifecycle/reflection_ask.py`               |
+| テストが `HOME` を一時ディレクトリへ差し替えて python3 を spawn すると、mise がグローバル config を not trusted と判定して shim が exit 1 になる (mise 2026.8.6)。失敗はテスト自身の assert 文言で出て実装の欠陥に見えるので、切り分けは `HOME=$(mktemp -d) python3 <script>` を直接叩いて mise の stderr を読む | `workflows/audit/tests/audit.seam.test.js`        |
+| closed display mode が有効なまま Amphetamine へ `start new session` を送ると、蓋を閉じた Mac では画面が 1 秒落ちて即ロックされる。assertion の解放は原因ではなく `PrevDisp` が立ったままでも落ちるので、切り分けは CDM の有無を変えて `Display is turned off` と張り直しの同一秒一致を数える                     | `hooks/integrations/amphetamine_agent_session.py` |
 
 ## ハーネスの教訓
 

--- a/hooks/integrations/amphetamine_agent_session.py
+++ b/hooks/integrations/amphetamine_agent_session.py
@@ -62,16 +62,13 @@ def _amph(app_command: str) -> str:
 
 def start_session() -> None:
     """The only place a session is issued: release's ownership test assumes the length."""
+    # Closed-display mode stays Amphetamine's own preference. Setting it per session drops the
+    # display for a second on every swap when the lid is shut.
     options = (
         f"duration:{SESSION_MINUTES}, interval:minutes, "
         + f"displaySleepAllowed:{DISPLAY_SLEEP_ALLOWED}"
     )
     _ = _amph(f"start new session with options {{{options}}}")
-    # The options record carries no closed-display flag, so it is set on the running session.
-    # Sent with no session running, the same command writes the machine-wide preference, which
-    # would outlive every Claude Code process.
-    if _amph("session is active") == "true":
-        _ = _amph("enable closed display mode")
 
 
 def remaining() -> int | None:

--- a/hooks/integrations/tests/amphetamine_agent_session.test.sh
+++ b/hooks/integrations/tests/amphetamine_agent_session.test.sh
@@ -20,7 +20,6 @@ cat > "$STUB_BIN/osascript" <<'STUB'
 printf '%s\n' "$*" >> "$OSASCRIPT_LOG"
 case "$*" in
   *"session time remaining"*) printf '%s\n' "${STUB_REMAINING:--3}" ;;
-  *"session is active"*) printf '%s\n' "${STUB_SESSION_ACTIVE:-true}" ;;
 esac
 exit 0
 STUB
@@ -56,7 +55,6 @@ run_hook_payload() {
     export PATH="$STUB_BIN:$PATH"
     export OSASCRIPT_LOG="$LOG"
     export STUB_REMAINING="$remaining"
-    export STUB_SESSION_ACTIVE="${STUB_SESSION_ACTIVE:-true}"
     export CLAUDE_AMPHETAMINE_STATE_DIR="$STATE_DIR"
     export CLAUDE_AMPHETAMINE_APP="$app"
     "$HOOK" "$action"
@@ -87,20 +85,9 @@ test_acquire_starts_a_session() {
   # and an infinite session would then keep the Mac awake until someone notices.
   assert_contains "asks for a finite duration" "duration:60, interval:minutes" "$(cat "$LOG")"
   assert_contains "holds the display awake" "displaySleepAllowed:false" "$(cat "$LOG")"
-  # The options record has no field for it, so it is sent as its own command.
-  assert_contains "keeps a closed lid awake" "enable closed display mode" "$(cat "$LOG")"
-  assert_eq "one marker written" "1" "$(marker_count)"
-}
-
-test_closed_display_mode_waits_for_a_running_session() {
-  echo "T-020: With no session running after the start, it sends no closed-display command"
-  local STATE_DIR LOG
-  setup
-  # Sent with no session running, the command writes the machine-wide preference instead of
-  # the session's, and that write outlives every Claude Code process.
-  STUB_SESSION_ACTIVE=false run_hook acquire session-a -3
-  assert_contains "sends start new session" "start new session" "$(cat "$LOG")"
+  # Setting closed-display mode per session drops the display for a second with the lid shut.
   assert_not_contains "no closed-display command" "closed display mode" "$(cat "$LOG")"
+  assert_eq "one marker written" "1" "$(marker_count)"
 }
 
 test_acquire_leaves_a_foreign_session_alone() {
@@ -304,7 +291,7 @@ test_release_extends_while_a_workflow_runs() {
 }
 
 test_release_closes_when_the_bg_marker_went_stale() {
-  echo "T-018: A stale bg marker sends end session and clears the marker"
+  echo "T-024: A stale bg marker sends end session and clears the marker"
   local STATE_DIR LOG stamp
   setup
   run_hook acquire session-a -3
@@ -340,6 +327,5 @@ test_background_throttles_repeat_calls
 test_background_leaves_a_foreign_session_alone
 test_release_extends_while_a_workflow_runs
 test_release_closes_when_the_bg_marker_went_stale
-test_closed_display_mode_waits_for_a_running_session
 
 report_results


### PR DESCRIPTION
## What & Why

蓋を閉じた Mac で Amphetamine の session を張り直すと、同じ秒に画面が 1 秒落ちて即ロックされていた。`start new session` の直後に送っていた `enable closed display mode` をやめる。

CDM は Amphetamine 自身の設定として持たせ、session のプロパティとしては触らない。

## 計測

`pmset -g log` の 7 日分 (2026-08-10 19:12 から 2026-08-17 19:05) を突き合わせた。張り直しは `Amphetamine ... Created PreventUserIdleDisplaySleep`、ドロップは `Display is turned off` で、同一秒 ±1 秒の一致を数えた。

張り直し 1093 回、画面オフ 53 秒、一致 21 件。

### 偶然ではない

張り直しの時刻を一定秒ずらして同じ突き合わせを行うと、一致数が落ちる。

| ずらし | 一致 |
| --- | --- |
| 0 (実測) | 21 |
| +30 | 1 |
| +60 | 2 |
| +120 | 1 |
| +300 | 0 |
| -30 | 0 |
| -60 | 1 |
| -120 | 4 |
| -300 | 1 |

8 通りの平均は 1.25 件で、実測はその 17 倍。画面オフは張り直しの秒に集中している。

### 発生には条件が 2 つ要る

| 区間 | CDM | 時間帯 | 張り直し | ドロップ |
| --- | --- | --- | --- | --- |
| 08-16 00:00-02:00 | なし | 深夜 | 92 | 0 |
| 08-17 00:00-03:00 | あり | 深夜 | 122 | 9 |
| 08-17 10:00-17:00 | あり | 日中 | 83 | 0 |

CDM が入ったままの日中 83 回はドロップ 0 件。画面が落ちようとする idle の瞬間に張り直しが重なったときだけ落ちる。

蓋を閉じたまま CDM の有無だけを変えて 5 回ずつ張り直す統制試行も行ったが、両アームともドロップ 0 件だった。試行時の環境は `displaysleep 20` かつ Web App が display sleep を抑止しており、画面が落ちようとする瞬間が来ない。

## Review focus

- **修正の効果はまだ測れていない**。CDM を外したのは 8/17 19:02 で、それ以降の張り直しは 5 回。深夜帯に 100 回程度たまるまで待つ必要がある。この PR は原因の特定までを主張し、効果の確認は実運用に委ねる
- `.claude/rules/CORRECTIONS.md` の行は「蓋を閉じた Mac では」としているが、計測では蓋が閉じているだけでは足りず idle が要ることが分かった。この行はまだ更新していない。深夜帯の観察が済んでから条件を書き足すか、今の時点で書き換えるかは判断が要る
- テストは CDM を送らないことを assert する形へ変え、session の有無で分岐していた T-020 を落とした。CDM を送らないなら session の状態を見る理由が無くなるため

## Changes

- `start_session()` から `enable closed display mode` の呼び出しと、その前段の `session is active` 判定を削除
- テストのスタブから `STUB_SESSION_ACTIVE` を落とし、`assert_not_contains` へ置き換え
- `.claude/rules/CORRECTIONS.md` に切り分け手順を記録

## Scope

- Not included: 効果の確認。深夜帯の張り直しが 100 回程度たまってから同じ集計を走らせる
- Not included: `displaysleep` の設定変更。統制試行で idle を作るには電源設定を触る必要があり、この PR の範囲を超える

## How to Test

1. `bash hooks/integrations/tests/amphetamine_agent_session.test.sh` が 43 passed/0 failed
2. `node --test "agents/**/tests/*.test.js" "hooks/**/tests/*.test.js" "skills/**/tests/*.test.js" "workflows/**/tests/*.test.js"` が 329 pass/0 fail
3. 効果の確認は、深夜帯を挟んだあとに `pmset -g log` で張り直しと `Display is turned off` の同一秒一致を数える

## Related

- 計測中に `enable closed display mode` を session なしで送るとマシン全体の設定を書き換えることを確認した。統制試行では毎回 `session is active` を確かめてから送り、試行後に session/CDM/display sleep allowed の 3 値が試行前と同じであることを照合している
