### PR TITLE
style: ruff format を通し、CI のゲートに載せる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,6 @@ jobs:
       # ruff は JS 依存に無いので版を直に固定する。手元は uvx ruff (2026-08-21 時点 0.16.4)。
       - name: ruff
         run: pipx run --spec ruff==0.16.4 ruff check .
+
+      - name: ruff format
+        run: pipx run --spec ruff==0.16.4 ruff format --check .

--- a/.ja/skills/dr/scripts/pre-check.py
+++ b/.ja/skills/dr/scripts/pre-check.py
@@ -41,8 +41,7 @@ def main() -> None:
         fail('Error: forbidden characters in title (/:*?"<>|)')
     guard_skill_dir(
         dr_dir,
-        "Set DR_DIR env var or run from a project root where"
-        + " docs/decisions/ is the archive.",
+        "Set DR_DIR env var or run from a project root where" + " docs/decisions/ is the archive.",
     )
 
     dr_dir.mkdir(parents=True, exist_ok=True)
@@ -50,9 +49,7 @@ def main() -> None:
         fail(f"Error: no write permission: {dr_dir}")
 
     numbers = [
-        int(m.group(1))
-        for entry in dr_dir.iterdir()
-        if (m := re.match(r"(\d{4})-", entry.name))
+        int(m.group(1)) for entry in dr_dir.iterdir() if (m := re.match(r"(\d{4})-", entry.name))
     ]
     next_num = f"{max(numbers, default=0) + 1:04d}"
 
@@ -70,15 +67,20 @@ def main() -> None:
                 {"file": dr_file.name, "similarity": f"{score:.2f}", "title": existing}
             )
 
-    print(json.dumps({
-        "status": "ok",
-        "number": next_num,
-        "filename": f"{next_num}-{slug}.md",
-        "slug": slug,
-        "date": datetime.now().astimezone().date().isoformat(),
-        "dr_dir": str(dr_dir),
-        "similar_drs": similar_drs,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "number": next_num,
+                "filename": f"{next_num}-{slug}.md",
+                "slug": slug,
+                "date": datetime.now().astimezone().date().isoformat(),
+                "dr_dir": str(dr_dir),
+                "similar_drs": similar_drs,
+            },
+            indent=2,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/.ja/skills/dr/scripts/update-index.py
+++ b/.ja/skills/dr/scripts/update-index.py
@@ -63,13 +63,19 @@ def parse_dr(path: Path) -> tuple[str, str, str]:
     """(title, status, date) from frontmatter and the first # heading."""
     frontmatter, body = split_frontmatter(path.read_text(encoding="utf-8"))
     status = next(
-        (line.removeprefix("status:").strip().strip('"')
-         for line in frontmatter if line.startswith("status:")),
+        (
+            line.removeprefix("status:").strip().strip('"')
+            for line in frontmatter
+            if line.startswith("status:")
+        ),
         "",
     )
     date_str = next(
-        (line.removeprefix("date:").strip().strip('"')
-         for line in frontmatter if line.startswith("date:")),
+        (
+            line.removeprefix("date:").strip().strip('"')
+            for line in frontmatter
+            if line.startswith("date:")
+        ),
         "",
     )
     title = next((line[2:] for line in body if line.startswith("# ")), "")
@@ -96,13 +102,9 @@ def main() -> None:
     parts = [HEADER + "\n".join(rows), "\n## By Status\n"]
     for key, heading in STATUS_SECTIONS:
         if by_status[key]:
-            entries = "\n".join(
-                f"- **{num}**: {title}" for num, title in sorted(by_status[key])
-            )
+            entries = "\n".join(f"- **{num}**: {title}" for num, title in sorted(by_status[key]))
             parts.append(f"### {heading}\n\n{entries}\n")
-    parts.append(
-        FOOTER.format(update_date=datetime.now().astimezone().date().isoformat())
-    )
+    parts.append(FOOTER.format(update_date=datetime.now().astimezone().date().isoformat()))
 
     index_file = dr_dir / "README.md"
     fd, temp_path = tempfile.mkstemp(dir=dr_dir)

--- a/.ja/skills/scribe/scripts/find_wiki_rule.py
+++ b/.ja/skills/scribe/scripts/find_wiki_rule.py
@@ -83,9 +83,7 @@ def find(wiki_dir: str, slug: str, files: list[str]) -> Report:
     related: list[Related] = []
     for page in pages:
         globs = read_globs(page)
-        hits = [
-            f for f in normalized if any(glob_to_regexp(normalize(g)).match(f) for g in globs)
-        ]
+        hits = [f for f in normalized if any(glob_to_regexp(normalize(g)).match(f) for g in globs)]
         if hits:
             matched.append({"page": page.name, "globs": globs, "files": hits})
             continue

--- a/docs/decisions/0098-adopt-usage-census-over-time-based-prediction-ledger.md
+++ b/docs/decisions/0098-adopt-usage-census-over-time-based-prediction-ledger.md
@@ -59,7 +59,7 @@ DR frontmatter の期限で発火する。
 Option B に月次 cron を足す。
 
 - Good, because 実行忘れが起きない
-- Bad, because 通知はゲートではない。`.claude/rules/CORRECTIONS.md` は手動統合バックログとして 13 エントリが未統合のまま積まれている
+- Bad, because 通知はゲートではない。`.claude/rules/CORRECTIONS.md` は手動統合バックログとして 13 エントリが未統合のまま積まれている (この判断の時点の実測。当該ファイルは 2026-08-21 に ADR-0097 の Deprecated と同時に削除した)
 
 ## More Information
 

--- a/hooks/_lib/tests/command_scan_test.py
+++ b/hooks/_lib/tests/command_scan_test.py
@@ -39,7 +39,9 @@ class TestCommands(unittest.TestCase):
         """T-016 A << with no closing line is a word inside quotes and drops no later line"""
         # Dropping them keeps the deletion that follows out of the scan, and the security hook
         # lets it through.
-        self.assertEqual(self.names("git commit -m 'see << EOF\nfor details'\nrm -rf x"), ["git", "rm"])
+        self.assertEqual(
+            self.names("git commit -m 'see << EOF\nfor details'\nrm -rf x"), ["git", "rm"]
+        )
         self.assertEqual(self.names("echo '<< END'\nrm -rf x"), ["echo", "rm"])
 
     def test_quotes_spanning_lines_hold_together(self) -> None:
@@ -87,7 +89,6 @@ class TestCommands(unittest.TestCase):
         """T-010 An unterminated quote raises, letting the caller choose fail-closed"""
         with self.assertRaises(ValueError):
             _ = list(command_scan.commands("echo 'unterminated"))
-
 
     def test_env_assignment_is_not_the_command(self) -> None:
         """T-020 A leading environment assignment is not read as the command name"""

--- a/hooks/_lib/tests/mirror_prose_test.py
+++ b/hooks/_lib/tests/mirror_prose_test.py
@@ -152,7 +152,9 @@ class EnglishVerdict(unittest.TestCase):
         self.assertIsNone(mirror_prose.check_english(path))
 
     def test_a_comment_quoting_a_japanese_literal_is_data(self) -> None:
-        path = self._write_pair("skills/x/scripts/m.py", '# The formatter turns "0件" into "0 件".\n')
+        path = self._write_pair(
+            "skills/x/scripts/m.py", '# The formatter turns "0件" into "0 件".\n'
+        )
         self.assertIsNone(mirror_prose.check_english(path))
 
     def test_a_japanese_string_literal_is_not_prose(self) -> None:

--- a/hooks/edit/tests/mirror_prose_guard_test.py
+++ b/hooks/edit/tests/mirror_prose_guard_test.py
@@ -128,7 +128,9 @@ function processOrder(order, user, config, db, logger) {
 
     def test_read_tool_is_skipped(self) -> None:
         """T-009 Tools other than Write / Edit are out of scope"""
-        path = self.write_at(".ja/skills/other/SKILL.md", "# Sample\n\nThis skill reviews the diff.")
+        path = self.write_at(
+            ".ja/skills/other/SKILL.md", "# Sample\n\nThis skill reviews the diff."
+        )
         self.assertEqual(self.run_hook(path, tool="Read"), "")
 
 

--- a/hooks/edit/tests/textlint_fix_test.py
+++ b/hooks/edit/tests/textlint_fix_test.py
@@ -62,7 +62,9 @@ class TestTextlintFix(unittest.TestCase):
         path = self.write(f"test-{label}.md", REDUNDANT_MD)
         _ = self.run_hook(tool, path)
         self.assertNotIn(
-            "することができます", path.read_text(encoding="utf-8"), f"the redundant expression survives ({label})"
+            "することができます",
+            path.read_text(encoding="utf-8"),
+            f"the redundant expression survives ({label})",
         )
 
     def test_md_write_fixes_file(self) -> None:

--- a/hooks/pre-bash/issue_body_gate.py
+++ b/hooks/pre-bash/issue_body_gate.py
@@ -81,7 +81,9 @@ def main() -> None:
     try:
         filing = gh_filing.find(command, kind="issue")
     except ValueError:
-        deny("issue-body-template: 引用符が閉じておらずコマンドを分割できず、どの断片が起票かを決められない。引用符を閉じて再試行する")
+        deny(
+            "issue-body-template: 引用符が閉じておらずコマンドを分割できず、どの断片が起票かを決められない。引用符を閉じて再試行する"
+        )
         return
     if filing is None:
         return
@@ -89,30 +91,40 @@ def main() -> None:
     title = gh_filing.flag(filing, gh_filing.TITLE_FLAGS)
     issue_type = _issue_type(title) if title else None
     if title is None or issue_type is None:
-        deny("issue-body-template: タイトルに型プレフィックス ([Bug] 等) が無く、どの骨格と照合するかを決められない。タイトルを型で始める")
+        deny(
+            "issue-body-template: タイトルに型プレフィックス ([Bug] 等) が無く、どの骨格と照合するかを決められない。タイトルを型で始める"
+        )
         return
 
     path = gh_filing.body_file(filing)
     if path is None:
-        deny("issue-body-template: 本文が --body のインライン指定で骨格と照合できない。本文を一時ファイルへ書き --body-file にリテラルの絶対パスで渡す")
+        deny(
+            "issue-body-template: 本文が --body のインライン指定で骨格と照合できない。本文を一時ファイルへ書き --body-file にリテラルの絶対パスで渡す"
+        )
         return
 
     # A hook carries none of the shell state the command will run under, so a path written as
     # `"$B"` or `$TMPDIR/body.md` arrives unexpanded and names nothing on disk.
     if not path.is_file():
-        deny(f"issue-body-template: --body-file の指す先 ({path}) が読めず本文を照合できない。パスを変数でなくリテラルの絶対パスで書く")
+        deny(
+            f"issue-body-template: --body-file の指す先 ({path}) が読めず本文を照合できない。パスを変数でなくリテラルの絶対パスで書く"
+        )
         return
 
     template = _template(issue_type, filing.directory)
     if template is None:
         known = ", ".join(sorted(p.stem for p in TEMPLATES.glob("*.md")))
         choices = f"型を {known} のいずれかにするか、" if known else ""
-        deny(f"issue-body-template: 型 [{issue_type}] に対応する骨格が .github/ISSUE_TEMPLATE/ にも skills/issue/templates/ にも無く本文を照合できない。{choices}skills/issue/templates/{issue_type}.md を足す")
+        deny(
+            f"issue-body-template: 型 [{issue_type}] に対応する骨格が .github/ISSUE_TEMPLATE/ にも skills/issue/templates/ にも無く本文を照合できない。{choices}skills/issue/templates/{issue_type}.md を足す"
+        )
         return
 
     errors = _errors(template, title, path)
     if errors is None:
-        deny(f"issue-body-template: validator ({VALIDATOR}) が errors 配列を返さず本文を照合できない。python3 で直接実行して出力を確かめる")
+        deny(
+            f"issue-body-template: validator ({VALIDATOR}) が errors 配列を返さず本文を照合できない。python3 で直接実行して出力を確かめる"
+        )
         return
     if errors:
         deny(f"issue-body-template: 本文の節構成が骨格と食い違う ({'; '.join(errors)})")

--- a/hooks/pre-bash/tests/body_proofread_test.py
+++ b/hooks/pre-bash/tests/body_proofread_test.py
@@ -22,7 +22,9 @@ HOOK = Path(__file__).resolve().parents[1] / "body_proofread.py"
 LINTED_BODY = "この機能はユーザーが設定を変更することができます。この説明は日本語判定の五十文字閾値を超えるための追加の文章です。"
 
 # The second line carries enough commas to trip max-ten, so a heredoc commit draws a finding.
-COMMIT_BODY = "fix(hooks): 処理を行うことが出来ます\n\nこれは、テスト、です、が、読点、が、多すぎ、ます。"
+COMMIT_BODY = (
+    "fix(hooks): 処理を行うことが出来ます\n\nこれは、テスト、です、が、読点、が、多すぎ、ます。"
+)
 
 FINDINGS = "textlint 校正結果"
 CHECKLIST = "構造レビュー"

--- a/hooks/pre-bash/tests/client_identifier_gate_test.py
+++ b/hooks/pre-bash/tests/client_identifier_gate_test.py
@@ -68,9 +68,7 @@ class ClientIdentifierGateTest(unittest.TestCase):
         (repo / name).write_text(text, encoding="utf-8")
         subprocess.run(["git", "add", name], cwd=repo, check=True, capture_output=True)
 
-    def run_hook(
-        self, command: str, cwd: Path, list_path: Path | None = None
-    ) -> object:
+    def run_hook(self, command: str, cwd: Path, list_path: Path | None = None) -> object:
         # separators without spaces: a hook that greps the raw payload sees the compact form,
         # so the fixture has to produce it too.
         payload = json.dumps(
@@ -78,9 +76,7 @@ class ClientIdentifierGateTest(unittest.TestCase):
             separators=(",", ":"),
         )
         env = dict(os.environ)
-        env["CLAUDE_CLIENT_NAMES_FILE"] = str(
-            self.list_path if list_path is None else list_path
-        )
+        env["CLAUDE_CLIENT_NAMES_FILE"] = str(self.list_path if list_path is None else list_path)
         proc = subprocess.run(
             [sys.executable, str(HOOK)],
             input=payload,

--- a/hooks/pre-bash/tests/issue_body_gate_test.py
+++ b/hooks/pre-bash/tests/issue_body_gate_test.py
@@ -140,9 +140,7 @@ class TestIssueBodyGate(unittest.TestCase):
     # separators without spaces: the hook's fast-exit greps the raw payload for the literal
     # `"tool_name":"Bash"`, which the default json.dumps spacing misses. Claude Code sends the
     # compact form, so this is what the hook actually receives.
-    def run_hook(
-        self, command: str, hook: Path | None = None
-    ) -> tuple[object, str, int]:
+    def run_hook(self, command: str, hook: Path | None = None) -> tuple[object, str, int]:
         payload = json.dumps(
             {"tool_name": "Bash", "tool_input": {"command": command}}, separators=(",", ":")
         )

--- a/hooks/pre-bash/tests/package_manager_rewrite_test.py
+++ b/hooks/pre-bash/tests/package_manager_rewrite_test.py
@@ -170,7 +170,13 @@ class TestPackageManagerRewrite(unittest.TestCase):
     def test_manager_flags_are_left_alone(self) -> None:
         """T-014 A flag of the manager itself is not read as a subcommand"""
         # Handed to na it reports on ni itself, never on the manager that was asked about.
-        for command in ("npm --version", "npm -v", "pnpm --version", "yarn --version", "bun --help"):
+        for command in (
+            "npm --version",
+            "npm -v",
+            "pnpm --version",
+            "yarn --version",
+            "bun --help",
+        ):
             self.assert_left_alone(command)
 
     def test_bun_test_runner_is_left_alone(self) -> None:

--- a/hooks/security/git_sandbox_guard.py
+++ b/hooks/security/git_sandbox_guard.py
@@ -28,12 +28,30 @@ from hook_payload import deny, field, parse
 # Subcommands that reach the working tree. Most move the index and leave the file behind
 # under the sandbox; checkout-index and read-tree go the other way, writing the tree from an
 # index the sandbox never blocked.
-REWRITES = frozenset({
-    "checkout", "switch", "restore", "pull", "merge", "rebase", "revert",
-    "cherry-pick", "stash", "am", "apply", "clean", "reset",
-    "rm", "mv", "sparse-checkout", "bisect", "checkout-index", "read-tree",
-    "filter-branch",
-})
+REWRITES = frozenset(
+    {
+        "checkout",
+        "switch",
+        "restore",
+        "pull",
+        "merge",
+        "rebase",
+        "revert",
+        "cherry-pick",
+        "stash",
+        "am",
+        "apply",
+        "clean",
+        "reset",
+        "rm",
+        "mv",
+        "sparse-checkout",
+        "bisect",
+        "checkout-index",
+        "read-tree",
+        "filter-branch",
+    }
+)
 
 # Printing the usage reaches no file, whichever subcommand it is asked of.
 HELP = frozenset({"--help", "-h"})
@@ -131,9 +149,7 @@ def rewrites(command: str) -> bool:
     commit message would read as a pull.
     """
     try:
-        return any(
-            c[0] == "git" and _rewrites_tree(c) for c in command_scan.commands(command)
-        )
+        return any(c[0] == "git" and _rewrites_tree(c) for c in command_scan.commands(command))
     except ValueError:
         return True
 

--- a/skills/dr/scripts/pre-check.py
+++ b/skills/dr/scripts/pre-check.py
@@ -41,8 +41,7 @@ def main() -> None:
         fail('Error: forbidden characters in title (/:*?"<>|)')
     guard_skill_dir(
         dr_dir,
-        "Set DR_DIR env var or run from a project root where"
-        + " docs/decisions/ is the archive.",
+        "Set DR_DIR env var or run from a project root where" + " docs/decisions/ is the archive.",
     )
 
     dr_dir.mkdir(parents=True, exist_ok=True)
@@ -50,9 +49,7 @@ def main() -> None:
         fail(f"Error: no write permission: {dr_dir}")
 
     numbers = [
-        int(m.group(1))
-        for entry in dr_dir.iterdir()
-        if (m := re.match(r"(\d{4})-", entry.name))
+        int(m.group(1)) for entry in dr_dir.iterdir() if (m := re.match(r"(\d{4})-", entry.name))
     ]
     next_num = f"{max(numbers, default=0) + 1:04d}"
 
@@ -70,15 +67,20 @@ def main() -> None:
                 {"file": dr_file.name, "similarity": f"{score:.2f}", "title": existing}
             )
 
-    print(json.dumps({
-        "status": "ok",
-        "number": next_num,
-        "filename": f"{next_num}-{slug}.md",
-        "slug": slug,
-        "date": datetime.now().astimezone().date().isoformat(),
-        "dr_dir": str(dr_dir),
-        "similar_drs": similar_drs,
-    }, indent=2))
+    print(
+        json.dumps(
+            {
+                "status": "ok",
+                "number": next_num,
+                "filename": f"{next_num}-{slug}.md",
+                "slug": slug,
+                "date": datetime.now().astimezone().date().isoformat(),
+                "dr_dir": str(dr_dir),
+                "similar_drs": similar_drs,
+            },
+            indent=2,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/skills/dr/scripts/update-index.py
+++ b/skills/dr/scripts/update-index.py
@@ -63,13 +63,19 @@ def parse_dr(path: Path) -> tuple[str, str, str]:
     """(title, status, date) from frontmatter and the first # heading."""
     frontmatter, body = split_frontmatter(path.read_text(encoding="utf-8"))
     status = next(
-        (line.removeprefix("status:").strip().strip('"')
-         for line in frontmatter if line.startswith("status:")),
+        (
+            line.removeprefix("status:").strip().strip('"')
+            for line in frontmatter
+            if line.startswith("status:")
+        ),
         "",
     )
     date_str = next(
-        (line.removeprefix("date:").strip().strip('"')
-         for line in frontmatter if line.startswith("date:")),
+        (
+            line.removeprefix("date:").strip().strip('"')
+            for line in frontmatter
+            if line.startswith("date:")
+        ),
         "",
     )
     title = next((line[2:] for line in body if line.startswith("# ")), "")
@@ -96,13 +102,9 @@ def main() -> None:
     parts = [HEADER + "\n".join(rows), "\n## By Status\n"]
     for key, heading in STATUS_SECTIONS:
         if by_status[key]:
-            entries = "\n".join(
-                f"- **{num}**: {title}" for num, title in sorted(by_status[key])
-            )
+            entries = "\n".join(f"- **{num}**: {title}" for num, title in sorted(by_status[key]))
             parts.append(f"### {heading}\n\n{entries}\n")
-    parts.append(
-        FOOTER.format(update_date=datetime.now().astimezone().date().isoformat())
-    )
+    parts.append(FOOTER.format(update_date=datetime.now().astimezone().date().isoformat()))
 
     index_file = dr_dir / "README.md"
     fd, temp_path = tempfile.mkstemp(dir=dr_dir)

--- a/skills/dr/tests/script-contract.test.js
+++ b/skills/dr/tests/script-contract.test.js
@@ -17,8 +17,10 @@ const validates = pair("scripts", "validate-dr.py");
 const indexes = pair("scripts", "update-index.py");
 
 const outputKeys = (src) => {
-  const block = src.slice(src.indexOf("print(json.dumps({"));
-  return [...block.matchAll(/^\s{8}"(\w+)":/gm)].map((m) => m[1]);
+  // Bounded to the dumps call rather than to an indent width, so reformatting the call does not
+  // change what the contract reads as.
+  const block = src.slice(src.indexOf("json.dumps("), src.indexOf("indent=2"));
+  return [...block.matchAll(/"(\w+)":/g)].map((m) => m[1]);
 };
 const statusValues = (src) =>
   (src.match(/^STATUS_VALUES = re\.compile\(r"([^"]+)"\)/m)?.[1] ?? "").split("|");

--- a/skills/scribe/scripts/find_wiki_rule.py
+++ b/skills/scribe/scripts/find_wiki_rule.py
@@ -84,9 +84,7 @@ def find(wiki_dir: str, slug: str, files: list[str]) -> Report:
     related: list[Related] = []
     for page in pages:
         globs = read_globs(page)
-        hits = [
-            f for f in normalized if any(glob_to_regexp(normalize(g)).match(f) for g in globs)
-        ]
+        hits = [f for f in normalized if any(glob_to_regexp(normalize(g)).match(f) for g in globs)]
         if hits:
             matched.append({"page": page.name, "globs": globs, "files": hits})
             continue

--- a/skills/scribe/tests/skill_contract_test.py
+++ b/skills/scribe/tests/skill_contract_test.py
@@ -137,7 +137,6 @@ class SkillContract(unittest.TestCase):
             for needle in ("templates/page.md", "_candidates.md", repairs[lang]):
                 self.assertIn(needle, step, f"{lang}: {needle}")
 
-
     def test_the_page_reaches_a_plan_through_thinks_finder(self) -> None:
         """The page a run writes reaches an implementation only by think citing it. No index and
         no lookup at implementation time stand between the two, so this is the whole path."""

--- a/workflows/build/tests/revalidate_test.py
+++ b/workflows/build/tests/revalidate_test.py
@@ -82,9 +82,7 @@ class RunTest(unittest.TestCase):
         ]
         results = revalidate.run(pre, self.root)
         self.assertEqual(len(results), 3)
-        self.assertEqual(
-            [r["path"] for r in results], ["present.js", "missing.js", "present.js"]
-        )
+        self.assertEqual([r["path"] for r in results], ["present.js", "missing.js", "present.js"])
 
     def test_none_pattern_normalized_to_empty_string(self) -> None:
         results = revalidate.run([{"path": "present.js", "pattern": None}], self.root)
@@ -134,9 +132,7 @@ class CliTest(unittest.TestCase):
     def test_stdin_to_stdout_contract(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             _ = (Path(tmp) / "f.txt").write_text("has anchor here", encoding="utf-8")
-            proc = self._run(
-                json.dumps([{"path": "f.txt", "pattern": "anchor"}]), cwd=tmp
-            )
+            proc = self._run(json.dumps([{"path": "f.txt", "pattern": "anchor"}]), cwd=tmp)
             self.assertEqual(proc.returncode, 0)
             out = cast("object", json.loads(proc.stdout))
             self.assertEqual(

--- a/workflows/build/tests/verify_tests_test.py
+++ b/workflows/build/tests/verify_tests_test.py
@@ -40,9 +40,7 @@ class RunTest(unittest.TestCase):
     def setUp(self) -> None:
         self._tmp = tempfile.TemporaryDirectory()
         self.root = Path(self._tmp.name)
-        _ = (self.root / "foo.test.js").write_text(
-            'test("rejects negative amounts", () => {});\n'
-        )
+        _ = (self.root / "foo.test.js").write_text('test("rejects negative amounts", () => {});\n')
         _ = (self.root / "foo.js").write_text("export const foo = 1;\n")
 
     @override
@@ -90,9 +88,7 @@ class RunTest(unittest.TestCase):
         _ = (self.root / "wrapped.test.js").write_text(
             'test(\n  "rejects negative\n  amounts",\n  () => {},\n);\n'
         )
-        results = self._run(
-            [{"files": ["wrapped.test.js"], "names": ["rejects negative amounts"]}]
-        )
+        results = self._run([{"files": ["wrapped.test.js"], "names": ["rejects negative amounts"]}])
         self.assertEqual(results[0]["found"], True)
 
     def test_whitespace_only_statement_is_not_found(self) -> None:


### PR DESCRIPTION
## What & Why

`ruff format --check` が 19 ファイルを未整形と報告する状態のまま、CI にも載っていなかった。整形して CI のゲートに載せる。#410 の上に積んである。

## Changes

### 整形 19 ファイル

`ruff.toml` の per-file-ignores が守っている `deny()` の日本語メッセージは、1 本のリテラルのまま呼び出しの中へ移っただけで折り返されていない。文面を grep で辿れる状態は変わらない。

```python
-        deny("issue-body-template: 引用符が閉じておらず…引用符を閉じて再試行する")
+        deny(
+            "issue-body-template: 引用符が閉じておらず…引用符を閉じて再試行する"
+        )
```

`.ja` と英語側の 3 ペア (`pre-check.py` / `update-index.py` / `find_wiki_rule.py`) はコメントを除く行数が一致したままで、構造のずれは出ていない。

### 落ちたテストの修正

`skills/dr/tests/script-contract.test.js` が整形で落ちた。出力キーの抽出が `print(json.dumps({` という呼び出しの形と 8 桁のインデントを固定しており、キー名という本来の契約でなく整形結果を見ていた。

```js
-  const block = src.slice(src.indexOf("print(json.dumps({"));
-  return [...block.matchAll(/^\s{8}"(\w+)":/gm)].map((m) => m[1]);
+  const block = src.slice(src.indexOf("json.dumps("), src.indexOf("indent=2"));
+  return [...block.matchAll(/"(\w+)":/g)].map((m) => m[1]);
```

`filename` キーを消すと落ちることを確かめた。

### ADR-0098 の宙ぶらりん参照

Option C の Bad が、削除済みの `.claude/rules/CORRECTIONS.md` を現在形で指していた。判断時点の実測であることと、いつ何と一緒に消えたかを併記する。DR 本文の履歴は書き換えず注記だけ足す形にした。

### CI

`ruff format --check .` を `test.yml` へ追加。`ruff check` と同じ pin 版を使う。zizmor は無指摘。

## How to Test

1. `uvx ruff format --check .` が `494 files already formatted`
2. `node --test` が 442 pass / 0 fail
3. CI の ruff format ステップが緑

https://claude.ai/code/session_01MmLNye2VFvuPN94Fk9dDFT