### PR TITLE
chore(lint): main に残った ruff と oxlint の指摘を消す

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/oxc-project/oxc/main/npm/oxlint/configuration_schema.json",
-  "ignorePatterns": ["plugins/**", "node_modules/**"],
+  "ignorePatterns": ["plugins/**", "node_modules/**", "skills/*/test/cases/**"],
   "globals": {
     "agent": "readonly",
     "parallel": "readonly",

--- a/hooks/pre-bash/client_identifier_gate.py
+++ b/hooks/pre-bash/client_identifier_gate.py
@@ -52,7 +52,7 @@ def _terms() -> list[str]:
     return out
 
 
-def _repo_root(cwd: str) -> Path | None:
+def _repo_root(cwd: str | Path) -> Path | None:
     """The git top level of cwd, or None when cwd is not inside a work tree."""
     try:
         proc = subprocess.run(
@@ -69,7 +69,7 @@ def _repo_root(cwd: str) -> Path | None:
     return Path(proc.stdout.strip()).resolve()
 
 
-def _added_lines(cwd: str) -> list[str] | None:
+def _added_lines(cwd: str | Path) -> list[str] | None:
     """Added lines of the staged diff, with their file headers. None when git cannot answer.
 
     A staged diff that cannot be read is not evidence of a clean commit, so the caller denies
@@ -122,7 +122,7 @@ def main() -> None:
         return
 
     cwd = field(payload, "cwd")
-    cwd = cwd if isinstance(cwd, str) and cwd else os.getcwd()
+    cwd = cwd if isinstance(cwd, str) and cwd else Path.cwd()
     if _repo_root(cwd) != GUARDED_REPO:
         return
 


### PR DESCRIPTION
## What & Why

マージ後の main で lint を掛け直したところ、ruff 1 件と oxlint 1 件が残っていた。どちらも CI が回していないため落ちず、手で測らないと出てこない。

## Changes

### ruff PTH109

`hooks/pre-bash/client_identifier_gate.py:125` の `os.getcwd()` を `Path.cwd()` へ。同じ形の分岐を書いている `hooks/security/git_sandbox_guard.py:189` が既に `Path.cwd()` で、`os.getcwd()` はこの 1 箇所だけだった。`_repo_root` と `_added_lines` は受け取った値を `subprocess.run(cwd=...)` へ渡すだけなので `str | Path` に広げた。

### oxlint no-unused-vars

`skills/*/test/cases/**` を `ignorePatterns` へ追加した。`use-context-reviewer-silence/test/cases/flag/empty-catch.ts` は reviewer に検出させるための故意の空 catch で、oxlint の指摘はその故意の違反を二重に数えている。1 ファイルでなくクラスごと外したのは、他の 10 個の `cases/` ディレクトリも同じ性質の fixture で、今たまたま無指摘なだけのため。

## How to Test

1. `uvx ruff check .` が `All checks passed!` で終わる
2. `npx oxlint` が無出力で終わる
3. `python3 hooks/pre-bash/tests/client_identifier_gate_test.py` が 9 tests OK

## Notes

`.ja` 全体の textlint 151 件は別件で、内訳と対処方針を会話へ出している。

https://claude.ai/code/session_01MmLNye2VFvuPN94Fk9dDFT