### PR TITLE
[Bug] command_scan が行継続をコマンド区切りとして扱う

### DIFF
--- a/hooks/_lib/command_scan.py
+++ b/hooks/_lib/command_scan.py
@@ -35,6 +35,9 @@ SEPARATORS = frozenset({";", "|", "||", "&&", "&", "\n"})
 # one command. As punctuation the newline stays a token, while one inside quotes stays
 # part of its token, so a multi-line commit message holds together.
 _NEWLINE = "\x00"
+# A line continuation is escaped onto this instead of onto _NEWLINE. shlex returns the same
+# character escaped or not, so as _NEWLINE it reads as the separator and splits the command.
+_CONTINUATION = "\x01"
 _PUNCTUATION = "();<>|&" + _NEWLINE
 
 _HEREDOC = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
@@ -66,10 +69,24 @@ def _without_heredocs(text: str) -> str:
     return "\n".join(kept)
 
 
+def _restore(token: str) -> str:
+    """A backslash still ahead of _CONTINUATION means shlex read both as quoted text, where
+    the two characters are literal. Outside quotes it consumes the backslash, leaving the
+    continuation to drop so the lines it separated join.
+    """
+    return (
+        token.replace("\\" + _CONTINUATION, "\\\n")
+        .replace(_CONTINUATION, "")
+        .replace(_NEWLINE, "\n")
+    )
+
+
 def _tokens(text: str) -> list[str]:
-    lexer = shlex.shlex(text.replace("\n", _NEWLINE), posix=True, punctuation_chars=_PUNCTUATION)
+    prepared = text.replace("\\\n", "\\" + _CONTINUATION).replace("\n", _NEWLINE)
+    lexer = shlex.shlex(prepared, posix=True, punctuation_chars=_PUNCTUATION)
     lexer.whitespace_split = True
-    return [token.replace(_NEWLINE, "\n") for token in lexer]
+    # A continuation between two words lexes as its own token, where the shell leaves nothing.
+    return [_restore(token) for token in lexer if token != _CONTINUATION]
 
 
 def commands(text: str) -> Iterator[list[str]]:

--- a/hooks/_lib/tests/command_scan_test.py
+++ b/hooks/_lib/tests/command_scan_test.py
@@ -109,6 +109,59 @@ class TestCommands(unittest.TestCase):
         self.assertEqual(self.names("./a=b --flag"), ["a=b"])
         self.assertEqual(self.names("1FOO=x rm -rf y"), ["1FOO=x"])
 
+    def test_a_line_continuation_does_not_split_a_command(self) -> None:
+        """T-023 A backslash before a newline joins the two lines into one command"""
+        # Split at the continuation, the security hook is handed an rm carrying no path.
+        self.assertEqual(
+            list(command_scan.commands("rm -rf \\\n  /tmp/x")), [["rm", "-rf", "/tmp/x"]]
+        )
+        # The other direction: an argument whose basename is destructive would stand in command
+        # position and be denied for a deletion the line never runs.
+        self.assertEqual(self.names("cp x \\\n  /some/dir/rm"), ["cp"])
+
+    def test_a_continuation_before_a_flag_keeps_it_on_the_same_command(self) -> None:
+        """T-024 A flag written after a continuation stays readable on the command it belongs to"""
+        # Split here, --title falls off the gh call and the gate denies a command carrying one.
+        found = list(command_scan.commands('gh issue create --repo r \\\n  --title "[Bug] x"'))
+        self.assertEqual(found, [["gh", "issue", "create", "--repo", "r", "--title", "[Bug] x"]])
+        self.assertEqual(command_scan.flag_value(found[0], "--title"), "[Bug] x")
+
+    def test_a_continuation_inside_a_command_prefix_keeps_it_matchable(self) -> None:
+        """T-025 A continuation between gh and its subcommand leaves the prefix still matching"""
+        # Split here, starts_with misses and the filing gate skips its check and exits 0.
+        found = list(command_scan.commands('gh \\\n  issue create --title "[Bug] x"'))
+        self.assertEqual(len(found), 1)
+        self.assertTrue(command_scan.starts_with(found[0], ["gh", "issue", "create"]))
+
+    def test_a_continuation_inside_a_word_joins_the_halves(self) -> None:
+        """T-026 A continuation with no space around it leaves no gap in the token"""
+        self.assertEqual(list(command_scan.commands("ec\\\nho hi")), [["echo", "hi"]])
+
+    def test_a_backslash_newline_inside_quotes_stays_literal(self) -> None:
+        """T-027 Inside quotes the backslash and the newline are text, not a continuation"""
+        # A commit message can hold both characters. Dropping them there rewrites the message.
+        self.assertEqual(
+            list(command_scan.commands("git commit -m 'a \\\nb'")),
+            [["git", "commit", "-m", "a \\\nb"]],
+        )
+
+    def test_a_continued_line_reads_the_same_as_the_joined_one(self) -> None:
+        """T-028 Taking a continuation out of the input never changes the token stream"""
+        # Every step ahead of shlex works on lines and cannot see quoting, which is where this
+        # bug came from. The property holds across all of them, so a later step cannot reopen it.
+        for continued in [
+            "rm -rf \\\n  /tmp/x",
+            'gh issue create --repo r \\\n  --title "[Bug] x"',
+            "cat > /tmp/m.txt << 'EOF'\nbody\nEOF\ngit commit \\\n  -F /tmp/m.txt",
+            "find . -type f \\\n  -exec rm {} \\;",
+        ]:
+            joined = continued.replace("\\\n  ", " ").replace("\\\n", "")
+            self.assertEqual(
+                list(command_scan.commands(continued)),
+                list(command_scan.commands(joined)),
+                continued,
+            )
+
 
 class TestFlagValue(unittest.TestCase):
     def test_reads_the_value_after_a_flag(self) -> None:


### PR DESCRIPTION
## What & Why

行継続 (`\` + 改行) を挟んだコマンドが、継続行ごとに別コマンドへ分割されなくなる。

`gh issue create` の途中に継続が入ると `starts_with(["gh","issue","create"])` は外れる。`issue-body-template.sh` は骨格照合ごと飛ばして exit 0 する。品質ゲートが素通りする経路が実地で起きていた。継続が `--title` の前に入る場合は title が None になり、「タイトルに型プレフィックスが無い」という実際と違う理由で deny する。

## Review focus

- `_restore` の判別。バックスラッシュが `_CONTINUATION` の手前に残っているかどうかで、引用符の内と外を見分ける。ここが引用状態を見ない前処理では直らないという issue の指摘に答えている部分
- `_tokens` の `if token != _CONTINUATION`。継続が単語と単語の間に立つと、バックスラッシュが消費された後に単独トークンとして残る
- 二重引用符の中の `\` + 改行は、シェルなら continuation として消えるが、ここでは文字どおり残る。shlex が引用符の中でバックスラッシュを残すため、外側と区別が付かない。現行と同じ挙動で、T-027 が固定している

## Changes

- 行継続だけを `\x01` へ寄せ、エスケープの解決を shlex 自身にやらせる。前処理側で引用状態を判定せずに済む

## Scope

- Not included: `_without_heredocs` の引用符非対応。T-016 が既存の挙動を固定しており、本 PR は触っていない

## Design Decisions

- `text.replace("\\\n", "")` のような単純な前処理を採らない。単引用符の中では `\` + 改行が文字どおりの 2 文字なので、引用状態を見ない置換は本文を壊す (issue の「修正時の注意」)
- 破壊的コマンドの誤検出も同じ修正で消える。`cp x \` 改行 `/some/dir/rm` は 1 コマンドに繋がるので、`/some/dir/rm` が command position に立たない (issue では未実測とされていた)

## How to Test

1. `python3 hooks/_lib/tests/command_scan_test.py` を実行し、29 件が OK で終わることを確認する
2. issue の repro を流し、A/B/C/E のトークン列が継続を含まない形と一致することを確認する
3. `_tokens` の `prepared` を元の 1 行へ戻すと 5 件落ちることを確認する (T-023〜T-026, T-028)

## Related

- Closes #368
