### PR TITLE
[Feature] build の停止理由を記録して数えられるようにする

### DIFF
--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -37,11 +37,97 @@ const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue 
 // ("a11y" など) を issue 参照と読まない。
 const issueNumber =
   (issueRef.match(/^#?(\d+)$/) || issueRef.match(/\/issues\/(\d+)(?:[/?#]|$)/) || [])[1] || "";
-if (!issueRef || !issueNumber) {
-  return {
-    stopped: "no-issue",
-    why: 'issue を args で渡す ("123" / "#123" / URL / {issue, repo})。resume 時に runtime は args を運ばないので、Workflow({scriptPath, resumeFromRunId, args}) で渡し直す。',
+// ---- run の記録: build の 1 実行につき jsonl 1 行 ----
+// 停止は返り値として呼び出し元に届くだけでどこにも残らないため、plan 品質が build を
+// 止めた回数を数えられなかった。停止はすべて下の stop ヘルパーを通り、そこから
+// workflows/build/record.py へ 1 行追記する。
+// PLAN_QUALITY は、その停止を issue の ## Plan 節の側で防げたかどうかを持つ。true の 6 つは
+// plan の内容そのものが起こす Load / Revalidate の停止で、false は環境・relay の取りこぼし・
+// 入れ子の code に由来する。true の件数を数えることが、/qualify を build の前段で必須にするか
+// (DR-0084 の再評価条件) を決める。
+const PLAN_QUALITY = {
+  "no-issue": false,
+  "no-repo": false,
+  "invalid-base": false,
+  "no-issue-body": false,
+  "no-plan": true,
+  "extraction-failed": true,
+  "invalid-plan": true,
+  "extraction-mismatch": true,
+  "oversized-unit": true,
+  "dirty-branch-point": false,
+  "revalidate-failed": false,
+  "revalidate-incomplete": false,
+  "plan-drift": true,
+  "code-failed": false,
+};
+// このブロックは obj() より前に置くので、schema は組み立てずに直に書く。
+const RECORD_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["run_id"],
+  properties: {
+    path: { type: "string", description: "record.py の stdout JSON の path をそのまま" },
+    run_id: { type: "string", description: "record.py の stdout JSON の run_id をそのまま" },
+  },
+};
+// workflow script は時計も乱数も持たない (rules/conventions/WORKFLOWS.md § Script evaluation
+// form) ので、runId は record.py の stdout から受け取る。停止の行はそれを渡し直し、同じ build
+// の開始の行と結び付く。
+let runId = "";
+// 記録が始まるのは anchor が存在してから、つまり repo が判明した後。それより上の gate は行を
+// 残さずに返る。どれも plan 品質の信号ではなく、記録の agent を固定するリポジトリも無い。
+let recordable = false;
+// branch は Branch が解決するまで分からないので、それより前に書く行は "" を持つ。
+let recordedBranch = "";
+const recordRun = async (reason, fields = {}) => {
+  const payload = {
+    run_id: runId,
+    issue: issueNumber,
+    repo,
+    branch: recordedBranch,
+    reason,
+    // 表に無い reason は開始の行であり、plan 品質による停止ではない。
+    plan_quality: PLAN_QUALITY[reason] === true,
+    ...fields,
   };
+  const written = await agent(
+    anchor(
+      `build の 1 実行を記録する。値を判断・要約・編集しない。手順は、(1) この JSON をそのまま一時ファイルへ書く。` +
+        `(2) \`python3 ${bundled("workflows/build/record.py")} < <tempfile>\` を実行する。` +
+        `(3) script の stdout の run_id と path をそのまま返す。` +
+        `script は {"path":...,"run_id":...} を出力する。\n` +
+        `入力 JSON は次のとおり。\n${JSON.stringify(payload)}`,
+    ),
+    {
+      label: `record:${reason}`,
+      agentType: "general-purpose",
+      schema: RECORD_SCHEMA,
+      model: "haiku",
+    },
+  );
+  const id = String((written && written.run_id) || "").trim();
+  // 記録が build を止めることはないので、relay の失敗は fail-open で進む。その run は件数から
+  // 落ちるが、読み手がそれを知れるのはこの行だけ。
+  if (!id) {
+    log(
+      `"${reason}" の行を書けなかった (記録側が run_id を返さなかった)。この run は build-runs.jsonl に現れない。`,
+    );
+    return;
+  }
+  runId = id;
+};
+// stopped の返り値を組み立てる唯一の場所。fields は呼び出し元への返り値に、recordFields は
+// jsonl の行に載る。
+const stop = async (reason, fields = {}, recordFields = {}) => {
+  if (recordable) await recordRun(reason, recordFields);
+  return { stopped: reason, ...fields };
+};
+
+if (!issueRef || !issueNumber) {
+  return await stop("no-issue", {
+    why: 'issue を args で渡す ("123" / "#123" / URL / {issue, repo})。resume 時に runtime は args を運ばないので、Workflow({scriptPath, resumeFromRunId, args}) で渡し直す。',
+  });
 }
 
 // repo が無いと agent は自身の cwd から「リポジトリ」を解決し、別の checkout で
@@ -55,16 +141,14 @@ const baseBranch = typeof input.base === "string" ? input.base.trim() : "";
 // そこへ差し込むのでなく run を止める。
 const BRANCH_NAME_SHAPE = /^[\w][\w./-]*$/;
 if (!repo) {
-  return {
-    stopped: "no-repo",
+  return await stop("no-repo", {
     why: `対象リポジトリを args.repo (絶対パス) で渡す: Workflow({name: "build", args: {issue: "${issueNumber}", repo: "/abs/path"}})。`,
-  };
+  });
 }
 if (baseBranch && !BRANCH_NAME_SHAPE.test(baseBranch)) {
-  return {
-    stopped: "invalid-base",
+  return await stop("invalid-base", {
     why: `args.base がブランチ名の形ではない。main のような素のブランチ名を渡す。`,
-  };
+  });
 }
 const anchor = (p) =>
   `すべての git / ファイル / ビルドコマンドを ${repo} のリポジトリから実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`;
@@ -105,6 +189,11 @@ const FETCH_SCHEMA = obj(["found", "body"], {
   },
 });
 
+// 開始の行は Load が issue を読む前に書く。途中で殺された run も分母に残り、完走した run と
+// 停止した run だけが件数に残る状態にならない。
+recordable = true;
+await recordRun("started");
+
 // ---- Load: 逐語 fetch → Plan 見出し確認 → 決定論 id 収集 → 抽出 → validate + クロスチェック ----
 // 渡すのは抽出した番号で、受け取った参照そのものではない。URL は /issues/N がどこかに
 // あれば一致するので、そのまま渡すと後続の文字列ごとシェルへ入る。番号なら anchor が
@@ -124,10 +213,9 @@ const fetched = await agent(
   },
 );
 if (!fetched || !fetched.found || !String(fetched.body || "").trim()) {
-  return {
-    stopped: "no-issue-body",
+  return await stop("no-issue-body", {
     why: `issue ${issueRef} の本文を取得できない。issue 番号と repo を確認する。`,
-  };
+  });
 }
 const body = fetched.body;
 
@@ -342,12 +430,11 @@ const oversizedUnits = (p) =>
 // 代わりに生成せず issue の精緻化に差し戻す。
 const planHeading = body.match(/^##\s+Plan\b.*$/m);
 if (!planHeading) {
-  return {
-    stopped: "no-plan",
+  return await stop("no-plan", {
     why:
       `issue ${issueRef} に ## Plan 節が無く、実装対象になる検証済みの選択が存在しない。` +
       `まず issue を精緻化する。/think で設計して plan を下書きし、/issue で issue の ## Plan 節へ転記してから build を再実行する。`,
-  };
+  });
 }
 
 const afterHeading = body.slice(planHeading.index + planHeading[0].length);
@@ -380,7 +467,7 @@ const plan = await agent(
   },
 );
 if (!plan) {
-  return { stopped: "extraction-failed", why: "extract agent が plan を返さなかった。" };
+  return await stop("extraction-failed", { why: "extract agent が plan を返さなかった。" });
 }
 
 // Bug issue はタイトルに `[Bug]` prefix を持つ。fetch が title を取得できなかったときは
@@ -388,7 +475,7 @@ if (!plan) {
 // 当て推量はしない)。
 const blockers = validate(plan, String(fetched.title || "").startsWith("[Bug]"));
 if (blockers.length) {
-  return { stopped: "invalid-plan", blockers, why: "抽出した plan が構造 validation に失敗。" };
+  return await stop("invalid-plan", { blockers, why: "抽出した plan が構造 validation に失敗。" });
 }
 
 // id 集合の厳密比較で、抽出時の silent drop と捏造を reject する。
@@ -402,22 +489,20 @@ const mismatch = {
   tests_extra: setDiff(planTestIds, bodyTestIds),
 };
 if (Object.values(mismatch).some((l) => l.length)) {
-  return {
-    stopped: "extraction-mismatch",
+  return await stop("extraction-mismatch", {
     detail: mismatch,
     why: "issue 本文と抽出結果の U/T id 集合が一致しない。",
-  };
+  });
 }
 
 const oversized = oversizedUnits(plan);
 if (oversized.length) {
-  return {
-    stopped: "oversized-unit",
+  return await stop("oversized-unit", {
     units: oversized.map((u) => u.id),
     why:
       `非 seam unit が UNIT_CAPS (files <= ${UNIT_CAPS.files} / tests <= ${UNIT_CAPS.tests}) を超えている。` +
       "/think Phase 3 の unit サイズ上限に沿って unit をさらに分割し、issue を /issue で精緻化して再実行する。",
-  };
+  });
 }
 log(
   `Plan 抽出: ${plan.units.length} unit / ${planTestIds.size} test scenario、id クロスチェック pass。`,
@@ -514,7 +599,7 @@ const [reval, branchRes, baseline] = await parallel([
     agent(
       anchor(
         `issue #${issueNumber} ${JSON.stringify(plan.outcome)} の作業ブランチを新規に checkout する。` +
-        `まず ${bundled("skills/checkout/references/branch-naming.md")} を読み、その規則でブランチ名を組み立てる。` +
+          `まず ${bundled("skills/checkout/references/branch-naming.md")} を読み、その規則でブランチ名を組み立てる。` +
           // base 起点を指定した呼び出しでは「現在のブランチを維持する」を書かない。
           // 同じプロンプトに両方を置くと後者が前者を打ち消す。
           (baseBranch
@@ -550,6 +635,9 @@ const [reval, branchRes, baseline] = await parallel([
     ),
 ]);
 const branch = (branchRes && branchRes.branch) || "";
+// ここから先の行は branch を持つ。停止を issue 番号だけでなく、それが起きた checkout まで
+// 辿れる。
+recordedBranch = branch;
 // build 以前から作業ツリーにある私物を Verify の scope 逸脱から差し引き、同じ一覧を
 // build 以前から作業ツリーにある私物を Verify の scope 逸脱から差し引き、commit agent の
 // never-stage 集合にも渡す。
@@ -564,8 +652,7 @@ if (!perUnitCommits) log("分岐点 sha を取得できず、Ship で 1 回 comm
 // 破棄したブランチや前タスクのブランチの上に積むと、Verify も PR もそれを今回の成果として
 // 扱う。scope 逸脱にも conformance にも現れないので、ここで止める。
 if (baseBranch && Number(branchRes && branchRes.ahead_of_base) > 0) {
-  return {
-    stopped: "dirty-branch-point",
+  return await stop("dirty-branch-point", {
     branch,
     base: baseBranch,
     ahead_of_base: Number(branchRes.ahead_of_base),
@@ -573,16 +660,15 @@ if (baseBranch && Number(branchRes && branchRes.ahead_of_base) > 0) {
       `分岐点が ${baseBranch} より ${Number(branchRes.ahead_of_base)} コミット進んでいる。既存のコミットの上に実装を積むと、` +
       `それが今回の成果として PR に載る。${baseBranch} から新しいブランチを切り直して再実行するか、` +
       `その差分を今回の起点として意図しているなら base を実際の起点ブランチに変えて再実行する。`,
-  };
+  });
 }
 if (revalidationTargets.length) {
   if (!reval || !Array.isArray(reval.results)) {
-    return {
-      stopped: "revalidate-failed",
+    return await stop("revalidate-failed", {
       detail: reval,
       branch,
       why: "revalidate agent が results 配列を返さなかった。",
-    };
+    });
   }
   // 件数でなく (path, pattern) で突き合わせる。並べ替えやすり替えは件数が変わらない。
   const keyOf = (o) => JSON.stringify([o.path, o.pattern || ""]);
@@ -614,12 +700,11 @@ if (revalidationTargets.length) {
       for (const r of retry.results) resultByKey.set(keyOf(r), r);
     unreported = preconditions.filter((pc) => !resultByKey.has(keyOf(pc)));
     if (unreported.length) {
-      return {
-        stopped: "revalidate-incomplete",
+      return await stop("revalidate-incomplete", {
         unreported,
         branch,
         why: "verifier が一部の前提に結果を返さなかった (ファイル不在の plan-drift とは別)。再実行する。",
-      };
+      });
     }
   }
   // `r &&` は precondition には効かない (ここに来た時点で必ず結果を持つ)。効くのは
@@ -636,12 +721,11 @@ if (revalidationTargets.length) {
     if (r && (!r.exists || !r.matches)) drift.push(r);
   }
   if (drift.length) {
-    return {
-      stopped: "plan-drift",
+    return await stop("plan-drift", {
       drift,
       branch,
       why: "issue の plan が前提にするコードが現在のコードベースに無い。issue を更新して再実行する。",
-    };
+    });
   }
   // reference_module のエントリは結果が欠けても fail-open で進むので、全件を
   // precondition として数えると走っていない検査まで pass したと読める。
@@ -678,7 +762,10 @@ const code =
     untracked_baseline: baselineUntracked,
   })) || null;
 if (!code || code.stopped) {
-  return { stopped: "code-failed", detail: code };
+  // code の内側で起きた plan 起因の停止はここへ code-failed として届き、plan 品質ではないと
+  // 分類される。nested_reason が内側の理由を行に載せるので、1 つの箱に埋もれず数えられる。
+  const nested = String((code && code.stopped) || "").trim();
+  return await stop("code-failed", { detail: code }, nested ? { nested_reason: nested } : {});
 }
 if (!code.tests_pass || !code.gates_pass)
   log(

--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -38,13 +38,9 @@ const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue 
 const issueNumber =
   (issueRef.match(/^#?(\d+)$/) || issueRef.match(/\/issues\/(\d+)(?:[/?#]|$)/) || [])[1] || "";
 // ---- run の記録: build の 1 実行につき jsonl 1 行 ----
-// 停止は返り値として呼び出し元に届くだけでどこにも残らないため、plan 品質が build を
-// 止めた回数を数えられなかった。停止はすべて下の stop ヘルパーを通り、そこから
-// workflows/build/record.py へ 1 行追記する。
-// PLAN_QUALITY は、その停止を issue の ## Plan 節の側で防げたかどうかを持つ。true の 6 つは
-// plan の内容そのものが起こす Load / Revalidate の停止で、false は環境・relay の取りこぼし・
-// 入れ子の code に由来する。true の件数を数えることが、/qualify を build の前段で必須にするか
-// (DR-0084 の再評価条件) を決める。
+// PLAN_QUALITY は、その停止を issue の ## Plan 節の側で防げたかどうかを持つ。true の件数が
+// /qualify を build の前段で必須にするか (DR-0084 の再評価条件) を決める。どのファイルにも
+// 届かない返り値のままでは、その問いに答えられない。
 const PLAN_QUALITY = {
   "no-issue": false,
   "no-repo": false,
@@ -71,14 +67,12 @@ const RECORD_SCHEMA = {
     run_id: { type: "string", description: "record.py の stdout JSON の run_id をそのまま" },
   },
 };
-// workflow script は時計も乱数も持たない (rules/conventions/WORKFLOWS.md § Script evaluation
-// form) ので、runId は record.py の stdout から受け取る。停止の行はそれを渡し直し、同じ build
-// の開始の行と結び付く。
+// workflow script は時計を持たず、乱数も引けない (rules/conventions/WORKFLOWS.md § Script
+// evaluation form) ので、runId は record.py が発行する。
 let runId = "";
-// 記録が始まるのは anchor が存在してから、つまり repo が判明した後。それより上の gate は行を
-// 残さずに返る。どれも plan 品質の信号ではなく、記録の agent を固定するリポジトリも無い。
+// anchor より上の gate は行を残さずに返る。plan 品質の信号ではなく、記録の agent を固定する
+// リポジトリも無い。
 let recordable = false;
-// branch は Branch が解決するまで分からないので、それより前に書く行は "" を持つ。
 let recordedBranch = "";
 const recordRun = async (reason, fields = {}) => {
   const payload = {
@@ -87,7 +81,7 @@ const recordRun = async (reason, fields = {}) => {
     repo,
     branch: recordedBranch,
     reason,
-    // 表に無い reason は開始の行であり、plan 品質による停止ではない。
+    // 表に無い reason は停止でなく開始の行。
     plan_quality: PLAN_QUALITY[reason] === true,
     ...fields,
   };
@@ -107,8 +101,7 @@ const recordRun = async (reason, fields = {}) => {
     },
   );
   const id = String((written && written.run_id) || "").trim();
-  // 記録が build を止めることはないので、relay の失敗は fail-open で進む。その run は件数から
-  // 落ちるが、読み手がそれを知れるのはこの行だけ。
+  // 記録が build を止めることはないので、relay の失敗は run を止めず fail-open で進む。
   if (!id) {
     log(
       `"${reason}" の行を書けなかった (記録側が run_id を返さなかった)。この run は build-runs.jsonl に現れない。`,
@@ -117,8 +110,7 @@ const recordRun = async (reason, fields = {}) => {
   }
   runId = id;
 };
-// stopped の返り値を組み立てる唯一の場所。fields は呼び出し元への返り値に、recordFields は
-// jsonl の行に載る。
+// stopped の返り値はここでしか組み立てない。行を残さずに抜ける停止を作れない。
 const stop = async (reason, fields = {}, recordFields = {}) => {
   if (recordable) await recordRun(reason, recordFields);
   return { stopped: reason, ...fields };
@@ -189,8 +181,8 @@ const FETCH_SCHEMA = obj(["found", "body"], {
   },
 });
 
-// 開始の行は Load が issue を読む前に書く。途中で殺された run も分母に残り、完走した run と
-// 停止した run だけが件数に残る状態にならない。
+// 開始の行は Load より前に書く。途中で殺された run も分母に残り、終端まで行った run だけで
+// 件数を数える状態にならない。
 recordable = true;
 await recordRun("started");
 
@@ -635,8 +627,6 @@ const [reval, branchRes, baseline] = await parallel([
     ),
 ]);
 const branch = (branchRes && branchRes.branch) || "";
-// ここから先の行は branch を持つ。停止を issue 番号だけでなく、それが起きた checkout まで
-// 辿れる。
 recordedBranch = branch;
 // build 以前から作業ツリーにある私物を Verify の scope 逸脱から差し引き、同じ一覧を
 // build 以前から作業ツリーにある私物を Verify の scope 逸脱から差し引き、commit agent の
@@ -762,9 +752,8 @@ const code =
     untracked_baseline: baselineUntracked,
   })) || null;
 if (!code || code.stopped) {
-  // code の内側で起きた plan 起因の停止はここへ code-failed として届き、plan 品質ではないと
-  // 分類される。nested_reason が内側の理由を行に載せるので、1 つの箱に埋もれず数えられる。
-  const nested = String((code && code.stopped) || "").trim();
+  // nested_reason が無いと、code の内側で起きた plan 起因の停止は code-failed としか数えられない。
+  const nested = String((code && code.stopped) || "");
   return await stop("code-failed", { detail: code }, nested ? { nested_reason: nested } : {});
 }
 if (!code.tests_pass || !code.gates_pass)

--- a/.ja/workflows/build/record.py
+++ b/.ja/workflows/build/record.py
@@ -1,0 +1,79 @@
+"""Usage: record.py   (build の run payload JSON を stdin で受ける)
+
+build の 1 実行を $HOME/.claude/history/build-runs.jsonl へ 1 行追記する。
+
+stdin:  JSON {issue, repo, branch, reason, plan_quality, run_id?, nested_reason?}
+        キーは row にそのまま写す。"?" の無い 5 つは、無ければ空の既定値で埋めるので、
+        どの row も同じキー集合で読める。
+stdout: {path, run_id} の JSON 1 行。呼び出し元は同じ build の次の row へ run_id を
+        渡し直す。停止の row が開始の row と結び付くのはこの経路だけ。
+exit 0 は成功。exit 1 は payload が parse 不能 (何も書かない)。
+
+row に追加される解決済みフィールド:
+  run_id        uuid4 の hex。payload が run_id を持たないときだけ発行する。build は
+                同じ秒のうちに開始して停止しうるので、timestamp では両者を分けられない。
+  generated_at  UTC ISO-8601
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn, cast
+
+HISTORY_DIR = Path.home() / ".claude" / "history"
+# ファイル名は固定。1 実行 1 行の追記なので、集計は jsonl を 1 本読むだけで済む。
+RUNS_PATH = HISTORY_DIR / "build-runs.jsonl"
+
+# 呼び出し元が載せる既定値付きのフィールド。開始の row は branch をまだ持たないが、
+# キーを落とすと読み手が row の種類ごとに分岐することになるので、空文字で埋める。
+DEFAULTS: dict[str, object] = {
+    "issue": "",
+    "repo": "",
+    "branch": "",
+    "reason": "",
+    "plan_quality": False,
+}
+
+
+def fail(message: str) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def build_row(payload: dict[str, object], run_id: str, generated_at: str) -> dict[str, object]:
+    row: dict[str, object] = {"run_id": run_id}
+    for key, default in DEFAULTS.items():
+        row[key] = payload.get(key, default)
+    for key, value in payload.items():
+        if key not in row:
+            row[key] = value
+    row["generated_at"] = generated_at
+    return row
+
+
+def main() -> None:
+    raw_stdin = sys.stdin.read()
+    try:
+        loaded = cast("object", json.loads(raw_stdin))
+    except ValueError as exc:
+        fail(f"unparseable payload: {exc}")
+    if not isinstance(loaded, dict):
+        fail("payload must be a JSON object")
+    payload = cast("dict[str, object]", loaded)
+
+    supplied = payload.pop("run_id", "")
+    run_id = str(supplied) if supplied else uuid.uuid4().hex
+
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    row = build_row(payload, run_id=run_id, generated_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    with RUNS_PATH.open("a") as fh:
+        _ = fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(json.dumps({"path": str(RUNS_PATH), "run_id": run_id}))
+
+
+if __name__ == "__main__":
+    main()

--- a/.ja/workflows/build/record.py
+++ b/.ja/workflows/build/record.py
@@ -5,8 +5,8 @@ build の 1 実行を $HOME/.claude/history/build-runs.jsonl へ 1 行追記す�
 stdin:  JSON {issue, repo, branch, reason, plan_quality, run_id?, nested_reason?}
         キーは row にそのまま写す。"?" の無い 5 つは、無ければ空の既定値で埋めるので、
         どの row も同じキー集合で読める。
-stdout: {path, run_id} の JSON 1 行。呼び出し元は同じ build の次の row へ run_id を
-        渡し直す。停止の row が開始の row と結び付くのはこの経路だけ。
+stdout: {path, run_id} の JSON 1 行。呼び出し元が同じ build の次の row へ run_id を
+        渡し直し、停止の row は開始の row と結び付く。
 exit 0 は成功。exit 1 は payload が parse 不能 (何も書かない)。
 
 row に追加される解決済みフィールド:
@@ -23,11 +23,11 @@ from pathlib import Path
 from typing import NoReturn, cast
 
 HISTORY_DIR = Path.home() / ".claude" / "history"
-# ファイル名は固定。1 実行 1 行の追記なので、集計は jsonl を 1 本読むだけで済む。
+# audit のような run ごとのファイルでなく 1 本に固定する。集計が jsonl を 1 本読むだけで済む。
 RUNS_PATH = HISTORY_DIR / "build-runs.jsonl"
 
-# 呼び出し元が載せる既定値付きのフィールド。開始の row は branch をまだ持たないが、
-# キーを落とすと読み手が row の種類ごとに分岐することになるので、空文字で埋める。
+# 開始の row は branch をまだ持たない。キーを落とすと読み手が row の種類ごとに分岐する
+# ことになるので、既定値で埋める。
 DEFAULTS: dict[str, object] = {
     "issue": "",
     "repo": "",
@@ -40,17 +40,6 @@ DEFAULTS: dict[str, object] = {
 def fail(message: str) -> NoReturn:
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(1)
-
-
-def build_row(payload: dict[str, object], run_id: str, generated_at: str) -> dict[str, object]:
-    row: dict[str, object] = {"run_id": run_id}
-    for key, default in DEFAULTS.items():
-        row[key] = payload.get(key, default)
-    for key, value in payload.items():
-        if key not in row:
-            row[key] = value
-    row["generated_at"] = generated_at
-    return row
 
 
 def main() -> None:
@@ -68,7 +57,12 @@ def main() -> None:
 
     HISTORY_DIR.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
-    row = build_row(payload, run_id=run_id, generated_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    row = {
+        "run_id": run_id,
+        **DEFAULTS,
+        **payload,
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
 
     with RUNS_PATH.open("a") as fh:
         _ = fh.write(json.dumps(row, ensure_ascii=False) + "\n")

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -38,11 +38,98 @@ const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue 
 // merely contains digits (e.g. "a11y") must not be read as an issue reference.
 const issueNumber =
   (issueRef.match(/^#?(\d+)$/) || issueRef.match(/\/issues\/(\d+)(?:[/?#]|$)/) || [])[1] || "";
-if (!issueRef || !issueNumber) {
-  return {
-    stopped: "no-issue",
-    why: 'Pass the issue as args ("123" / "#123" / URL / {issue, repo}). On resume the runtime does not carry args, so re-pass it: Workflow({scriptPath, resumeFromRunId, args}).',
+// ---- Run recording: one jsonl row per build run ----
+// A stop reaches the caller as a return value and lands nowhere else, so how often plan quality
+// stopped a build could not be counted. Every stop routes through the stop helper below, which
+// appends a row through workflows/build/record.py.
+// PLAN_QUALITY says whether the issue's ## Plan section could have prevented that stop. The six
+// true values are the Load / Revalidate stops the plan's own content causes; the false ones come
+// from the environment, a dropped relay, or the nested code run. Counting the true ones is what
+// decides whether /qualify becomes mandatory ahead of build (DR-0084's reassessment trigger).
+const PLAN_QUALITY = {
+  "no-issue": false,
+  "no-repo": false,
+  "invalid-base": false,
+  "no-issue-body": false,
+  "no-plan": true,
+  "extraction-failed": true,
+  "invalid-plan": true,
+  "extraction-mismatch": true,
+  "oversized-unit": true,
+  "dirty-branch-point": false,
+  "revalidate-failed": false,
+  "revalidate-incomplete": false,
+  "plan-drift": true,
+  "code-failed": false,
+};
+// The schema is written out rather than assembled by obj(), which this block precedes.
+const RECORD_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["run_id"],
+  properties: {
+    path: { type: "string", description: "path from record.py's stdout JSON, verbatim" },
+    run_id: { type: "string", description: "run_id from record.py's stdout JSON, verbatim" },
+  },
+};
+// runId comes back from record.py's stdout, because a workflow script has neither a clock nor a
+// random source (rules/conventions/WORKFLOWS.md § Script evaluation form). The stop row carries
+// it back, which is how it joins the start row of the same build.
+let runId = "";
+// Recording starts once anchor exists, which is after the repo is known. The gates above that
+// point return without a row: neither is a plan-quality signal, and the recorder's agent would
+// have no repository to be anchored to.
+let recordable = false;
+// The branch is unknown until Branch resolves it, so the rows written before then carry "".
+let recordedBranch = "";
+const recordRun = async (reason, fields = {}) => {
+  const payload = {
+    run_id: runId,
+    issue: issueNumber,
+    repo,
+    branch: recordedBranch,
+    reason,
+    // A reason outside the table is the start row, which is not a plan-quality stop.
+    plan_quality: PLAN_QUALITY[reason] === true,
+    ...fields,
   };
+  const written = await agent(
+    anchor(
+      `Record one build run; do not judge, summarize, or edit any value. The steps are, (1) write this exact JSON to a temp file; ` +
+        `(2) run \`python3 ${bundled("workflows/build/record.py")} < <tempfile>\`; ` +
+        `(3) return the script's stdout run_id and path verbatim. ` +
+        `The script prints {"path":...,"run_id":...}.\n` +
+        `The input JSON is as follows.\n${JSON.stringify(payload)}`,
+    ),
+    {
+      label: `record:${reason}`,
+      agentType: "general-purpose",
+      schema: RECORD_SCHEMA,
+      model: "haiku",
+    },
+  );
+  const id = String((written && written.run_id) || "").trim();
+  // Recording never gates a build, so a failed relay falls open. The run is then absent from
+  // the count, and this line is the only place a reader learns that.
+  if (!id) {
+    log(
+      `The "${reason}" row was not written (the recorder returned no run_id), so this run is missing from build-runs.jsonl.`,
+    );
+    return;
+  }
+  runId = id;
+};
+// The single assembly point for a stopped return. fields lands on the caller's return value,
+// recordFields on the jsonl row.
+const stop = async (reason, fields = {}, recordFields = {}) => {
+  if (recordable) await recordRun(reason, recordFields);
+  return { stopped: reason, ...fields };
+};
+
+if (!issueRef || !issueNumber) {
+  return await stop("no-issue", {
+    why: 'Pass the issue as args ("123" / "#123" / URL / {issue, repo}). On resume the runtime does not carry args, so re-pass it: Workflow({scriptPath, resumeFromRunId, args}).',
+  });
 }
 
 // Without repo, agents resolve "the repository" from their own cwd and can run
@@ -57,16 +144,14 @@ const baseBranch = typeof input.base === "string" ? input.base.trim() : "";
 // name's shape stops the run instead of being spliced into them.
 const BRANCH_NAME_SHAPE = /^[\w][\w./-]*$/;
 if (!repo) {
-  return {
-    stopped: "no-repo",
+  return await stop("no-repo", {
     why: `Pass the target repository as args.repo (absolute path): Workflow({name: "build", args: {issue: "${issueNumber}", repo: "/abs/path"}}).`,
-  };
+  });
 }
 if (baseBranch && !BRANCH_NAME_SHAPE.test(baseBranch)) {
-  return {
-    stopped: "invalid-base",
+  return await stop("invalid-base", {
     why: `args.base is not a branch name. Pass a plain branch name such as main.`,
-  };
+  });
 }
 const anchor = (p) =>
   `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`;
@@ -109,6 +194,11 @@ const FETCH_SCHEMA = obj(["found", "body"], {
   },
 });
 
+// The start row is written before Load reads the issue, so a run killed mid-flight still stands
+// in the denominator instead of leaving the count with completed and stopped runs alone.
+recordable = true;
+await recordRun("started");
+
 // ---- Load: verbatim fetch -> Plan heading check -> deterministic id collection -> extract -> validate + cross-check ----
 // The extracted number, never the reference as given: a URL matches as long as /issues/N
 // appears anywhere in it, so passing it through would carry whatever follows into the shell.
@@ -128,10 +218,9 @@ const fetched = await agent(
   },
 );
 if (!fetched || !fetched.found || !String(fetched.body || "").trim()) {
-  return {
-    stopped: "no-issue-body",
+  return await stop("no-issue-body", {
     why: `Could not fetch the body of issue ${issueRef}. Check the issue number and repo.`,
-  };
+  });
 }
 const body = fetched.body;
 
@@ -358,12 +447,11 @@ const oversizedUnits = (p) =>
 // place.
 const planHeading = body.match(/^##\s+Plan\b.*$/m);
 if (!planHeading) {
-  return {
-    stopped: "no-plan",
+  return await stop("no-plan", {
     why:
       `Issue ${issueRef} has no ## Plan section, so there is no verified selection to implement against. ` +
       `Refine the issue first: run /think to design and draft the plan, then /issue to transfer it into the issue's ## Plan section, and relaunch build.`,
-  };
+  });
 }
 
 const afterHeading = body.slice(planHeading.index + planHeading[0].length);
@@ -396,7 +484,7 @@ const plan = await agent(
   },
 );
 if (!plan) {
-  return { stopped: "extraction-failed", why: "The extract agent returned no plan." };
+  return await stop("extraction-failed", { why: "The extract agent returned no plan." });
 }
 
 // A Bug issue carries a `[Bug]` prefix in its title. fetch omits title when it could not read
@@ -404,11 +492,10 @@ if (!plan) {
 // not-a-Bug rather than guessing either way.
 const blockers = validate(plan, String(fetched.title || "").startsWith("[Bug]"));
 if (blockers.length) {
-  return {
-    stopped: "invalid-plan",
+  return await stop("invalid-plan", {
     blockers,
     why: "The extracted plan fails structural validation.",
-  };
+  });
 }
 
 // Reject silent drops / fabrications in extraction via exact id-set comparison.
@@ -422,22 +509,20 @@ const mismatch = {
   tests_extra: setDiff(planTestIds, bodyTestIds),
 };
 if (Object.values(mismatch).some((l) => l.length)) {
-  return {
-    stopped: "extraction-mismatch",
+  return await stop("extraction-mismatch", {
     detail: mismatch,
     why: "The U/T id sets in the issue body and the extraction do not match.",
-  };
+  });
 }
 
 const oversized = oversizedUnits(plan);
 if (oversized.length) {
-  return {
-    stopped: "oversized-unit",
+  return await stop("oversized-unit", {
     units: oversized.map((u) => u.id),
     why:
       `A non-seam unit exceeds UNIT_CAPS (files <= ${UNIT_CAPS.files} / tests <= ${UNIT_CAPS.tests}). Split it further ` +
       "per /think Phase 3's unit-size guidance, then refine the issue's Plan via /issue and relaunch.",
-  };
+  });
 }
 log(
   `Plan extracted: ${plan.units.length} unit(s), ${planTestIds.size} test scenario(s), id cross-check pass.`,
@@ -572,6 +657,9 @@ const [reval, branchRes, baseline] = await parallel([
     ),
 ]);
 const branch = (branchRes && branchRes.branch) || "";
+// From here on the rows carry the branch, so a stop can be traced back to the checkout it
+// happened on rather than to the issue number alone.
+recordedBranch = branch;
 // Subtracts pre-existing clutter from Verify's scope deviations, and doubles as the
 // commit agents' never-stage set.
 const baselineUntracked = baseline && Array.isArray(baseline.untracked) ? baseline.untracked : [];
@@ -587,8 +675,7 @@ if (!perUnitCommits)
 // PR treat it as this run's output. It shows up in neither scope deviations nor
 // conformance, so stop here.
 if (baseBranch && Number(branchRes && branchRes.ahead_of_base) > 0) {
-  return {
-    stopped: "dirty-branch-point",
+  return await stop("dirty-branch-point", {
     branch,
     base: baseBranch,
     ahead_of_base: Number(branchRes.ahead_of_base),
@@ -596,16 +683,15 @@ if (baseBranch && Number(branchRes && branchRes.ahead_of_base) > 0) {
       `The branch point is ${Number(branchRes.ahead_of_base)} commit(s) ahead of ${baseBranch}. Implementing on top of those commits ` +
       `puts them on the PR as this build's work. Branch off ${baseBranch} again and relaunch, or - if that delta ` +
       `is the intended starting point - set base to the actual starting branch and relaunch.`,
-  };
+  });
 }
 if (revalidationTargets.length) {
   if (!reval || !Array.isArray(reval.results)) {
-    return {
-      stopped: "revalidate-failed",
+    return await stop("revalidate-failed", {
       detail: reval,
       branch,
       why: "The revalidate agent returned no results array.",
-    };
+    });
   }
   // Bind by (path, pattern), not by count: reordered or substituted entries keep the
   // length identical.
@@ -638,12 +724,11 @@ if (revalidationTargets.length) {
       for (const r of retry.results) resultByKey.set(keyOf(r), r);
     unreported = preconditions.filter((pc) => !resultByKey.has(keyOf(pc)));
     if (unreported.length) {
-      return {
-        stopped: "revalidate-incomplete",
+      return await stop("revalidate-incomplete", {
         unreported,
         branch,
         why: "The verifier returned no result for some preconditions (distinct from plan-drift, where the file is absent). Relaunch.",
-      };
+      });
     }
   }
   // `r &&` does nothing for a precondition, which always has a result by here; it exists for a
@@ -660,12 +745,11 @@ if (revalidationTargets.length) {
     if (r && (!r.exists || !r.matches)) drift.push(r);
   }
   if (drift.length) {
-    return {
-      stopped: "plan-drift",
+    return await stop("plan-drift", {
       drift,
       branch,
       why: "Code the issue's plan presupposes is absent from the current codebase. Update the issue and relaunch.",
-    };
+    });
   }
   // A reference_module entry advances fail-open when its result is missing, so counting
   // them all as passed preconditions claims a verification that never ran.
@@ -703,7 +787,11 @@ const code =
     untracked_baseline: baselineUntracked,
   })) || null;
 if (!code || code.stopped) {
-  return { stopped: "code-failed", detail: code };
+  // A plan-caused stop inside code arrives here as code-failed, which is classified as not
+  // plan-quality. nested_reason carries the inner reason onto the row, so the count can reach
+  // it instead of losing it under one bucket.
+  const nested = String((code && code.stopped) || "").trim();
+  return await stop("code-failed", { detail: code }, nested ? { nested_reason: nested } : {});
 }
 if (!code.tests_pass || !code.gates_pass)
   log(

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -39,13 +39,9 @@ const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue 
 const issueNumber =
   (issueRef.match(/^#?(\d+)$/) || issueRef.match(/\/issues\/(\d+)(?:[/?#]|$)/) || [])[1] || "";
 // ---- Run recording: one jsonl row per build run ----
-// A stop reaches the caller as a return value and lands nowhere else, so how often plan quality
-// stopped a build could not be counted. Every stop routes through the stop helper below, which
-// appends a row through workflows/build/record.py.
-// PLAN_QUALITY says whether the issue's ## Plan section could have prevented that stop. The six
-// true values are the Load / Revalidate stops the plan's own content causes; the false ones come
-// from the environment, a dropped relay, or the nested code run. Counting the true ones is what
-// decides whether /qualify becomes mandatory ahead of build (DR-0084's reassessment trigger).
+// PLAN_QUALITY says whether the issue's ## Plan section could have prevented the stop. Counting
+// the true ones decides whether /qualify becomes mandatory ahead of build (DR-0084's
+// reassessment trigger), which a stopped return value reaching no file could never answer.
 const PLAN_QUALITY = {
   "no-issue": false,
   "no-repo": false,
@@ -72,15 +68,12 @@ const RECORD_SCHEMA = {
     run_id: { type: "string", description: "run_id from record.py's stdout JSON, verbatim" },
   },
 };
-// runId comes back from record.py's stdout, because a workflow script has neither a clock nor a
-// random source (rules/conventions/WORKFLOWS.md § Script evaluation form). The stop row carries
-// it back, which is how it joins the start row of the same build.
+// record.py mints runId, because a workflow script has neither a clock nor a random source
+// (rules/conventions/WORKFLOWS.md § Script evaluation form).
 let runId = "";
-// Recording starts once anchor exists, which is after the repo is known. The gates above that
-// point return without a row: neither is a plan-quality signal, and the recorder's agent would
-// have no repository to be anchored to.
+// The gates ahead of anchor return without a row: neither is a plan-quality signal, and the
+// recorder's agent would have no repository to be anchored to.
 let recordable = false;
-// The branch is unknown until Branch resolves it, so the rows written before then carry "".
 let recordedBranch = "";
 const recordRun = async (reason, fields = {}) => {
   const payload = {
@@ -89,7 +82,7 @@ const recordRun = async (reason, fields = {}) => {
     repo,
     branch: recordedBranch,
     reason,
-    // A reason outside the table is the start row, which is not a plan-quality stop.
+    // A reason outside the table is the start row, not a stop.
     plan_quality: PLAN_QUALITY[reason] === true,
     ...fields,
   };
@@ -109,8 +102,7 @@ const recordRun = async (reason, fields = {}) => {
     },
   );
   const id = String((written && written.run_id) || "").trim();
-  // Recording never gates a build, so a failed relay falls open. The run is then absent from
-  // the count, and this line is the only place a reader learns that.
+  // Recording never gates a build, so a failed relay falls open instead of stopping the run.
   if (!id) {
     log(
       `The "${reason}" row was not written (the recorder returned no run_id), so this run is missing from build-runs.jsonl.`,
@@ -119,8 +111,7 @@ const recordRun = async (reason, fields = {}) => {
   }
   runId = id;
 };
-// The single assembly point for a stopped return. fields lands on the caller's return value,
-// recordFields on the jsonl row.
+// Every stopped return is assembled here, so no stop can leave without its row.
 const stop = async (reason, fields = {}, recordFields = {}) => {
   if (recordable) await recordRun(reason, recordFields);
   return { stopped: reason, ...fields };
@@ -194,8 +185,8 @@ const FETCH_SCHEMA = obj(["found", "body"], {
   },
 });
 
-// The start row is written before Load reads the issue, so a run killed mid-flight still stands
-// in the denominator instead of leaving the count with completed and stopped runs alone.
+// The start row goes ahead of Load, so a run killed mid-flight still stands in the denominator
+// rather than leaving the count to the runs that reached an end.
 recordable = true;
 await recordRun("started");
 
@@ -657,8 +648,6 @@ const [reval, branchRes, baseline] = await parallel([
     ),
 ]);
 const branch = (branchRes && branchRes.branch) || "";
-// From here on the rows carry the branch, so a stop can be traced back to the checkout it
-// happened on rather than to the issue number alone.
 recordedBranch = branch;
 // Subtracts pre-existing clutter from Verify's scope deviations, and doubles as the
 // commit agents' never-stage set.
@@ -787,10 +776,8 @@ const code =
     untracked_baseline: baselineUntracked,
   })) || null;
 if (!code || code.stopped) {
-  // A plan-caused stop inside code arrives here as code-failed, which is classified as not
-  // plan-quality. nested_reason carries the inner reason onto the row, so the count can reach
-  // it instead of losing it under one bucket.
-  const nested = String((code && code.stopped) || "").trim();
+  // Without nested_reason a plan-caused stop inside code would be counted as code-failed alone.
+  const nested = String((code && code.stopped) || "");
   return await stop("code-failed", { detail: code }, nested ? { nested_reason: nested } : {});
 }
 if (!code.tests_pass || !code.gates_pass)

--- a/workflows/build/record.py
+++ b/workflows/build/record.py
@@ -6,7 +6,7 @@ stdin:  JSON {issue, repo, branch, reason, plan_quality, run_id?, nested_reason?
         Every key is copied to the row verbatim. The five without a "?" are filled with
         an empty default when absent, so every row reads with the same key set.
 stdout: one line of JSON, {path, run_id}. The caller passes run_id back on the next row
-        of the same build. That is the only path by which a stop row joins its start row.
+        of the same build, which is how a stop row joins its start row.
 exit 0 on success. exit 1 on an unparseable payload (nothing written).
 
 Resolved fields, added to the row:
@@ -23,12 +23,11 @@ from pathlib import Path
 from typing import NoReturn, cast
 
 HISTORY_DIR = Path.home() / ".claude" / "history"
-# The file name is fixed. One run appends one line, so counting reads a single jsonl.
+# One fixed file, not audit's file per run: counting then reads a single jsonl.
 RUNS_PATH = HISTORY_DIR / "build-runs.jsonl"
 
-# The fields the caller supplies, with their defaults. A start row does not know its branch
-# yet, and dropping the key would make the reader branch on the kind of row, so it is filled
-# with an empty string instead.
+# A start row does not know its branch yet. Dropping the key would make the reader branch on
+# the kind of row, so the defaults fill it instead.
 DEFAULTS: dict[str, object] = {
     "issue": "",
     "repo": "",
@@ -41,17 +40,6 @@ DEFAULTS: dict[str, object] = {
 def fail(message: str) -> NoReturn:
     print(f"Error: {message}", file=sys.stderr)
     sys.exit(1)
-
-
-def build_row(payload: dict[str, object], run_id: str, generated_at: str) -> dict[str, object]:
-    row: dict[str, object] = {"run_id": run_id}
-    for key, default in DEFAULTS.items():
-        row[key] = payload.get(key, default)
-    for key, value in payload.items():
-        if key not in row:
-            row[key] = value
-    row["generated_at"] = generated_at
-    return row
 
 
 def main() -> None:
@@ -69,7 +57,12 @@ def main() -> None:
 
     HISTORY_DIR.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
-    row = build_row(payload, run_id=run_id, generated_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+    row = {
+        "run_id": run_id,
+        **DEFAULTS,
+        **payload,
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
 
     with RUNS_PATH.open("a") as fh:
         _ = fh.write(json.dumps(row, ensure_ascii=False) + "\n")

--- a/workflows/build/record.py
+++ b/workflows/build/record.py
@@ -1,0 +1,80 @@
+"""Usage: record.py   (build run payload JSON on stdin)
+
+Append one build run to $HOME/.claude/history/build-runs.jsonl.
+
+stdin:  JSON {issue, repo, branch, reason, plan_quality, run_id?, nested_reason?}
+        Every key is copied to the row verbatim. The five without a "?" are filled with
+        an empty default when absent, so every row reads with the same key set.
+stdout: one line of JSON, {path, run_id}. The caller passes run_id back on the next row
+        of the same build. That is the only path by which a stop row joins its start row.
+exit 0 on success. exit 1 on an unparseable payload (nothing written).
+
+Resolved fields, added to the row:
+  run_id        uuid4 hex, minted only when the payload carries none. A build can start
+                and stop within the same second, so a timestamp cannot separate the two.
+  generated_at  UTC ISO-8601
+"""
+
+import json
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn, cast
+
+HISTORY_DIR = Path.home() / ".claude" / "history"
+# The file name is fixed. One run appends one line, so counting reads a single jsonl.
+RUNS_PATH = HISTORY_DIR / "build-runs.jsonl"
+
+# The fields the caller supplies, with their defaults. A start row does not know its branch
+# yet, and dropping the key would make the reader branch on the kind of row, so it is filled
+# with an empty string instead.
+DEFAULTS: dict[str, object] = {
+    "issue": "",
+    "repo": "",
+    "branch": "",
+    "reason": "",
+    "plan_quality": False,
+}
+
+
+def fail(message: str) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def build_row(payload: dict[str, object], run_id: str, generated_at: str) -> dict[str, object]:
+    row: dict[str, object] = {"run_id": run_id}
+    for key, default in DEFAULTS.items():
+        row[key] = payload.get(key, default)
+    for key, value in payload.items():
+        if key not in row:
+            row[key] = value
+    row["generated_at"] = generated_at
+    return row
+
+
+def main() -> None:
+    raw_stdin = sys.stdin.read()
+    try:
+        loaded = cast("object", json.loads(raw_stdin))
+    except ValueError as exc:
+        fail(f"unparseable payload: {exc}")
+    if not isinstance(loaded, dict):
+        fail("payload must be a JSON object")
+    payload = cast("dict[str, object]", loaded)
+
+    supplied = payload.pop("run_id", "")
+    run_id = str(supplied) if supplied else uuid.uuid4().hex
+
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    row = build_row(payload, run_id=run_id, generated_at=now.strftime("%Y-%m-%dT%H:%M:%SZ"))
+
+    with RUNS_PATH.open("a") as fh:
+        _ = fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(json.dumps({"path": str(RUNS_PATH), "run_id": run_id}))
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -1469,6 +1469,14 @@ test("T-004 build.js and its .ja mirror return stopped only from the stop helper
     );
     assert.match(source, /stopped:\s*reason/, `${path}'s single stopped return is the helper's`);
     assert.ok(stopReasons(source).size > 0, `${path} routes its stops through stop("...")`);
+    // The three lines that turn recording on. The behavior cases exercise build.js alone, so a
+    // mirror that dropped one of them would keep the suite green while recording nothing.
+    for (const line of [
+      /recordable = true;/,
+      /await recordRun\("started"\);/,
+      /recordedBranch = branch;/,
+    ])
+      assert.match(source, line, `${path} carries ${line.source}`);
   }
 });
 

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -1312,10 +1312,74 @@ test("with the per-unit commits on, the Ship prompt instructs a remainder commit
   );
 });
 
+// The mirror runs nowhere, so a helper added on one side alone stays invisible until a reader
+// opens the other file. The stop-route checks read both paths.
+const jaBuildJs = join(here, "..", "..", "..", ".ja", "workflows", "build.js");
+
+// The stopped values are no longer literals at the return sites: every stop routes through the
+// stop helper, which looks its classification up in PLAN_QUALITY. The value set now lives in
+// that table and in the arguments the call sites pass, so both are read as text.
+const planQualityTable = (source) => {
+  const block = source.match(/const PLAN_QUALITY = \{([\s\S]*?)\n\};/);
+  assert.ok(block, "the source declares a PLAN_QUALITY table");
+  const table = {};
+  for (const m of block[1].matchAll(/"([^"]+)":\s*(true|false)/g)) table[m[1]] = m[2] === "true";
+  return table;
+};
+const stopReasons = (source) =>
+  new Set([...source.matchAll(/\bstop\(\s*"([^"]+)"/g)].map((m) => m[1]));
+
+// T-004: one literal `stopped:` remains, and it sits in the helper. A return that assembles its
+// own stopped object skips the recording, and the run then never reaches the jsonl.
+test("T-004 build.js and its .ja mirror return stopped only from the stop helper", async () => {
+  for (const path of [buildJs, jaBuildJs]) {
+    const source = await readFile(path, "utf8");
+    assert.equal(
+      (source.match(/\bstopped:/g) || []).length,
+      1,
+      `${path} assembles a stopped object in exactly one place`,
+    );
+    assert.match(source, /stopped:\s*reason/, `${path}'s single stopped return is the helper's`);
+    assert.ok(stopReasons(source).size > 0, `${path} routes its stops through stop("...")`);
+  }
+});
+
+// T-005: a stop value with no table entry would be counted as not plan-caused by default, and a
+// table entry no call site uses would claim a stop route that does not exist.
+test("T-005 the plan-quality table's key set matches the stopped value set", async () => {
+  for (const path of [buildJs, jaBuildJs]) {
+    const source = await readFile(path, "utf8");
+    assert.deepEqual(
+      Object.keys(planQualityTable(source)).sort(),
+      [...stopReasons(source)].sort(),
+      `${path}'s PLAN_QUALITY keys and its stop() arguments are the same set`,
+    );
+  }
+});
+
+// The six plan-caused values are what the count exists for. Reclassifying one changes what the
+// /qualify decision reads, so the split is pinned rather than left to the table's current shape.
+test("the plan-quality table marks exactly the six stops a plan can cause", async () => {
+  const table = planQualityTable(await readFile(buildJs, "utf8"));
+  assert.deepEqual(
+    Object.keys(table)
+      .filter((k) => table[k])
+      .sort(),
+    [
+      "extraction-failed",
+      "extraction-mismatch",
+      "invalid-plan",
+      "no-plan",
+      "oversized-unit",
+      "plan-drift",
+    ],
+    "the plan-quality stops are the six the issue's ## Plan section can be written to avoid",
+  );
+});
+
 test("the snapshot of the stopped value set matches 14 values exactly and holds no remnant of the audit route", async () => {
   const source = await readFile(buildJs, "utf8");
-  const stopped = new Set();
-  for (const m of source.matchAll(/stopped:\s*"([^"]+)"/g)) stopped.add(m[1]);
+  const stopped = new Set(Object.keys(planQualityTable(source)));
   assert.deepEqual(
     [...stopped].sort(),
     [

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -3,12 +3,16 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runWorkflow } from "../../_lib/run-workflow.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const buildJs = join(here, "..", "..", "build.js");
+const recordPy = join(here, "..", "record.py");
 
 // The shared args clearing build.js's no-repo gate. repo is used only to assemble the anchor
 // and guard strings, so one fixed absolute path covers every test.
@@ -97,11 +101,10 @@ const makeStubs = ({
     const kind = kindOf(opts);
     switch (kind) {
       case "record":
-        // The default stands in for record.py's stdout. A run_id override of null takes the
-        // fail-open route, where the row is lost and the build carries on.
-        return record !== undefined
-          ? record
-          : { path: "/home/sample/.claude/history/build-runs.jsonl", run_id: RECORDED_RUN_ID };
+        // The default stands in for record.py's stdout. An override returning an empty run_id
+        // takes the fail-open route; a function override runs the real script on the prompt.
+        if (record !== undefined) return typeof record === "function" ? record(prompt) : record;
+        return { path: "/home/sample/.claude/history/build-runs.jsonl", run_id: RECORDED_RUN_ID };
       case "translate":
         // The default fails open (no translations) and keeps the English originals. Only the
         // test verifying that translations land passes a translate stub.
@@ -1406,6 +1409,52 @@ test("a recorder returning no run_id leaves the build running and logs the lost 
     logs.some((m) => /build-runs\.jsonl/.test(m)),
     "the lost row reaches log() with the file it is missing from",
   );
+});
+
+// T-008: the seam. Every case above stubs the recorder, so build.js and record.py can each be
+// right while the payload never reaches the file. This one carries the real prompt into the real
+// script and reads the rows back off disk.
+// HOME points at a temporary directory, matching record.py's HISTORY_DIR, so the developer's own
+// build-runs.jsonl is never written.
+test("T-008 a no-plan stop reaches the real record.py as a plan-quality row joined to the start row", async () => {
+  const home = mkdtempSync(join(tmpdir(), "build-record-seam-"));
+  try {
+    const { result } = await runWorkflow(buildJs, {
+      args,
+      stubs: makeStubs({
+        body: "An issue body with no Plan heading.\n\n## Context\n\nExplanation only.",
+        record: (prompt) => {
+          // The payload is the prompt's last line, where recordRun puts the stringified JSON.
+          const payload = prompt.trim().split("\n").pop();
+          const res = spawnSync("python3", [recordPy], {
+            input: payload,
+            encoding: "utf8",
+            env: { ...process.env, HOME: home },
+          });
+          assert.equal(res.status, 0, `record.py exits 0 (stderr: ${res.stderr})`);
+          return JSON.parse(res.stdout);
+        },
+      }),
+    });
+    assert.equal(result.stopped, "no-plan");
+
+    const rows = readFileSync(join(home, ".claude", "history", "build-runs.jsonl"), "utf8")
+      .split("\n")
+      .filter((line) => line.trim())
+      .map((line) => JSON.parse(line));
+    assert.equal(rows.length, 2, "the run leaves a start row and a stop row");
+    assert.deepEqual(
+      rows.map((r) => r.reason),
+      ["started", "no-plan"],
+      "the rows read as the run went: started, then the stop that ended it",
+    );
+    assert.equal(rows[0].plan_quality, false, "the start row is not a plan-quality stop");
+    assert.equal(rows[1].plan_quality, true, "no-plan counts toward the plan-quality total");
+    assert.equal(rows[1].run_id, rows[0].run_id, "the stop row joins the start row of this run");
+    assert.equal(rows[1].issue, "123", "the row carries the issue the stop belongs to");
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 // T-004: one literal `stopped:` remains, and it sits in the helper. A return that assembles its

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -55,8 +55,7 @@ const makePlan = (overrides = {}) => ({
   ...overrides,
 });
 
-// The run_id record.py mints. The stub returns it from the start row, and a later row carrying
-// it back is what shows the two rows belong to one build.
+// The run_id record.py mints. A later row carrying it back is what ties two rows to one build.
 const RECORDED_RUN_ID = "a1b2c3d4e5f6";
 
 // Classifies an agent call by the shape of its schema rather than by its label string, which
@@ -101,8 +100,7 @@ const makeStubs = ({
     const kind = kindOf(opts);
     switch (kind) {
       case "record":
-        // The default stands in for record.py's stdout. An override returning an empty run_id
-        // takes the fail-open route; a function override runs the real script on the prompt.
+        // The default stands in for record.py's stdout; a function override runs the real script.
         if (record !== undefined) return typeof record === "function" ? record(prompt) : record;
         return { path: "/home/sample/.claude/history/build-runs.jsonl", run_id: RECORDED_RUN_ID };
       case "translate":
@@ -1327,13 +1325,11 @@ test("with the per-unit commits on, the Ship prompt instructs a remainder commit
   );
 });
 
-// The mirror runs nowhere, so a helper added on one side alone stays invisible until a reader
-// opens the other file. The stop-route checks read both paths.
+// The mirror runs nowhere, so drift on that side stays invisible until a reader opens the file.
 const jaBuildJs = join(here, "..", "..", "..", ".ja", "workflows", "build.js");
 
-// The stopped values are no longer literals at the return sites: every stop routes through the
-// stop helper, which looks its classification up in PLAN_QUALITY. The value set now lives in
-// that table and in the arguments the call sites pass, so both are read as text.
+// The stopped values are no longer literals at the return sites, so the set is read off the
+// table and the call sites' arguments as text. A workflow script cannot be imported.
 const planQualityTable = (source) => {
   const block = source.match(/const PLAN_QUALITY = \{([\s\S]*?)\n\};/);
   assert.ok(block, "the source declares a PLAN_QUALITY table");
@@ -1344,9 +1340,8 @@ const planQualityTable = (source) => {
 const stopReasons = (source) =>
   new Set([...source.matchAll(/\bstop\(\s*"([^"]+)"/g)].map((m) => m[1]));
 
-// T-006: a run killed between Load and Ship writes no stop row, so without a row at the start
-// it would leave the history holding finished and stopped runs alone. The count would then read
-// the stop rate off a denominator the killed runs already left.
+// T-006: a run killed between Load and Ship writes no stop row, so without a start row it would
+// leave the stop rate reading off a denominator the killed runs already left.
 test("T-006 the start row is written before Load fetches the issue", async () => {
   const { calls } = await runWorkflow(buildJs, { args, stubs: makeStubs() });
   const records = agentCallsOf(calls, "record");
@@ -1363,9 +1358,8 @@ test("T-006 the start row is written before Load fetches the issue", async () =>
   assert.ok(firstRecord < firstFetch, "the start row is written before the fetch");
 });
 
-// T-007: code returns its own stopped value, and build folds every one of them into code-failed.
-// Counting on the outer reason alone would put a plan-caused stop inside code into the same
-// bucket as a failed test run.
+// T-007: build folds every stopped value code returns into code-failed, so the outer reason
+// alone would bucket a plan-caused stop with a failed test run.
 test("T-007 a stop inside code carries the nested reason and the start row's run_id", async () => {
   const { result, calls } = await runWorkflow(buildJs, {
     args,
@@ -1383,7 +1377,7 @@ test("T-007 a stop inside code carries the nested reason and the start row's run
 });
 
 // The gates above anchor have no repository to run the recorder in, and neither is a
-// plan-quality signal. They return without a row rather than writing one with an empty repo.
+// plan-quality signal.
 test("the gates ahead of the repo check write no row", async () => {
   for (const [label, runArgs] of [
     ["no-issue", {}],
@@ -1396,9 +1390,8 @@ test("the gates ahead of the repo check write no row", async () => {
   }
 });
 
-// Recording is not a gate. A recorder that returns nothing must not turn a runnable build into
-// a stopped one, and the loss has to reach the run log, which is where a reader learns the run
-// is missing from the count.
+// A recorder that returns nothing must not turn a runnable build into a stopped one. Nothing
+// but the run log tells a reader that this run is missing from the count.
 test("a recorder returning no run_id leaves the build running and logs the lost row", async () => {
   const { result, logs } = await runWorkflow(buildJs, {
     args,
@@ -1412,8 +1405,7 @@ test("a recorder returning no run_id leaves the build running and logs the lost 
 });
 
 // T-008: the seam. Every case above stubs the recorder, so build.js and record.py can each be
-// right while the payload never reaches the file. This one carries the real prompt into the real
-// script and reads the rows back off disk.
+// right while the payload never reaches the file.
 // HOME points at a temporary directory, matching record.py's HISTORY_DIR, so the developer's own
 // build-runs.jsonl is never written.
 test("T-008 a no-plan stop reaches the real record.py as a plan-quality row joined to the start row", async () => {
@@ -1469,8 +1461,7 @@ test("T-004 build.js and its .ja mirror return stopped only from the stop helper
     );
     assert.match(source, /stopped:\s*reason/, `${path}'s single stopped return is the helper's`);
     assert.ok(stopReasons(source).size > 0, `${path} routes its stops through stop("...")`);
-    // The three lines that turn recording on. The behavior cases exercise build.js alone, so a
-    // mirror that dropped one of them would keep the suite green while recording nothing.
+    // The behavior cases run build.js alone, so a mirror dropping one of these stays green.
     for (const line of [
       /recordable = true;/,
       /await recordRun\("started"\);/,
@@ -1493,8 +1484,8 @@ test("T-005 the plan-quality table's key set matches the stopped value set", asy
   }
 });
 
-// The six plan-caused values are what the count exists for. Reclassifying one changes what the
-// /qualify decision reads, so the split is pinned rather than left to the table's current shape.
+// Reclassifying one of the six changes what the /qualify decision reads, so the split is pinned
+// rather than left to whatever the table currently holds.
 test("the plan-quality table marks exactly the six stops a plan can cause", async () => {
   const table = planQualityTable(await readFile(buildJs, "utf8"));
   assert.deepEqual(

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -51,11 +51,16 @@ const makePlan = (overrides = {}) => ({
   ...overrides,
 });
 
+// The run_id record.py mints. The stub returns it from the start row, and a later row carrying
+// it back is what shows the two rows belong to one build.
+const RECORDED_RUN_ID = "a1b2c3d4e5f6";
+
 // Classifies an agent call by the shape of its schema rather than by its label string, which
 // would couple these tests to wording build.js is free to reword.
 const kindOf = (opts) => {
   const p = (opts && opts.schema && opts.schema.properties) || null;
   if (!p) return "plain";
+  if ("run_id" in p) return "record";
   if ("found" in p && "body" in p) return "fetch";
   if ("units" in p) return "extract";
   if ("results" in p) {
@@ -85,11 +90,18 @@ const makeStubs = ({
   branch,
   untracked,
   code,
+  record,
   ship,
 } = {}) => ({
   agent: (prompt, opts) => {
     const kind = kindOf(opts);
     switch (kind) {
+      case "record":
+        // The default stands in for record.py's stdout. A run_id override of null takes the
+        // fail-open route, where the row is lost and the build carries on.
+        return record !== undefined
+          ? record
+          : { path: "/home/sample/.claude/history/build-runs.jsonl", run_id: RECORDED_RUN_ID };
       case "translate":
         // The default fails open (no translations) and keeps the English originals. Only the
         // test verifying that translations land passes a translate stub.
@@ -1328,6 +1340,73 @@ const planQualityTable = (source) => {
 };
 const stopReasons = (source) =>
   new Set([...source.matchAll(/\bstop\(\s*"([^"]+)"/g)].map((m) => m[1]));
+
+// T-006: a run killed between Load and Ship writes no stop row, so without a row at the start
+// it would leave the history holding finished and stopped runs alone. The count would then read
+// the stop rate off a denominator the killed runs already left.
+test("T-006 the start row is written before Load fetches the issue", async () => {
+  const { calls } = await runWorkflow(buildJs, { args, stubs: makeStubs() });
+  const records = agentCallsOf(calls, "record");
+  assert.equal(records.length, 1, "a run that finishes writes the start row and nothing after");
+  assert.match(records[0].prompt, /"reason":"started"/, "the first row's reason is started");
+  assert.match(
+    records[0].prompt,
+    /"plan_quality":false/,
+    "the start row is not counted as a plan-quality stop",
+  );
+  const firstRecord = calls.agent.findIndex((c) => kindOf(c.opts) === "record");
+  const firstFetch = calls.agent.findIndex((c) => kindOf(c.opts) === "fetch");
+  assert.ok(firstFetch >= 0, "the run reaches Load's fetch");
+  assert.ok(firstRecord < firstFetch, "the start row is written before the fetch");
+});
+
+// T-007: code returns its own stopped value, and build folds every one of them into code-failed.
+// Counting on the outer reason alone would put a plan-caused stop inside code into the same
+// bucket as a failed test run.
+test("T-007 a stop inside code carries the nested reason and the start row's run_id", async () => {
+  const { result, calls } = await runWorkflow(buildJs, {
+    args,
+    stubs: makeStubs({ code: { stopped: "invalid-plan" } }),
+  });
+  assert.equal(result.stopped, "code-failed");
+  const stopRow = agentCallsOf(calls, "record").at(-1).prompt;
+  assert.match(stopRow, /"reason":"code-failed"/);
+  assert.match(stopRow, /"nested_reason":"invalid-plan"/, "the inner reason reaches the row");
+  assert.match(
+    stopRow,
+    new RegExp(`"run_id":"${RECORDED_RUN_ID}"`),
+    "the stop row carries the run_id the start row minted",
+  );
+});
+
+// The gates above anchor have no repository to run the recorder in, and neither is a
+// plan-quality signal. They return without a row rather than writing one with an empty repo.
+test("the gates ahead of the repo check write no row", async () => {
+  for (const [label, runArgs] of [
+    ["no-issue", {}],
+    ["no-repo", { issue: "123" }],
+    ["invalid-base", { issue: "123", repo, base: "not a branch" }],
+  ]) {
+    const { result, calls } = await runWorkflow(buildJs, { args: runArgs, stubs: makeStubs() });
+    assert.equal(result.stopped, label);
+    assert.equal(agentCallsOf(calls, "record").length, 0, `${label} writes no row`);
+  }
+});
+
+// Recording is not a gate. A recorder that returns nothing must not turn a runnable build into
+// a stopped one, and the loss has to reach the run log, which is where a reader learns the run
+// is missing from the count.
+test("a recorder returning no run_id leaves the build running and logs the lost row", async () => {
+  const { result, logs } = await runWorkflow(buildJs, {
+    args,
+    stubs: makeStubs({ record: { run_id: "" } }),
+  });
+  assert.equal(result.stopped, undefined, "the build is not stopped by a failed record");
+  assert.ok(
+    logs.some((m) => /build-runs\.jsonl/.test(m)),
+    "the lost row reaches log() with the file it is missing from",
+  );
+});
 
 // T-004: one literal `stopped:` remains, and it sits in the helper. A return that assembles its
 // own stopped object skips the recording, and the run then never reaches the jsonl.

--- a/workflows/build/tests/record_test.py
+++ b/workflows/build/tests/record_test.py
@@ -1,0 +1,147 @@
+# pyright: reportUninitializedInstanceVariable=false
+"""Tests for workflows/build/record.py (deterministic build-run recorder).
+
+Run: python3 workflows/build/tests/record_test.py
+
+The CLI contract (stdin JSON -> one appended line in build-runs.jsonl, {path, run_id}
+JSON on stdout, exit 1 on a bad payload) is exercised via subprocess with an isolated
+HOME, so the developer's own history file is never touched.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "record.py"
+
+# The seven keys every row carries. A start row and a stop row read the same, so a reader
+# counting stop reasons never has to branch on which kind of row it is looking at.
+ROW_FIELDS = {
+    "run_id",
+    "issue",
+    "repo",
+    "branch",
+    "reason",
+    "plan_quality",
+    "generated_at",
+}
+
+PAYLOAD = {
+    "issue": "386",
+    "repo": "/abs/target-repo",
+    "branch": "feat/sample",
+    "reason": "no-plan",
+    "plan_quality": True,
+}
+
+
+def loaded(text: str) -> dict[str, object]:
+    """A parsed JSON object. Anything else fails the test here rather than downstream."""
+    value = cast("object", json.loads(text))
+    assert isinstance(value, dict)
+    return cast("dict[str, object]", value)
+
+
+class CliTest(unittest.TestCase):
+    def _run(self, payload: object, home: str) -> subprocess.CompletedProcess[str]:
+        # PATH="" keeps the run off any git binary, so nothing the script resolves
+        # depends on the checkout the test happens to run in.
+        env = {"HOME": str(home), "PATH": ""}
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def _lines(self, path: Path) -> list[dict[str, object]]:
+        return [loaded(line) for line in path.read_text().splitlines() if line.strip()]
+
+    def test_appends_one_line_per_run(self) -> None:
+        """T-001: a payload on stdin appends exactly one line to build-runs.jsonl."""
+        with tempfile.TemporaryDirectory() as home:
+            first = self._run(PAYLOAD, home)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            out_path = Path(str(loaded(first.stdout)["path"]))
+            self.assertEqual(out_path.name, "build-runs.jsonl")
+            self.assertEqual(len(self._lines(out_path)), 1)
+
+            second = self._run(PAYLOAD, home)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(
+                str(loaded(second.stdout)["path"]),
+                str(out_path),
+                "the file name is fixed, so a second run appends instead of writing beside it",
+            )
+            self.assertEqual(len(self._lines(out_path)), 2)
+
+    def test_appended_line_carries_every_row_field(self) -> None:
+        """T-002: the line holds run_id, issue, repo, branch, reason, plan_quality, generated_at."""
+        with tempfile.TemporaryDirectory() as home:
+            result = self._run(PAYLOAD, home)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            row = self._lines(Path(str(loaded(result.stdout)["path"])))[0]
+            self.assertEqual(ROW_FIELDS - set(row.keys()), set())
+            self.assertEqual(row["issue"], "386")
+            self.assertEqual(row["reason"], "no-plan")
+            self.assertEqual(row["plan_quality"], True)
+
+    def test_minted_run_id_is_returned_and_differs_between_runs(self) -> None:
+        """T-002: two runs within the same second get distinct run_ids, and stdout reports each."""
+        with tempfile.TemporaryDirectory() as home:
+            first = loaded(self._run(PAYLOAD, home).stdout)
+            second = loaded(self._run(PAYLOAD, home).stdout)
+            self.assertNotEqual(first["run_id"], second["run_id"])
+            rows = self._lines(Path(str(first["path"])))
+            self.assertEqual([row["run_id"] for row in rows], [first["run_id"], second["run_id"]])
+
+    def test_supplied_run_id_is_kept(self) -> None:
+        """T-002: a run_id in the payload ties the stop row to the start row of the same run."""
+        with tempfile.TemporaryDirectory() as home:
+            start = loaded(self._run({**PAYLOAD, "reason": "started"}, home).stdout)
+            stop = loaded(self._run({**PAYLOAD, "run_id": start["run_id"]}, home).stdout)
+            self.assertEqual(stop["run_id"], start["run_id"])
+            rows = self._lines(Path(str(start["path"])))
+            self.assertEqual({row["run_id"] for row in rows}, {start["run_id"]})
+
+    def test_extra_keys_are_copied_verbatim(self) -> None:
+        """T-002: nested_reason reaches the row, so a plan-caused stop inside code stays visible."""
+        with tempfile.TemporaryDirectory() as home:
+            result = self._run({**PAYLOAD, "nested_reason": "invalid-plan"}, home)
+            row = self._lines(Path(str(loaded(result.stdout)["path"])))[0]
+            self.assertEqual(row["nested_reason"], "invalid-plan")
+
+    def test_unparseable_payload_exits_1_and_writes_nothing(self) -> None:
+        """T-003: broken stdin exits 1 and leaves no file behind."""
+        with tempfile.TemporaryDirectory() as home:
+            env = {"HOME": home, "PATH": ""}
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                input="not json",
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((Path(home) / ".claude" / "history" / "build-runs.jsonl").exists())
+
+    def test_non_object_payload_exits_1_and_writes_nothing(self) -> None:
+        """T-003: valid JSON that is not an object is refused the same way."""
+        with tempfile.TemporaryDirectory() as home:
+            result = self._run(["not", "an", "object"], home)
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((Path(home) / ".claude" / "history" / "build-runs.jsonl").exists())
+
+
+if __name__ == "__main__":
+    _ = unittest.main()


### PR DESCRIPTION
## What & Why

build の各実行が `~/.claude/history/build-runs.jsonl` に 1 行残り、plan 品質が原因の停止件数を種類ごとに数えられる。

停止はこれまで workflow の返り値としてしか現れず、どこにも残らなかった。件数を取る手段が無いため、`/qualify` を build の前段で必須にするかを決められず、DR-0084 の再評価条件「未検証 plan による build 失敗が繰り返される場合」も満たしているか確かめられない。

## Review focus

- `PLAN_QUALITY` 表の true/false の割り振り。ここが件数の意味を決める。true の 6 つは plan の内容そのものが起こす Load/Revalidate の停止、false の 8 つは環境・relay の取りこぼし・入れ子の code に由来する
- `stop()` を通しても返り値の形が変わっていないこと。既存の 14 か所の早期 return はどれも `{stopped, ...}` を返し続ける
- `.ja/workflows/build.js` は流し読みでよい。コードは英語側と同一で、差分はコメントの言語だけ

## Changes

- 停止経路を `stop()` ヘルパー 1 つに集約した。14 か所それぞれに記録を挟むと、1 か所の漏れが件数を静かに欠けさせる
- 開始の行を Load より前に書く。途中で殺された run が分母から消えると、停止率が実際より小さく出る
- `code-failed` は入れ子の停止理由を `nested_reason` として行に載せる。畳まずに残さないと、code 内で起きた plan 起因の停止が 1 つの箱に埋もれる

## Scope

- Not included: `/qualify` を必須にするかの判断。件数が揃ってから別 issue で扱う
- Not included: 記録を読む集計コマンドの CLI 化。当面は jq で足りる
- 開始の行 1 本だけの run は、完走したのか途中で殺されたのか区別できない。停止件数と停止率の分母はどちらも成立するので、完了の行は足していない

## Design Decisions

- `run_id` と `generated_at` は `record.py` 側で解決する。issue の reference_module 規約は「timestamp と分類は script でなく呼び出し側が決めて payload に載せる」と書いている。ただし workflow script は時計を持たず、乱数も引けない (rules/conventions/WORKFLOWS.md § Script evaluation form)。分類にあたる `plan_quality` は規約どおり build.js が決める
- run の識別に uuid4 を使う。build は同じ秒のうちに開始して停止しうるので、秒精度の timestamp では開始の行と停止の行を分けられない
- 記録の失敗は build を止めない。行が書けなかったことは `log()` に出す (WORKFLOWS.md § Degradation recording)
- base は issue が指定する `refactor/skills-rules-conformance` ではなく main。そのブランチは手元と origin のどちらにも残っていない

## How to Test

1. `python3 workflows/build/tests/record_test.py` を実行し、7 件が OK で終わることを確認する
2. `node --test workflows/build/tests/build.behavior.test.js` を実行し、67 件が pass することを確認する
3. `T-008` の seam ケースが、実物の `record.py` が書いた 2 行 (`started` と `no-plan`) を読み、同じ `run_id` を持つことを確認する
4. 集計を試すなら `jq -r 'select(.plan_quality) | .reason' ~/.claude/history/build-runs.jsonl | sort | uniq -c`

## Related

- Closes #386
