### PR TITLE
refactor(transcribe): 何もしない置換を消し、コメントを why に絞る

### DIFF
--- a/.ja/skills/transcribe/scripts/cli.js
+++ b/.ja/skills/transcribe/scripts/cli.js
@@ -4,7 +4,14 @@
 //   verify  <xlsx> <dir>                    元の全セルが出力に残っているか照合する
 
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { cellText, fillRatio, profiles, sheetFileName, sheetToMarkdown } from "./convert.js";
+import {
+  cellText,
+  fillRatio,
+  isColumnRuler,
+  profiles,
+  sheetFileName,
+  sheetToMarkdown,
+} from "./convert.js";
 
 const out = (text) => process.stdout.write(`${text}\n`);
 const err = (text) => process.stderr.write(`${text}\n`);
@@ -48,8 +55,7 @@ if (command === "list") {
     `\nsheets: ${workbook.sheets.length} / cells: ${total.toLocaleString()} / ` +
       `filled: ${filled.toLocaleString()} (${(ratio * 100).toFixed(1)}%)`,
   );
-  // 充填率が低いファイルはレイアウト目的の空セルが大半を占め、素のまま読むと
-  // 空セルがトークンを食う。閾値は書式ごとに違うので、判断は読み手に返す。
+  // 閾値は書式ごとに違うので、ここで分岐せず判断を読み手に返す。
   if (ratio < 0.2) out("充填率が低い。extract で整形してから読む。");
   process.exit(0);
 }
@@ -66,8 +72,8 @@ if (command === "extract") {
     err(`profile が無い: ${profileName} (${Object.keys(profiles).join(", ")})`);
     process.exit(2);
   }
-  // 名前で指定したシートは、ファイル名に使う元の位置が読み込み結果からは分からない。
-  // 判定関数はシート本体を読む前のメタデータに対して走るので、そこで位置を控える。
+  // 読み込み結果はファイル名に要る元のシート位置を落としており、判定関数だけが
+  // その位置を見られる。
   const only = options.sheet;
   let resolved = null;
   let filter;
@@ -126,7 +132,7 @@ if (command === "verify") {
       missing.push({ sheet: sheet.name, reason: "出力が無い" });
       continue;
     }
-    // 出力側は改行を <br>、パイプを \| へ変換しているので、比較前に戻す。
+    // escapeCell の変換を戻さないと、エスケープしたセルがすべて欠落として出る。
     const flat = markdown.replace(/<br>/g, "").replace(/\\\|/g, "|").replace(/\s+/g, "");
     let lost = 0;
     let sample = "";
@@ -134,9 +140,9 @@ if (command === "verify") {
       const cells = row
         .map((cell) => cellText(cell).trim())
         .filter((t) => t !== "");
-      // 1,2,3,... だけが並ぶ行は列番号のものさしで、変換後の Markdown には残らない。
-      // 落とすと欠落として毎シート報告され、本物の欠落が埋もれる。
-      if (cells.length >= 10 && cells.every((t, i) => t === String(i + 1))) continue;
+      // 列番号のものさしは変換後の Markdown に残らないため、数えると毎シート欠落として
+      // 報告され、本物の欠落が埋もれる。
+      if (isColumnRuler(cells)) continue;
       for (const text of cells) {
         if (flat.includes(text.replace(/\s+/g, ""))) continue;
         lost++;

--- a/.ja/skills/transcribe/scripts/convert.js
+++ b/.ja/skills/transcribe/scripts/convert.js
@@ -1,7 +1,6 @@
-// xlsx のシートを Markdown へ変換する。
-// 汎用の抽出処理と、書式ごとの判定を分けて持つ。書式判定はプロファイルが担う。
+// 抽出は書式に依存させず、書式ごとの判定はすべてプロファイルが持つ。
 
-/** セルの値を文字列にする。日付、数式、リッチテキストはそれぞれ別の形で入る。 */
+/** 日付、数式、エラー、リッチテキストはそれぞれ別の形で入る。 */
 export function cellText(cell) {
   if (cell == null) return "";
   if (cell instanceof Date) return cell.toISOString().slice(0, 10);
@@ -15,26 +14,27 @@ export function cellText(cell) {
 }
 
 /**
- * 空セルを落とし、残ったセルを列位置つきで返す。
  * 業務 Excel は 1 項目をセル結合で複数セルに広げるため、列位置が表の列と項目の
- * 入れ子を復元する手がかりになる。
+ * 入れ子を後から復元する手がかりになる。
  */
 export function cellsOf(row) {
   const out = [];
   for (let i = 0; i < row.length; i++) {
-    const text = cellText(row[i]).replace(/ /g, " ").trim();
+    const text = cellText(row[i]).trim();
     if (text !== "") out.push({ col: i, text });
   }
   return out;
 }
 
-/** 1,2,3,... と連番だけが並ぶ行は Excel 上の列番号ガイドなので落とす。 */
-export function isColumnRuler(cells) {
-  if (cells.length < 10) return false;
-  return cells.every((cell, i) => cell.text === String(i + 1));
+const textsOf = (cells) => cells.map((cell) => cell.text);
+
+/** 1,2,3,... と連番だけが並ぶ行は Excel 上の列番号ガイドで、内容ではない。 */
+export function isColumnRuler(texts) {
+  if (texts.length < 10) return false;
+  return texts.every((text, i) => text === String(i + 1));
 }
 
-/** 全シートの充填率。低いほどレイアウト目的の空セルが多く、整形の効果が大きい。 */
+/** 充填率が低いほどレイアウト目的の空セルが多く、整形の効果が大きい。 */
 export function fillRatio(sheets) {
   let total = 0;
   let filled = 0;
@@ -52,7 +52,6 @@ export function escapeCell(text) {
 }
 
 /**
- * ヘッダ行とサブヘッダ行の列位置から列の境界を作る。
  * データ行のセルは列位置が入る区間へ割り当てるので、途中の列が空でも右の列がずれない。
  */
 export function buildColumns(head, sub) {
@@ -71,7 +70,7 @@ export function rowToCells(cells, columns, nestColumnLabel) {
   for (const cell of cells) {
     let index = columns.findIndex((column) => cell.col >= column.start && cell.col < column.end);
     if (index < 0) index = 0;
-    // 入れ子を表す列では、列内のセル位置が階層の深さを表す。全角空白で復元する。
+    // 入れ子を表す列では、列内のセル位置が階層の深さを表す。
     const nested = nestColumnLabel && columns[index].label.includes(nestColumnLabel);
     const depth = nested ? cell.col - columns[index].start : 0;
     slots[index].push("　".repeat(Math.max(0, depth)) + cell.text);
@@ -80,8 +79,8 @@ export function rowToCells(cells, columns, nestColumnLabel) {
 }
 
 /**
- * 書式プロファイル。値が null の判定は行わない。
- * generic は表として解釈しないため、書式が未知のファイルでもセルを落とさない。
+ * 値が null の判定は行わないため、generic は表として解釈せず、書式が未知の
+ * ファイルでもセルを落とさない。
  */
 export const profiles = {
   generic: {
@@ -111,11 +110,10 @@ export function sheetToMarkdown(sheet, profile = profiles.generic) {
   const lines = [`# ${sheet.name}`, ""];
   let i = 0;
 
-  // 文書情報ヘッダを持つ書式では、先頭の数行を引用として畳む。
   if (profile.docHeaderFirstCell && rows[0]?.[0]?.text === profile.docHeaderFirstCell) {
     const meta = [];
     for (const row of rows.slice(0, 3)) {
-      if (!row.length || isColumnRuler(row)) continue;
+      if (!row.length || isColumnRuler(textsOf(row))) continue;
       meta.push(row.map((cell) => cell.text).join(" / "));
     }
     if (meta.length) lines.push(`> ${meta.join("  \n> ")}`, "");
@@ -131,7 +129,7 @@ export function sheetToMarkdown(sheet, profile = profiles.generic) {
 
   while (i < rows.length) {
     const cells = rows[i];
-    if (!cells.length || isColumnRuler(cells)) {
+    if (!cells.length || isColumnRuler(textsOf(cells))) {
       flushCode();
       i++;
       continue;

--- a/skills/transcribe/scripts/cli.js
+++ b/skills/transcribe/scripts/cli.js
@@ -4,7 +4,14 @@
 //   verify  <xlsx> <dir>                    check that every source cell survived into the output
 
 import { readFile, writeFile, mkdir } from "node:fs/promises";
-import { cellText, fillRatio, profiles, sheetFileName, sheetToMarkdown } from "./convert.js";
+import {
+  cellText,
+  fillRatio,
+  isColumnRuler,
+  profiles,
+  sheetFileName,
+  sheetToMarkdown,
+} from "./convert.js";
 
 const out = (text) => process.stdout.write(`${text}\n`);
 const err = (text) => process.stderr.write(`${text}\n`);
@@ -48,8 +55,7 @@ if (command === "list") {
     `\nsheets: ${workbook.sheets.length} / cells: ${total.toLocaleString()} / ` +
       `filled: ${filled.toLocaleString()} (${(ratio * 100).toFixed(1)}%)`,
   );
-  // A file with a low fill ratio is mostly layout-only empty cells, and reading it raw
-  // spends tokens on those. The threshold differs per layout, so the call goes back to the reader.
+  // The threshold differs per layout, so the call goes back to the reader rather than branching here.
   if (ratio < 0.2) out("Fill ratio is low. Convert with extract before reading.");
   process.exit(0);
 }
@@ -66,9 +72,8 @@ if (command === "extract") {
     err(`no such profile: ${profileName} (${Object.keys(profiles).join(", ")})`);
     process.exit(2);
   }
-  // For a sheet named by name, the read result does not carry the original position the
-  // file name needs. The predicate runs against sheet metadata before the body is parsed,
-  // so capture the position there.
+  // The read result drops the original sheet position that the file name needs, and the
+  // predicate is the only place it is still visible.
   const only = options.sheet;
   let resolved = null;
   let filter;
@@ -127,7 +132,7 @@ if (command === "verify") {
       missing.push({ sheet: sheet.name, reason: "no output" });
       continue;
     }
-    // The output turned newlines into <br> and pipes into \|, so undo that before comparing.
+    // Undo what escapeCell did, or every escaped cell reads as lost.
     const flat = markdown.replace(/<br>/g, "").replace(/\\\|/g, "|").replace(/\s+/g, "");
     let lost = 0;
     let sample = "";
@@ -135,9 +140,9 @@ if (command === "verify") {
       const cells = row
         .map((cell) => cellText(cell).trim())
         .filter((t) => t !== "");
-      // A row of nothing but 1,2,3,... is a column ruler and never survives into the Markdown.
-      // Counting it would report a loss on every sheet and bury the real ones.
-      if (cells.length >= 10 && cells.every((t, i) => t === String(i + 1))) continue;
+      // A column ruler never survives into the Markdown, so counting it would report a
+      // loss on every sheet and bury the real ones.
+      if (isColumnRuler(cells)) continue;
       for (const text of cells) {
         if (flat.includes(text.replace(/\s+/g, ""))) continue;
         lost++;

--- a/skills/transcribe/scripts/convert.js
+++ b/skills/transcribe/scripts/convert.js
@@ -1,7 +1,6 @@
-// Convert xlsx sheets into Markdown.
-// Generic extraction and per-layout judgment are kept apart. A profile carries the layout judgment.
+// Extraction stays layout-agnostic; a profile carries every layout-specific judgment.
 
-/** Turn a cell value into text. Dates, formulas and rich text each arrive in their own shape. */
+/** Dates, formulas, errors and rich text each arrive in their own shape. */
 export function cellText(cell) {
   if (cell == null) return "";
   if (cell instanceof Date) return cell.toISOString().slice(0, 10);
@@ -15,26 +14,27 @@ export function cellText(cell) {
 }
 
 /**
- * Drop empty cells and return the rest with their column position.
- * Business spreadsheets spread one item across several cells via merges, so the column
- * position is what lets the table columns and the item nesting be restored.
+ * A business spreadsheet spreads one item across several cells via merges, so the column
+ * position is what lets the table columns and the item nesting be restored later.
  */
 export function cellsOf(row) {
   const out = [];
   for (let i = 0; i < row.length; i++) {
-    const text = cellText(row[i]).replace(/ /g, " ").trim();
+    const text = cellText(row[i]).trim();
     if (text !== "") out.push({ col: i, text });
   }
   return out;
 }
 
-/** A row holding only 1,2,3,... is Excel's column-number guide, so drop it. */
-export function isColumnRuler(cells) {
-  if (cells.length < 10) return false;
-  return cells.every((cell, i) => cell.text === String(i + 1));
+const textsOf = (cells) => cells.map((cell) => cell.text);
+
+/** A row of nothing but 1,2,3,... is Excel's column-number guide, not content. */
+export function isColumnRuler(texts) {
+  if (texts.length < 10) return false;
+  return texts.every((text, i) => text === String(i + 1));
 }
 
-/** Fill ratio across all sheets. The lower it is, the more layout-only empty cells, and the more conversion pays off. */
+/** The lower the ratio, the more layout-only empty cells, and the more conversion pays off. */
 export function fillRatio(sheets) {
   let total = 0;
   let filled = 0;
@@ -52,9 +52,8 @@ export function escapeCell(text) {
 }
 
 /**
- * Build column boundaries from the column positions of the header and sub-header rows.
- * A data cell is assigned to the interval its column position falls in, so an empty
- * middle column does not shift the columns to its right.
+ * A data cell lands in the interval its column position falls in, so an empty middle
+ * column does not shift the columns to its right.
  */
 export function buildColumns(head, sub) {
   const starts = [...new Set([...head, ...sub].map((cell) => cell.col))].sort((a, b) => a - b);
@@ -72,7 +71,7 @@ export function rowToCells(cells, columns, nestColumnLabel) {
   for (const cell of cells) {
     let index = columns.findIndex((column) => cell.col >= column.start && cell.col < column.end);
     if (index < 0) index = 0;
-    // In a nesting column, the cell position within the column carries the depth. Restore it with full-width spaces.
+    // In a nesting column, the cell position within the column carries the depth.
     const nested = nestColumnLabel && columns[index].label.includes(nestColumnLabel);
     const depth = nested ? cell.col - columns[index].start : 0;
     slots[index].push("　".repeat(Math.max(0, depth)) + cell.text);
@@ -81,8 +80,8 @@ export function rowToCells(cells, columns, nestColumnLabel) {
 }
 
 /**
- * Layout profiles. A judgment whose value is null is not performed.
- * generic does not read anything as a table, so an unknown layout loses no cells.
+ * A judgment set to null is not performed, so generic reads nothing as a table and an
+ * unknown layout loses no cells.
  */
 export const profiles = {
   generic: {
@@ -112,11 +111,10 @@ export function sheetToMarkdown(sheet, profile = profiles.generic) {
   const lines = [`# ${sheet.name}`, ""];
   let i = 0;
 
-  // In layouts carrying a document header, fold the leading rows into a quote.
   if (profile.docHeaderFirstCell && rows[0]?.[0]?.text === profile.docHeaderFirstCell) {
     const meta = [];
     for (const row of rows.slice(0, 3)) {
-      if (!row.length || isColumnRuler(row)) continue;
+      if (!row.length || isColumnRuler(textsOf(row))) continue;
       meta.push(row.map((cell) => cell.text).join(" / "));
     }
     if (meta.length) lines.push(`> ${meta.join("  \n> ")}`, "");
@@ -132,7 +130,7 @@ export function sheetToMarkdown(sheet, profile = profiles.generic) {
 
   while (i < rows.length) {
     const cells = rows[i];
-    if (!cells.length || isColumnRuler(cells)) {
+    if (!cells.length || isColumnRuler(textsOf(cells))) {
       flushCode();
       i++;
       continue;

--- a/skills/transcribe/tests/convert.test.js
+++ b/skills/transcribe/tests/convert.test.js
@@ -83,7 +83,7 @@ test("a two-cell row starting with one cell matching a header word stays body ra
 
 test("a column-number guide row holding nothing but a sequence drops from the output", () => {
   const ruler = Array.from({ length: 12 }, (_, i) => String(i + 1));
-  assert.equal(isColumnRuler(ruler.map((text, col) => ({ col, text }))), true);
+  assert.equal(isColumnRuler(ruler), true);
   assert.equal(sheetToMarkdown(sheetOf(ruler)).includes("| 1 | 2 |"), false);
 });
 


### PR DESCRIPTION
## What & Why

CLI 化を検討する前に、`skills/transcribe/scripts/` を読める形にする。読んでいる途中で no-op が 1 つと重複した判定が 1 つ出た。

## Changes

### 何もしない置換 (バグ)

```js
const text = cellText(row[i]).replace(/ /g, " ").trim();
```

hexdump で見ると正規表現側も置換先も `0x20` の半角スペースで、半角スペースを半角スペースへ置き換えている。`git log -S` で追うと初回コミット `ac9a61ee` の時点からこの形で、formatter が壊したものではない。

意図はほぼ確実に NBSP (U+00A0) の正規化で、日本語の業務スプレッドシートでは頻出する。ただし実測すると `trim()` が前後の NBSP と全角空白を既に落としているので、取りこぼしているのは語中の NBSP だけ。

```
trim removes leading/trailing NBSP: "x"
inner NBSP survives: "a b"
```

挙動を変えないよう、今回は消すだけにした。語中 NBSP をどう扱うかは別途判断したい。

### 重複した判定

列番号ものさしの判定が `convert.js` の `isColumnRuler` と `cli.js` の verify に 1 つずつあった。閾値 10 は同じ知識で片方だけ動かせないため、`isColumnRuler` を文字列配列で受ける形にして `cli.js` から呼ぶ。`convert.js` 側は `textsOf` を挟む。

### コメント

コードを読めば分かる説明を落とし、why と why-not だけ残した。関数名の言い換えになっていた行 (`Turn a cell value into text.`、`Fill ratio across all sheets.` ほか) と、直下の式をなぞる行を削除。

## How to Test

1. `node --test` が 441 pass / 0 fail
2. 3 シートの xlsx を `extract --profile ja-api-spec` に通し、整形前の出力とバイト単位で一致すること (確認済み)
3. `npx oxlint` と `npx textlint '.ja/**/*.md'` が無出力

## Notes

CLI として切り出して `use-cli-<name>` skill から呼ぶ案は別で扱う。`hucre/xlsx` はバンドル資材で唯一の node_modules 依存で、プラグインだけ導入した利用者は `bun add hucre` の手動 1 ステップが要る。CLI 化するとその依存が構造的に消える。

https://claude.ai/code/session_01MmLNye2VFvuPN94Fk9dDFT