### PR TITLE
[Feature] audit の全 finding が disposition を持つ

### DIFF
--- a/.ja/agents/_lib/finding-schema.md
+++ b/.ja/agents/_lib/finding-schema.md
@@ -65,6 +65,32 @@ Evidence, Trigger, Reasoning は具体的な言語を使う。
 | theoretically          | (削除する。実際のパスを記述)    |
 | in some cases          | when [specific condition]       |
 
+## Disposition
+
+Severity は影響の大きさを表す。Disposition は読んだ人間が次に何をするかを表す。マージを止めるべきか作者の判断に委ねてよいかは severity が答えない軸なので、2 つを 1 つの finding に並べて載せる。
+
+DR-0078 が定めた共通コア (Severity/Evidence/一行 claim/ID) に足す 1 本目の軸。この語彙は audit 側に閉じ、`/preview` へは戻さない (`skills/preview/tests/plan-alignment.test.js` が禁止している)。
+
+| 値   | 意味                                 | 併走する severity | 供給元                          |
+| ---- | ------------------------------------ | ----------------- | ------------------------------- |
+| must | マージ前に直す                       | critical / high   | script の既定値、または 3 本    |
+| want | 直さない理由が無ければ直す           | medium            | 下記 3 本の reviewer            |
+| imo  | 作者が決める                         | low               | 下記 3 本の reviewer            |
+| nits | 見た目の指摘。直すかは任意           | low               | 下記 3 本の reviewer            |
+| ask  | コードだけでは決まらない。人間に聞く | 対応なし          | critic の needs_context verdict |
+| info | 処理済み。記録として残す             | 対応なし          | triage の disputed / downgraded |
+
+「併走する severity」は目安であって導出規則ではない。既定値は severity から導かず must に固定する。`workflows/assert.js` の gate は severity を見ず `issues.length > 0` だけで NotReady を出すので、severity 由来の既定値だと blocking な finding へ nits が付く。
+
+| 規則          | 内容                                                                                                        |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| 既定値        | must。reviewer が申告しない finding には script が付ける                                                    |
+| 申告できる値  | must / want / imo / nits の 4 つ。ask と info は reviewer が出す種類ではない                                |
+| 上書きの主体  | reviewer-design / reviewer-readability / reviewer-reuse の 3 本のみ。指摘が作者の好みに寄りうる lens に限る |
+| 上書きの条件  | disposition_reason を添える。理由の無い上書きは既定値 must に戻す                                           |
+| 統合順序      | must > want > imo > nits。統合した finding は統合元のうち最も強い値を採る                                   |
+| gate との関係 | disposition はいかなる gate の入力にもしない。修正の順序を表す軸であって、マージ可否を表す軸ではない        |
+
 ## キャリブレーションフィルタ
 
 順に適用する。いずれかが除外したら報告しない。

--- a/.ja/rules/conventions/SUBAGENT.md
+++ b/.ja/rules/conventions/SUBAGENT.md
@@ -78,7 +78,7 @@ memory は次の 3 つをすべて満たすとき付与し、project スコー�
 
 ## 指摘の重要度
 
-reviewer- 系は `~/.claude/agents/_lib/finding-schema.md` の Severity (critical/high/medium/low) に従う。独自のゲート判定を返すエージェント (critic- 系の confirmed/disputed など) は自分の方式に従う。
+reviewer- 系は `~/.claude/agents/_lib/finding-schema.md` の Severity (critical/high/medium/low) に従う。何を先に直すかは同ファイルの Disposition が持ち、値の一覧はそこにある。独自のゲート判定を返すエージェント (critic- 系の confirmed/disputed など) は自分の方式に従う。
 
 ## 参照記法
 

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -338,8 +338,7 @@ const findingsSchema = ({ withSourceIds = false } = {}) => ({
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
-          // 必須にしない。trigger を返さない reviewer は findings 配列ごと検証に落ち、
-          // その中の finding をすべて失う。
+          // optional にする。必須だと trigger を返さない reviewer が findings 配列ごと落ちる。
           category: { type: "string", description: "reviewer 自身の finding 分類" },
           trigger: {
             type: "string",
@@ -640,17 +639,16 @@ const raw = await parallel(
   ),
 );
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
-// 既定値は script が持つ。reviewer が何も申告しなくても数えられる値が残る
-// (agents/_lib/finding-schema.md § Disposition)。severity から導かず固定するのは、assert の
-// gate が severity を見ないため。導出すると、マージを止める finding に nits が付く。
+// severity から導かず固定する (agents/_lib/finding-schema.md § Disposition)。assert の gate は
+// severity を見ないので、導出するとマージを止める finding に nits が付く。
 const DEFAULT_DISPOSITION = "must";
 const DECLARABLE_DISPOSITIONS = new Set(["must", "want", "imo", "nits"]);
 let restoredDispositions = 0;
 const dispositionOf = (f) => {
-  const declared = String(f.disposition || "");
-  const reason = String(f.disposition_reason || "").trim();
+  const declared = f.disposition || "";
+  const reason = (f.disposition_reason || "").trim();
   if (!declared) return { disposition: DEFAULT_DISPOSITION };
-  // 理由の無い上書きは judgment でなく好みなので、申告された値として運ばず既定値へ戻す。
+  // 理由の無い上書きは判断でなく好みなので、申告された値としては運ばない。
   if (!DECLARABLE_DISPOSITIONS.has(declared) || !reason) {
     restoredDispositions += 1;
     return { disposition: DEFAULT_DISPOSITION };
@@ -671,8 +669,7 @@ units.forEach((u, i) => {
         line: f.line,
         severity: f.severity,
         message: f.summary,
-        // 無いフィールドは空文字にせず無いまま残す。何も返さなかった reviewer と、空を
-        // 返した reviewer を読み手が区別できる。
+        // 無いものは無いまま残す。空文字だと、空を返した reviewer と区別が付かない。
         ...(f.category ? { category: f.category } : {}),
         ...(f.trigger ? { trigger: f.trigger } : {}),
         ...dispositionOf(f),
@@ -872,8 +869,7 @@ const integrated = await agent(
 // フォールバック先を triage 前の findings にすると、id が付く前の配列に落ちるので、
 // challenge が disputed と判定した finding を黙って呼び戻すことになる。
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// Integrate が読む projection は disposition を含まないので、出力にも戻ってこない。ここで
-// 既定値を当て直すことで、返り値の finding が survivors と同じ軸で読める。
+// Integrate が読む projection は disposition を含まないので、ここで既定値を当て直す。
 const finalFindings = integratedFindings.map((f) =>
   f.disposition ? f : { ...f, disposition: DEFAULT_DISPOSITION },
 );

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -338,6 +338,23 @@ const findingsSchema = ({ withSourceIds = false } = {}) => ({
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
+          // 必須にしない。trigger を返さない reviewer は findings 配列ごと検証に落ち、
+          // その中の finding をすべて失う。
+          category: { type: "string", description: "reviewer 自身の finding 分類" },
+          trigger: {
+            type: "string",
+            description: "その問題が顕在化する具体的な条件",
+          },
+          disposition: {
+            type: "string",
+            enum: ["must", "want", "imo", "nits"],
+            description:
+              "読んだ人間が次に何をするか。agents/_lib/finding-schema.md § Disposition に従う。省略すると既定値を採る",
+          },
+          disposition_reason: {
+            type: "string",
+            description: "既定値から外す理由。上書きには必須",
+          },
           ...(withSourceIds
             ? {
                 source_ids: {
@@ -623,6 +640,23 @@ const raw = await parallel(
   ),
 );
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
+// 既定値は script が持つ。reviewer が何も申告しなくても数えられる値が残る
+// (agents/_lib/finding-schema.md § Disposition)。severity から導かず固定するのは、assert の
+// gate が severity を見ないため。導出すると、マージを止める finding に nits が付く。
+const DEFAULT_DISPOSITION = "must";
+const DECLARABLE_DISPOSITIONS = new Set(["must", "want", "imo", "nits"]);
+let restoredDispositions = 0;
+const dispositionOf = (f) => {
+  const declared = String(f.disposition || "");
+  const reason = String(f.disposition_reason || "").trim();
+  if (!declared) return { disposition: DEFAULT_DISPOSITION };
+  // 理由の無い上書きは judgment でなく好みなので、申告された値として運ばず既定値へ戻す。
+  if (!DECLARABLE_DISPOSITIONS.has(declared) || !reason) {
+    restoredDispositions += 1;
+    return { disposition: DEFAULT_DISPOSITION };
+  }
+  return { disposition: declared, disposition_reason: reason };
+};
 // flatten すると unit との対応が消えるため、その前に snapshot 用へ reviewer ごとの帰属を
 // 記録しておく。
 const rawFindings = [];
@@ -637,10 +671,19 @@ units.forEach((u, i) => {
         line: f.line,
         severity: f.severity,
         message: f.summary,
+        // 無いフィールドは空文字にせず無いまま残す。何も返さなかった reviewer と、空を
+        // 返した reviewer を読み手が区別できる。
+        ...(f.category ? { category: f.category } : {}),
+        ...(f.trigger ? { trigger: f.trigger } : {}),
+        ...dispositionOf(f),
       });
     }
   }
 });
+if (restoredDispositions)
+  log(
+    `disposition: ${restoredDispositions} override(s) restored to ${DEFAULT_DISPOSITION} (no disposition_reason).`,
+  );
 // skip は unit 単位で集計する。reviewer を key にすると、同じ reviewer の生き残った unit が
 // 出力ありと見なされ、stall した unit の未 review ファイルが隠れてしまう。
 const skipped = units
@@ -828,7 +871,12 @@ const integrated = await agent(
 
 // フォールバック先を triage 前の findings にすると、id が付く前の配列に落ちるので、
 // challenge が disputed と判定した finding を黙って呼び戻すことになる。
-const finalFindings = (integrated && integrated.findings) || survivorsInput;
+const integratedFindings = (integrated && integrated.findings) || survivorsInput;
+// Integrate が読む projection は disposition を含まないので、出力にも戻ってこない。ここで
+// 既定値を当て直すことで、返り値の finding が survivors と同じ軸で読める。
+const finalFindings = integratedFindings.map((f) =>
+  f.disposition ? f : { ...f, disposition: DEFAULT_DISPOSITION },
+);
 const snapshot = await writeSnapshot({
   preFlight,
   rawFindings,

--- a/agents/_lib/finding-schema.md
+++ b/agents/_lib/finding-schema.md
@@ -65,6 +65,32 @@ Evidence, Trigger, and Reasoning fields MUST use concrete language.
 | theoretically          | (remove. describe the actual path) |
 | in some cases          | when [specific condition]          |
 
+## Disposition
+
+Severity states how large the impact is. Disposition states what the reader does next. Whether a finding blocks a merge or is left to the author is an axis severity does not answer, so the two ride on one finding together.
+
+This is the first axis added to the common core DR-0078 settled (Severity / Evidence / one-line claim / ID). The vocabulary stays on the audit side and does not return to `/preview`, which `skills/preview/tests/plan-alignment.test.js` forbids.
+
+| Value | Meaning                                  | Severity it rides with | Supplied by                        |
+| ----- | ---------------------------------------- | ---------------------- | ---------------------------------- |
+| must  | Fix before merge                         | critical / high        | the script default, or the 3       |
+| want  | Fix unless there is a reason not to      | medium                 | the 3 reviewers below              |
+| imo   | The author decides                       | low                    | the 3 reviewers below              |
+| nits  | Cosmetic. Fixing it is optional          | low                    | the 3 reviewers below              |
+| ask   | Undecidable from code alone. Ask a human | none                   | the critic's needs_context verdict |
+| info  | Already handled. Kept for the record     | none                   | triage's disputed / downgraded     |
+
+"Severity it rides with" is a guide, not a derivation rule. The default is pinned to must rather than derived from severity. `workflows/assert.js`'s gate ignores severity and returns NotReady on `issues.length > 0` alone, so a severity-derived default would put nits on a finding that blocks the merge.
+
+| Rule           | Content                                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------------------------- |
+| Default        | must. The script sets it on a finding the reviewer did not declare                                             |
+| Declarable     | must / want / imo / nits. ask and info are not kinds a reviewer produces                                       |
+| Who overrides  | reviewer-design / reviewer-readability / reviewer-reuse only, the lenses whose findings can turn on preference |
+| Override needs | A disposition_reason. An override without one falls back to the default must                                   |
+| Consolidation  | must > want > imo > nits. A consolidated finding takes the strongest value among its sources                   |
+| Gates          | Disposition feeds no gate. It is the order to fix in, not the call on whether to merge                         |
+
 ## Calibration Filters
 
 Apply in order. If any filter excludes, do not report.

--- a/docs/decisions/0104-keep-disposition-out-of-audit-gates.md
+++ b/docs/decisions/0104-keep-disposition-out-of-audit-gates.md
@@ -1,0 +1,57 @@
+---
+status: "accepted"
+date: "2026-08-21"
+decision-makers: "thkt"
+---
+
+# Keep disposition out of audit gates
+
+## Context and Problem Statement
+
+audit と assert が返す finding は severity (critical/high/medium/low) だけを持つ。severity は影響の大きさを表す軸なので、読んだ人間が次に何をするか、つまりマージを止めるべきか作者の判断に委ねてよいかには答えない。
+
+品質語彙の持ち主はコミット `7a5f7e74` で `/preview` から audit へ移った。`skills/preview/tests/plan-alignment.test.js` が preview へのラベル再登場を禁止している。移った先の audit がまだ語彙を持たないので、語彙をどこに置くかと、それを gate に使うかを同時に決める必要がある。
+
+DR-0078 は finding atom family の共通コアを Severity/Evidence/一行 claim/ID と定めた。disposition はそのコアに足す 1 本目の軸になる。
+
+## Decision Outcome
+
+disposition を `agents/_lib/finding-schema.md` の 1 箇所で定義し、いかなる gate の入力にもしない。既定値は severity から導かず must に固定する。
+
+gate の入力にしない理由は 2 つある。第 1 に、`workflows/assert.js` の ternary gate は severity を見ず `issues.length > 0` だけで NotReady を出す。disposition を足しても gate の分岐は変わらないので、入力にすると読み手に「効いている」と誤解させる。第 2 に、disposition は reviewer が申告できる軸である。gate の入力にすると、reviewer が nits を申告することで gate を通せることになり、裁量で迂回できない品質ゲートという前提が崩れる。
+
+既定値を severity 由来にしない理由も gate の形から出る。gate が severity を見ない以上、high の finding も low の finding も等しくマージを止める。severity 由来の既定値だと、マージを止める finding に nits が付き、行の意味と実際の効き方が逆を向く。
+
+### Consequences
+
+- Good, report を読んだ人間が、finding ごとに自分の判断が要るかどうかを severity を解釈せずに読み取れる
+- Good, gate の判定が変わらないので、この変更が原因で通っていた PR が止まることも、止まっていた PR が通ることもない
+- Good, DR-0078 の共通コアに軸を足す形が 1 例できる。2 本目の軸を足すときの前例になる
+- Bad, disposition と gate が独立するので、must ばかりが並ぶ report でも gate は issue の件数だけを見る。優先順位を gate に反映したくなったときは、この DR の再検討が要る
+- Bad, reviewer が申告できる値と script が供給する値が同じ列に並ぶ。供給元の列を読まないと、誰が決めた値か分からない
+
+### Confirmation
+
+- `workflows/audit/tests/audit.triage.test.js` が、申告の無い finding に must が付くこと、理由の無い上書きが must へ戻り件数が log に残ることを検査する
+- `workflows/audit/tests/audit.seam.test.js` が、reviewer 出力から返り値までを実モジュールで通し、全 finding が disposition を持つことを検査する
+- `workflows/assert/tests/assert.degradation.test.js` が、gate の判定が disposition を読まないことを gate_reason の内容で示す (別 issue)
+
+### Reassessment Triggers
+
+- must 以外の disposition が付いた finding が実際に出て、その扱いが gate と食い違った実例が出たとき
+- gate を severity か disposition で分ける必要が生じ、false positive の実例が伴ったとき
+
+## Considered Options
+
+- disposition を severity から機械的に導出する。`workflows/audit.js` の triage は needs_context の finding を survivors から外すので、導出の時点で ask に当たる finding が 0 件になり、must/want/imo/nits は severity の純粋な言い換えへ縮退する
+- reviewer 全 18 本に必須フィールドとして持たせる。must は High、want は Medium、imo と nits は Low に対応するため、約 40 ファイルの変更の大部分が severity の言い換えになる
+- `workflows/assert.js` の gate を severity で分ける。過去に「gate の緩和は false positive の実例が出たときだけ」と決めており、今回は設計上の不整合の指摘に留まって実例が無い
+
+## More Information
+
+DR-0078 が定めた共通コア (Severity/Evidence/一行 claim/ID) に軸を 1 本足す関係にある。共通コア自体の境界は変えないので、DR-0078 の Reassessment Triggers は発火しない。
+
+### References
+
+- `7a5f7e74` 品質語彙を `/preview` から外し、コード品質は `/code-review` と audit の担当と定めたコミット
+- `.claude/workspace/research/2026-08-02-audit-reviewer-refinement.md` category と trigger の透過を prune 品質に効く最も安い変更として記録

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -73,7 +73,7 @@ This directory contains important decisions about the project.
 | [0065](0065-scout-json-output-schema-and-sysexits-exit-code-policy.md) | scout JSON output schema and sysexits exit code policy | accepted | 2026-05-07 |
 | [0066](0066-cli-exit-code-policy-grouped-by-error-topology.md) | CLI exit code policy grouped by error topology | accepted | 2026-05-13 |
 | [0067](0067-define-boundary-between-rules-adr-and-claudemd.md) | Define boundary between RULES, ADR, and CLAUDE.md | accepted | 2026-05-13 |
-| [0068](0068-stop-hook-knowledge-reflection-subagent-and-mechanical.md) | Adopt Stop hook Knowledge Reflection with subagent extraction and mechanical activity log | accepted | 2026-05-14 |
+| [0068](0068-stop-hook-knowledge-reflection-subagent-and-mechanical.md) | Adopt Stop hook Knowledge Reflection with subagent extraction and mechanical activity log | deprecated | 2026-05-14 |
 | [0069](0069-adopt-yomu-indirect-prompt-injection-defense.md) | Adopt Indirect Prompt Injection Defense Design for yomu | accepted | 2026-05-19 |
 | [0070](0070-rename-audit-undocumented-skill-to-audit-adr-gaps.md) | ADR-0070: Rename audit-undocumented skill to audit-adr-gaps | superseded by DR-0075 | 2026-06-13 |
 | [0071](0071-think-assert-no-source-enforcement.md) | ADR-0071: think と assert の no-source 状態の統一原則と enforcement 非対称 | accepted | 2026-06-01 |
@@ -102,13 +102,14 @@ This directory contains important decisions about the project.
 | [0094](0094-require-root-cause-for-bug-plans.md) | DR-0094: Bug の plan に root_cause を要求する判定を title のプレフィックスで行う | accepted | 2026-07-31 |
 | [0095](0095-move-audit-membership-rule-from-agent-to-script.md) | DR-0095: audit の membership 判定を enhancer-integration の Phase 2 から script の triage に移す | accepted | 2026-08-02 |
 | [0096](0096-fence-untrusted-findings-in-four-audit-stages.md) | DR-0096: audit の prompt data 境界を Challenge/Verify/Integrate/Snapshot の 4 段に絞る | accepted | 2026-08-03 |
-| [0097](0097-ask-instead-of-extract-when-returning-corrections-to-rules.md) | Ask instead of extract when returning corrections to rules | accepted | 2026-08-09 |
+| [0097](0097-ask-instead-of-extract-when-returning-corrections-to-rules.md) | Ask instead of extract when returning corrections to rules | deprecated | 2026-08-09 |
 | [0098](0098-adopt-usage-census-over-time-based-prediction-ledger.md) | ADR-0098: 機構の退役判断に時間ベースの予測台帳ではなく使用センサスを採る | accepted | 2026-08-13 |
 | [0099](0099-retire-fix-finding-id-route-for-direct-finding-input.md) | Retire fix's Finding ID route in favor of Direct Finding Input | accepted | 2026-08-18 |
 | [0100](0100-replace-5-whys-with-hypothesis-elimination-in-rca.md) | Replace 5 Whys with hypothesis elimination in root cause analysis | accepted | 2026-08-18 |
 | [0101](0101-extract-shared-embedding-crate-ruri-core.md) | embedding + storage ユーティリティの共有クレート化 (rurico) | proposed | 2026-03-24 |
 | [0102](0102-resolve-uncertainty-at-issue-creation-instead-of-marking-it.md) | Resolve uncertainty at issue creation instead of marking it | accepted | 2026-08-19 |
 | [0103](0103-carry-reference-rules-in-the-plan-instead-of-a-flat-index.md) | Carry reference rules in the plan instead of a flat index | accepted | 2026-08-20 |
+| [0104](0104-keep-disposition-out-of-audit-gates.md) | Keep disposition out of audit gates | accepted | 2026-08-21 |
 
 ## By Status
 
@@ -175,7 +176,6 @@ This directory contains important decisions about the project.
 - **0065**: scout JSON output schema and sysexits exit code policy
 - **0066**: CLI exit code policy grouped by error topology
 - **0067**: Define boundary between RULES, ADR, and CLAUDE.md
-- **0068**: Adopt Stop hook Knowledge Reflection with subagent extraction and mechanical activity log
 - **0069**: Adopt Indirect Prompt Injection Defense Design for yomu
 - **0071**: ADR-0071: think と assert の no-source 状態の統一原則と enforcement 非対称
 - **0072**: ADR-0072: yomu 利用停止とコード検索の ugrep/bfs 統一
@@ -200,18 +200,20 @@ This directory contains important decisions about the project.
 - **0094**: DR-0094: Bug の plan に root_cause を要求する判定を title のプレフィックスで行う
 - **0095**: DR-0095: audit の membership 判定を enhancer-integration の Phase 2 から script の triage に移す
 - **0096**: DR-0096: audit の prompt data 境界を Challenge/Verify/Integrate/Snapshot の 4 段に絞る
-- **0097**: Ask instead of extract when returning corrections to rules
 - **0098**: ADR-0098: 機構の退役判断に時間ベースの予測台帳ではなく使用センサスを採る
 - **0099**: Retire fix's Finding ID route in favor of Direct Finding Input
 - **0100**: Replace 5 Whys with hypothesis elimination in root cause analysis
 - **0102**: Resolve uncertainty at issue creation instead of marking it
 - **0103**: Carry reference rules in the plan instead of a flat index
+- **0104**: Keep disposition out of audit gates
 
 ### Deprecated
 
 - **0034**: ADR-0034: LaunchAgent によるバックログライフサイクル自動化
 - **0036**: LLMによるクロスセッション知識合成wikiプラグインの構築
 - **0057**: Make evaluator-test a Pure Measurement Agent
+- **0068**: Adopt Stop hook Knowledge Reflection with subagent extraction and mechanical activity log
+- **0097**: Ask instead of extract when returning corrections to rules
 
 ### Superseded
 
@@ -250,5 +252,5 @@ This project uses [MADR (Markdown Any Decision Records)](https://adr.github.io/m
 
 ---
 
-*Last updated: 2026-08-20*
+*Last updated: 2026-08-21*
 *Auto-generated by: update-index.py*

--- a/rules/conventions/SUBAGENT.md
+++ b/rules/conventions/SUBAGENT.md
@@ -78,7 +78,7 @@ Grant memory when all three below hold, and remove it when the project scope sta
 
 ## Finding severity
 
-reviewer- agents follow the Severity (critical / high / medium / low) in `~/.claude/agents/_lib/finding-schema.md`. An agent returning its own gate verdict (critic- agents with confirmed / disputed) follows its own scheme.
+reviewer- agents follow the Severity (critical / high / medium / low) in `~/.claude/agents/_lib/finding-schema.md`. What to fix first is the Disposition in the same file, which is where the values are listed. An agent returning its own gate verdict (critic- agents with confirmed / disputed) follows its own scheme.
 
 ## Reference notation
 

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -347,8 +347,7 @@ const findingsSchema = ({ withSourceIds = false } = {}) => ({
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
-          // Optional, not required: a reviewer that returns no trigger would otherwise fail
-          // validation on its whole findings array and lose every finding in it.
+          // Optional: required, a reviewer returning no trigger loses its whole findings array.
           category: { type: "string", description: "the reviewer's own finding category" },
           trigger: {
             type: "string",
@@ -652,19 +651,16 @@ const raw = await parallel(
   ),
 );
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
-// The script owns the default, so a reviewer that declares nothing still leaves a countable
-// value (agents/_lib/finding-schema.md § Disposition). The default is pinned rather than
-// derived from severity: assert's gate ignores severity, so a derived default would put nits
-// on a finding that blocks the merge.
+// Pinned rather than derived from severity (agents/_lib/finding-schema.md § Disposition):
+// assert's gate ignores severity, so a derived default would put nits on a blocking finding.
 const DEFAULT_DISPOSITION = "must";
 const DECLARABLE_DISPOSITIONS = new Set(["must", "want", "imo", "nits"]);
 let restoredDispositions = 0;
 const dispositionOf = (f) => {
-  const declared = String(f.disposition || "");
-  const reason = String(f.disposition_reason || "").trim();
+  const declared = f.disposition || "";
+  const reason = (f.disposition_reason || "").trim();
   if (!declared) return { disposition: DEFAULT_DISPOSITION };
-  // An override with no reason is a preference stated as a verdict, so it falls back instead
-  // of travelling as a declared value.
+  // An override with no reason is a preference stated as a verdict, so it does not travel.
   if (!DECLARABLE_DISPOSITIONS.has(declared) || !reason) {
     restoredDispositions += 1;
     return { disposition: DEFAULT_DISPOSITION };
@@ -685,8 +681,7 @@ units.forEach((u, i) => {
         line: f.line,
         severity: f.severity,
         message: f.summary,
-        // An absent field stays absent rather than becoming an empty string, so a reader can
-        // tell a reviewer that returned nothing from one that returned blank.
+        // Absent stays absent: an empty string would read as a reviewer that answered blank.
         ...(f.category ? { category: f.category } : {}),
         ...(f.trigger ? { trigger: f.trigger } : {}),
         ...dispositionOf(f),
@@ -890,9 +885,7 @@ const integrated = await agent(
 // Falling back to the pre-triage findings array would land on the state before ids were
 // assigned, silently readmitting findings the challenge pass had disputed.
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// Integrate reads a projection that carries no disposition, so its output comes back without
-// one. Applying the default again here keeps the returned findings readable on the same axis
-// as the survivors.
+// Integrate reads a projection carrying no disposition, so the default is applied again here.
 const finalFindings = integratedFindings.map((f) =>
   f.disposition ? f : { ...f, disposition: DEFAULT_DISPOSITION },
 );

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -347,6 +347,23 @@ const findingsSchema = ({ withSourceIds = false } = {}) => ({
             enum: ["critical", "high", "medium", "low"],
           },
           summary: { type: "string" },
+          // Optional, not required: a reviewer that returns no trigger would otherwise fail
+          // validation on its whole findings array and lose every finding in it.
+          category: { type: "string", description: "the reviewer's own finding category" },
+          trigger: {
+            type: "string",
+            description: "the concrete condition under which the issue manifests",
+          },
+          disposition: {
+            type: "string",
+            enum: ["must", "want", "imo", "nits"],
+            description:
+              "what the reader does next, per agents/_lib/finding-schema.md § Disposition. Omit it to take the default",
+          },
+          disposition_reason: {
+            type: "string",
+            description: "why this finding departs from the default. Required to override",
+          },
           ...(withSourceIds
             ? {
                 source_ids: {
@@ -635,6 +652,25 @@ const raw = await parallel(
   ),
 );
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
+// The script owns the default, so a reviewer that declares nothing still leaves a countable
+// value (agents/_lib/finding-schema.md § Disposition). The default is pinned rather than
+// derived from severity: assert's gate ignores severity, so a derived default would put nits
+// on a finding that blocks the merge.
+const DEFAULT_DISPOSITION = "must";
+const DECLARABLE_DISPOSITIONS = new Set(["must", "want", "imo", "nits"]);
+let restoredDispositions = 0;
+const dispositionOf = (f) => {
+  const declared = String(f.disposition || "");
+  const reason = String(f.disposition_reason || "").trim();
+  if (!declared) return { disposition: DEFAULT_DISPOSITION };
+  // An override with no reason is a preference stated as a verdict, so it falls back instead
+  // of travelling as a declared value.
+  if (!DECLARABLE_DISPOSITIONS.has(declared) || !reason) {
+    restoredDispositions += 1;
+    return { disposition: DEFAULT_DISPOSITION };
+  }
+  return { disposition: declared, disposition_reason: reason };
+};
 // Capture per-reviewer attribution for the snapshot before the flatten above
 // drops which unit produced what.
 const rawFindings = [];
@@ -649,10 +685,19 @@ units.forEach((u, i) => {
         line: f.line,
         severity: f.severity,
         message: f.summary,
+        // An absent field stays absent rather than becoming an empty string, so a reader can
+        // tell a reviewer that returned nothing from one that returned blank.
+        ...(f.category ? { category: f.category } : {}),
+        ...(f.trigger ? { trigger: f.trigger } : {}),
+        ...dispositionOf(f),
       });
     }
   }
 });
+if (restoredDispositions)
+  log(
+    `disposition: ${restoredDispositions} override(s) restored to ${DEFAULT_DISPOSITION} (no disposition_reason).`,
+  );
 // Skip accounting is per-unit: keying on the reviewer would set "produced" from
 // any surviving unit and hide the files a stalled unit never reviewed.
 const skipped = units
@@ -844,7 +889,13 @@ const integrated = await agent(
 
 // Falling back to the pre-triage findings array would land on the state before ids were
 // assigned, silently readmitting findings the challenge pass had disputed.
-const finalFindings = (integrated && integrated.findings) || survivorsInput;
+const integratedFindings = (integrated && integrated.findings) || survivorsInput;
+// Integrate reads a projection that carries no disposition, so its output comes back without
+// one. Applying the default again here keeps the returned findings readable on the same axis
+// as the survivors.
+const finalFindings = integratedFindings.map((f) =>
+  f.disposition ? f : { ...f, disposition: DEFAULT_DISPOSITION },
+);
 const snapshot = await writeSnapshot({
   preFlight,
   rawFindings,

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -128,10 +128,8 @@ test("T-019 carrying a test-file-only diff under focus=security leaves the zero-
   );
 });
 
-// The default is applied at two points: on rawFindings as the reviewer output is captured, and
-// again on what Integrate returns, whose input projection carries no disposition. A run where
-// nobody declares one is the case that shows whether both fired, which the triage cases cannot
-// see because they stop before Integrate.
+// The default is applied twice: on rawFindings, and again on what Integrate returns. The triage
+// cases stop before Integrate, so only a full run shows whether the second one fired.
 test("T-022 a run where no reviewer declares a disposition returns every finding as must", async () => {
   const { result, record } = await run([{ path: "sample.js", churn: 0 }], {
     security: {

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -128,6 +128,44 @@ test("T-019 carrying a test-file-only diff under focus=security leaves the zero-
   );
 });
 
+// The default is applied at two points: on rawFindings as the reviewer output is captured, and
+// again on what Integrate returns, whose input projection carries no disposition. A run where
+// nobody declares one is the case that shows whether both fired, which the triage cases cannot
+// see because they stop before Integrate.
+test("T-022 a run where no reviewer declares a disposition returns every finding as must", async () => {
+  const { result, record } = await run([{ path: "sample.js", churn: 0 }], {
+    security: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+    },
+    silence: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+    },
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    integrate: INTEGRATED,
+  });
+  assert.ok(result.findings.length > 0, "the run returns findings to apply the default to");
+  assert.deepEqual(
+    [...new Set(result.findings.map((f) => f.disposition))],
+    ["must"],
+    "every returned finding carries must, including the ones Integrate rebuilt",
+  );
+  assert.deepEqual(
+    [...new Set(result.survivors.map((s) => s.disposition))],
+    ["must"],
+    "the survivors carry it on the same axis as the returned findings",
+  );
+  assert.deepEqual(
+    [...new Set(record.raw_findings.map((f) => f.disposition))],
+    ["must"],
+    "the record the real snapshot.py wrote carries it too",
+  );
+});
+
 // T-001 in the degradation file stops at reading the prompt. This carries the same finding to
 // the real snapshot.py and checks the count in the record on disk does not shrink. An attacker
 // does not know the nonce, so the only forgeable thing is a fixed string carrying none.

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -14,10 +14,12 @@ const auditJs = join(here, "..", "..", "audit.js");
 
 // The shortest stub carrying Route -> Review (the security and silence reviewers) -> Challenge.
 // defaultAgentStub in _fixtures.js decides the default responses and the id numbering.
-const runChallenge = (challenge) =>
+// extra overrides a reviewer's own response, which the disposition cases need to make a reviewer
+// declare a value at all.
+const runChallenge = (challenge, extra = {}) =>
   runWorkflow(auditJs, {
     args: { focus: "security", skipPreflight: true },
-    stubs: { agent: defaultAgentStub({ challenge }) },
+    stubs: { agent: defaultAgentStub({ challenge, ...extra }) },
   });
 
 test("T-001 drops a finding from survivors when challenge returns disputed", async () => {
@@ -61,6 +63,93 @@ test("T-003 treats a finding with no verdict as confirmed and counts it under no
     logs.some((l) => /no_verdict/.test(l) && /1/.test(l)),
     "log() carries the count of findings that drew no verdict as no_verdict",
   );
+});
+
+// A reviewer that declares nothing must still produce a countable disposition. Left absent, a
+// reader has to fall back to severity, which is the axis this one exists to stop answering with.
+test("T-005 a finding declaring no disposition carries must after triage", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "confirmed" },
+      { id: "R-2", verdict: "confirmed" },
+    ],
+  });
+  assert.deepEqual(
+    result.survivors.map((s) => s.disposition),
+    ["must", "must"],
+    "the script fills the default rather than leaving the field absent",
+  );
+});
+
+// An override with no reason is a preference stated as a verdict. Falling back silently would
+// leave the reader unable to tell a declared must from one the script restored.
+test("T-006 an override without a disposition_reason falls back to must and the count reaches log()", async () => {
+  const { result, logs } = await runChallenge(
+    {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    {
+      security: {
+        findings: [
+          { file: "sample.js", line: "1", severity: "high", summary: "s", disposition: "nits" },
+        ],
+      },
+    },
+  );
+  const byId = new Map(result.survivors.map((s) => [s.id, s]));
+  assert.equal(byId.get("R-1").disposition, "must", "a reasonless override is restored to must");
+  assert.equal(byId.get("R-1").disposition_reason, undefined, "no reason is invented for it");
+  assert.ok(
+    logs.some((l) => /disposition/.test(l) && /1/.test(l)),
+    "log() carries how many overrides were restored",
+  );
+});
+
+// findingsSchema drops every key it does not list, so a reviewer can fill category and trigger
+// and the report still shows neither. These two are what the prune quality reads.
+test("T-007 the category and trigger a reviewer returned stay on the survivor", async () => {
+  const { result } = await runChallenge(
+    {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    {
+      security: {
+        findings: [
+          {
+            file: "sample.js",
+            line: "1",
+            severity: "high",
+            summary: "s",
+            category: "injection",
+            trigger: "every Bash tool call",
+          },
+        ],
+      },
+    },
+  );
+  const byId = new Map(result.survivors.map((s) => [s.id, s]));
+  assert.equal(byId.get("R-1").category, "injection");
+  assert.equal(byId.get("R-1").trigger, "every Bash tool call");
+});
+
+// Required fields would fail the whole findings array of a reviewer that returns no trigger, so
+// the two stay optional and an absent one stays absent rather than becoming an empty string.
+test("T-008 a finding with no trigger stays a survivor and its trigger stays absent", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "confirmed" },
+      { id: "R-2", verdict: "confirmed" },
+    ],
+  });
+  const byId = new Map(result.survivors.map((s) => [s.id, s]));
+  assert.ok(byId.get("R-1"), "the finding survives without a trigger");
+  assert.equal(byId.get("R-1").trigger, undefined, "the absent trigger is not filled in");
 });
 
 test("T-004 leaves the reviewer name out of the input handed to the critic", async () => {

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -14,8 +14,7 @@ const auditJs = join(here, "..", "..", "audit.js");
 
 // The shortest stub carrying Route -> Review (the security and silence reviewers) -> Challenge.
 // defaultAgentStub in _fixtures.js decides the default responses and the id numbering.
-// extra overrides a reviewer's own response, which the disposition cases need to make a reviewer
-// declare a value at all.
+// extra overrides a reviewer's own response, which the disposition cases need to declare one.
 const runChallenge = (challenge, extra = {}) =>
   runWorkflow(auditJs, {
     args: { focus: "security", skipPreflight: true },
@@ -65,8 +64,7 @@ test("T-003 treats a finding with no verdict as confirmed and counts it under no
   );
 });
 
-// A reviewer that declares nothing must still produce a countable disposition. Left absent, a
-// reader has to fall back to severity, which is the axis this one exists to stop answering with.
+// Left absent, the reader falls back to severity, the axis this one exists to stop answering with.
 test("T-005 a finding declaring no disposition carries must after triage", async () => {
   const { result } = await runChallenge({
     verdicts: [
@@ -81,8 +79,7 @@ test("T-005 a finding declaring no disposition carries must after triage", async
   );
 });
 
-// An override with no reason is a preference stated as a verdict. Falling back silently would
-// leave the reader unable to tell a declared must from one the script restored.
+// Falling back silently leaves a declared must and a restored one reading the same.
 test("T-006 an override without a disposition_reason falls back to must and the count reaches log()", async () => {
   const { result, logs } = await runChallenge(
     {
@@ -108,8 +105,7 @@ test("T-006 an override without a disposition_reason falls back to must and the 
   );
 });
 
-// findingsSchema drops every key it does not list, so a reviewer can fill category and trigger
-// and the report still shows neither. These two are what the prune quality reads.
+// findingsSchema drops every key it does not list, so both reach the report only once listed.
 test("T-007 the category and trigger a reviewer returned stay on the survivor", async () => {
   const { result } = await runChallenge(
     {
@@ -138,8 +134,7 @@ test("T-007 the category and trigger a reviewer returned stay on the survivor", 
   assert.equal(byId.get("R-1").trigger, "every Bash tool call");
 });
 
-// Required fields would fail the whole findings array of a reviewer that returns no trigger, so
-// the two stay optional and an absent one stays absent rather than becoming an empty string.
+// Required, these would fail the whole findings array of a reviewer that returns no trigger.
 test("T-008 a finding with no trigger stays a survivor and its trigger stays absent", async () => {
   const { result } = await runChallenge({
     verdicts: [


### PR DESCRIPTION
## What & Why

audit を回すと、reviewer が何も申告しなくても返り値の全 finding が disposition を持つ。語彙は `agents/_lib/finding-schema.md` の 1 箇所で定義される。

finding は severity しか持たず、読んだ人間はマージを止めるべきか作者の判断に委ねてよいかを severity から推し量ることになっていた。severity は影響の大きさであって、その問いには答えない。品質語彙の持ち主はコミット `7a5f7e74` で `/preview` から audit へ移ったが、移った先の audit がまだ語彙を持っていなかった。

## Review focus

- **`toCriticRef` を触っていないこと**。critic に disposition を見せると challenge の verdict が reviewer の申告に引きずられる。その代わり Integrate の出力にも disposition が戻らないので、`finalFindings` で既定値を当て直している。既定値が 2 か所で当たる形になった理由がここ
- **既定値を must に固定した判断**。DR-0104 に理由を書いた。severity 由来にすると、`workflows/assert.js` の gate が severity を見ない以上、マージを止める finding に nits が付く
- `agents/_lib/finding-schema.md` の `## Disposition` 節は流し読みでよい。値と規則の表で、判断の根拠は DR-0104 側にある

## Changes

- schema への追加は 4 つとも optional。必須にすると trigger を返さない reviewer の findings 配列がまるごと検証に落ち、その中の finding をすべて失う
- 理由の無い上書きは既定値へ戻し、戻した件数を `log()` に出す。黙って戻すと、申告された must と script が戻した must が同じに見える

## Scope

- Not included: reviewer 3 本の上書き行と Integrate の統合順序 (#417)
- Not included: ask/info のチャネル (#418)
- Not included: assert の gate_reason (#416)
- disposition はいかなる gate の入力にもしない。gate の分岐は 1 行も変えていない

## Design Decisions

- `toCriticRef` は 5 フィールドの projection のまま。disposition を critic へ渡すと、reviewer の申告が challenge の verdict を biasing する経路ができる
- 既定値は `rawFindings` を組む時点と `finalFindings` の 2 か所で当てる。Integrate が読む projection が disposition を含まないので、1 か所では返り値に載らない
- plan の U-002 は files に `.ja/workflows/audit.js` を挙げていないが、MIRROR.md が同一コミットでのミラーを求めるため含めた
- T-NNN を T-005〜T-008/T-022 に振り直した。plan の T-001〜T-005 は `audit.triage.test.js` と `audit.seam.test.js` の既存番号と衝突する。着手前に #415・#417・#418 の本文も更新済み

## How to Test

1. `node --test workflows/audit/tests/audit.triage.test.js workflows/audit/tests/audit.seam.test.js` を実行し、落ちるテストが無いことを確認する
2. `workflows/audit.js` の `finalFindings` の既定値適用を外すと T-022 が落ちることを確認する
3. `node --test "workflows/**/tests/*.test.js"` で 237 件が pass することを確認する

## Related

- Closes #415
- Parent: #374
