### PR TITLE
assert の gate 理由を返り値に載せる

### DIFF
--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -292,9 +292,9 @@ log(
 );
 
 let gate = "NotReady";
-// 下の gate 分岐で成立した条件。NotReady を読んだ人間が issue の件数で止まったのか
-// severity や disposition なのかを判別できるようにする (後者は gate に一切影響しない)。
-let gateReason = [];
+// severity も disposition も gate に影響しないので、NotReady を読んだ人間は findings から
+// 原因を導けない。実際に成立した条件を並べる。
+const gateReason = [];
 let issues = [];
 let testsCol = "skipped";
 let adversarialSummary = {
@@ -575,9 +575,6 @@ try {
   // NotReady。severity は修正優先度のヒントに留まり、gate には影響しない。caveat は issues 0 を
   // 前提に、動的 evidence が env 起因などで欠けたとき、または入れ子の audit が fail-open して
   // findings が未検証のときに付く。
-  // gateReason はこの同じ分岐で成立した条件を並べる (severity や disposition は gate に
-  // 影響しないため含めない)。NotReady を読んだ人間が、例えば issue の件数で止まったことを
-  // 判別できるようにする。
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
     if (buildCol === "fail") gateReason.push("build fail");

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -586,7 +586,7 @@ try {
     if (challengeStalled) gateReason.push("challenge stalled");
   } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
-    gateReason.push("build pass", `tests ${testsCol}`, "0 issues");
+    gateReason.push(`build ${buildCol}`, `tests ${testsCol}`, "0 issues");
   } else {
     gate = "Ready (caveat)";
     if (envFail) gateReason.push("env fail (dynamic verification skipped)");

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -292,6 +292,9 @@ log(
 );
 
 let gate = "NotReady";
+// 下の gate 分岐で成立した条件。NotReady を読んだ人間が issue の件数で止まったのか
+// severity や disposition なのかを判別できるようにする (後者は gate に一切影響しない)。
+let gateReason = [];
 let issues = [];
 let testsCol = "skipped";
 let adversarialSummary = {
@@ -572,12 +575,24 @@ try {
   // NotReady。severity は修正優先度のヒントに留まり、gate には影響しない。caveat は issues 0 を
   // 前提に、動的 evidence が env 起因などで欠けたとき、または入れ子の audit が fail-open して
   // findings が未検証のときに付く。
+  // gateReason はこの同じ分岐で成立した条件を並べる (severity や disposition は gate に
+  // 影響しないため含めない)。NotReady を読んだ人間が、例えば issue の件数で止まったことを
+  // 判別できるようにする。
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
+    if (buildCol === "fail") gateReason.push("build fail");
+    if (testsCol === "fail") gateReason.push("tests fail");
+    if (issues.length > 0) gateReason.push(`${issues.length} issue(s)`);
+    if (challengeStalled) gateReason.push("challenge stalled");
   } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
+    gateReason.push("build pass", `tests ${testsCol}`, "0 issues");
   } else {
     gate = "Ready (caveat)";
+    if (envFail) gateReason.push("env fail (dynamic verification skipped)");
+    if (auditDegraded) gateReason.push("audit challenge failed open");
+    if (testsCol !== "pass" && testsCol !== "no-runner" && !envFail)
+      gateReason.push(`tests ${testsCol}`);
   }
 } finally {
   // ---- Cleanup: worktree 撤去 (結果に関わらず必ず走る) ----
@@ -599,6 +614,7 @@ log(`Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length
 
 return {
   gate,
+  gate_reason: gateReason,
   mode: boot.mode,
   build: buildCol,
   tests: testsCol,

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -294,6 +294,9 @@ log(
 );
 
 let gate = "NotReady";
+// Conditions that held at the gate branch below, so a NotReady reader can tell the stop was
+// the issue count rather than severity or disposition (neither of which ever gates).
+let gateReason = [];
 let issues = [];
 let testsCol = "skipped";
 let adversarialSummary = {
@@ -584,12 +587,24 @@ try {
   // issues means NotReady. Severity remains a fix-priority hint and never affects the
   // gate. caveat presumes zero issues and applies when dynamic evidence is missing for env
   // reasons, or when the nested audit failed open and left its findings unverified.
+  // gateReason lists, at this same branch, exactly which conditions held (never severity or
+  // disposition, since neither ever gates), so a NotReady reader can tell the stop was e.g.
+  // the issue count rather than guessing from the issues themselves.
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
+    if (buildCol === "fail") gateReason.push("build fail");
+    if (testsCol === "fail") gateReason.push("tests fail");
+    if (issues.length > 0) gateReason.push(`${issues.length} issue(s)`);
+    if (challengeStalled) gateReason.push("challenge stalled");
   } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
+    gateReason.push("build pass", `tests ${testsCol}`, "0 issues");
   } else {
     gate = "Ready (caveat)";
+    if (envFail) gateReason.push("env fail (dynamic verification skipped)");
+    if (auditDegraded) gateReason.push("audit challenge failed open");
+    if (testsCol !== "pass" && testsCol !== "no-runner" && !envFail)
+      gateReason.push(`tests ${testsCol}`);
   }
 } finally {
   // ---- Cleanup: tear down the worktree (always runs regardless of outcome) ----
@@ -611,6 +626,7 @@ log(`Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length
 
 return {
   gate,
+  gate_reason: gateReason,
   mode: boot.mode,
   build: buildCol,
   tests: testsCol,

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -294,9 +294,9 @@ log(
 );
 
 let gate = "NotReady";
-// Conditions that held at the gate branch below, so a NotReady reader can tell the stop was
-// the issue count rather than severity or disposition (neither of which ever gates).
-let gateReason = [];
+// Neither severity nor disposition gates, so a NotReady reader cannot infer the cause from the
+// findings alone. These are the conditions that actually held.
+const gateReason = [];
 let issues = [];
 let testsCol = "skipped";
 let adversarialSummary = {
@@ -587,9 +587,6 @@ try {
   // issues means NotReady. Severity remains a fix-priority hint and never affects the
   // gate. caveat presumes zero issues and applies when dynamic evidence is missing for env
   // reasons, or when the nested audit failed open and left its findings unverified.
-  // gateReason lists, at this same branch, exactly which conditions held (never severity or
-  // disposition, since neither ever gates), so a NotReady reader can tell the stop was e.g.
-  // the issue count rather than guessing from the issues themselves.
   if (buildCol === "fail" || testsCol === "fail" || issues.length > 0 || challengeStalled) {
     gate = "NotReady";
     if (buildCol === "fail") gateReason.push("build fail");

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -598,7 +598,7 @@ try {
     if (challengeStalled) gateReason.push("challenge stalled");
   } else if (!envFail && !auditDegraded && (testsCol === "pass" || testsCol === "no-runner")) {
     gate = "Ready";
-    gateReason.push("build pass", `tests ${testsCol}`, "0 issues");
+    gateReason.push(`build ${buildCol}`, `tests ${testsCol}`, "0 issues");
   } else {
     gate = "Ready (caveat)";
     if (envFail) gateReason.push("env fail (dynamic verification skipped)");

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -344,3 +344,22 @@ test("T-002 build と tests が fail で issue が 0 件の run の gate_reason 
     "with zero issues the issue condition never held, so gate_reason names build/tests only",
   );
 });
+
+// A repository with no build concept reaches the Ready branch with buildCol "skipped" (bootstrap
+// reports install ok + build skipped, so envFail stays false). A hardcoded "build pass" there
+// would contradict the `build` field of the same return object.
+test("T-003 a Ready run whose build was skipped does not report build as passing", async () => {
+  const skippedBoot = { ...bootOk, build: "skipped" };
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: makeGateReasonAgent({ boot: skippedBoot }) },
+  });
+  assert.equal(result.gate, "Ready", "no build concept and passing tests still reach Ready");
+  assert.equal(result.build, "skipped", "the build column reports what bootstrap returned");
+  const reasonText = JSON.stringify(result.gate_reason);
+  assert.ok(
+    !/build pass/.test(reasonText),
+    "gate_reason does not claim a build that never ran passed",
+  );
+  assert.match(reasonText, /build skipped/, "gate_reason reports the build column it read");
+});

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -265,3 +265,85 @@ test("T-008 assert running a nested audit with no challenge stub receives challe
     "a run that really nested audit and saw its challenge fail open (challenge_ran=false) lands on gate Ready (caveat)",
   );
 });
+
+// U-001: a human reading a NotReady result can tell the stop was the issue count, not severity
+// or disposition. gate_reason is assembled at the same site as the gate branch (the script,
+// not an agent), listing the conditions that held. The gate branch itself is unchanged; only
+// gate_reason is new on the return value.
+//
+// T-002 wants a run where both build and tests are non-passing. The gate script's own dynamicOk
+// gate (buildCol === "fail" => dynamicOk false => the test-exec agent is never invoked, so
+// testsCol can only land on "skipped") makes a literal simultaneous build:"fail" /
+// tests:"fail" unreachable through a real run: a failed build always skips the test stage
+// rather than failing it. boot.build: "fail" is the closest reachable state (buildCol "fail",
+// testsCol forced to "skipped"), and it already NotReady's the gate on build alone, which is
+// what this scenario needs: a non-issue cause with zero issues.
+const makeSynthAgent = (issues) => (prompt, opts) => {
+  const label = opts && opts.label;
+  if (label === "bootstrap") return bootOk;
+  if (label === "test-exec") return { outcome: "pass", passed: 1, failed: 0 };
+  if (label === "adversarial") return { ran: true, tests: [] };
+  if (label === "codex-review") return { ran: true, findings: [] };
+  if (label === "synthesize") return { issues, root_causes: [], report: "ok" };
+  if (label === "cleanup") return {};
+  return undefined;
+};
+
+test("T-001 issue が 1 件以上あるだけで NotReady になった run の gate_reason に issue の件数が入る", async () => {
+  const issues = [
+    { file: "a.js", line: 10, severity: "high", summary: "x", source: ["audit"] },
+    { file: "b.js", line: 20, severity: "medium", summary: "y", source: ["audit"] },
+  ];
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: makeSynthAgent(issues) },
+  });
+  assert.equal(
+    result.gate,
+    "NotReady",
+    "build passes and tests pass, so issues alone gate NotReady",
+  );
+  assert.ok(
+    result.gate_reason !== undefined,
+    "gate_reason is present on the return value alongside gate",
+  );
+  const reasonText = JSON.stringify(result.gate_reason);
+  assert.match(
+    reasonText,
+    /issue/i,
+    "gate_reason names the issue condition as one of the conditions that held",
+  );
+  assert.match(
+    reasonText,
+    new RegExp(`\\b${issues.length}\\b`),
+    "gate_reason carries the issue count (2), not just the word issue",
+  );
+});
+
+test("T-002 build と tests が fail で issue が 0 件の run の gate_reason に issue の件数が入らない", async () => {
+  const failBoot = { ...bootOk, build: "fail" };
+  const agentStub = (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "bootstrap") return failBoot;
+    if (label === "codex-review") return { ran: true, findings: [] };
+    if (label === "synthesize") return { issues: [], root_causes: [], report: "ok" };
+    if (label === "cleanup") return {};
+    // test-exec / adversarial are never invoked once build fails (dynamicOk gates them off);
+    // no stub branch needed for those labels.
+    return undefined;
+  };
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: agentStub },
+  });
+  assert.equal(result.gate, "NotReady", "a failed build gates NotReady with zero issues");
+  assert.ok(
+    result.gate_reason !== undefined,
+    "gate_reason is present on the return value alongside gate",
+  );
+  const reasonText = JSON.stringify(result.gate_reason);
+  assert.ok(
+    !/issue/i.test(reasonText),
+    "with zero issues the issue condition never held, so gate_reason names build/tests only",
+  );
+});

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -266,21 +266,12 @@ test("T-008 assert running a nested audit with no challenge stub receives challe
   );
 });
 
-// U-001: a human reading a NotReady result can tell the stop was the issue count, not severity
-// or disposition. gate_reason is assembled at the same site as the gate branch (the script,
-// not an agent), listing the conditions that held. The gate branch itself is unchanged; only
-// gate_reason is new on the return value.
+// The gate branch itself is unchanged; only gate_reason is new on the return value.
 //
-// T-002 wants a run where both build and tests are non-passing. The gate script's own dynamicOk
-// gate (buildCol === "fail" => dynamicOk false => the test-exec agent is never invoked, so
-// testsCol can only land on "skipped") makes a literal simultaneous build:"fail" /
-// tests:"fail" unreachable through a real run: a failed build always skips the test stage
-// rather than failing it. boot.build: "fail" is the closest reachable state (buildCol "fail",
-// testsCol forced to "skipped"), and it already NotReady's the gate on build alone, which is
-// what this scenario needs: a non-issue cause with zero issues.
-// T-001 and T-002 differ only in which stage return values they need to override (boot for
-// T-002's failed build, issues for T-001's issue count); the rest of the label dispatch is
-// shared, so one factory takes both as overrides instead of duplicating it per test.
+// T-002's literal state, build and tests both failing, is unreachable: buildCol === "fail"
+// forces dynamicOk false, so the test-exec agent never runs and testsCol can only be "skipped".
+// boot.build: "fail" is the closest reachable state, and it already gates NotReady on build
+// alone, which is what the case needs: a non-issue cause with zero issues.
 const makeGateReasonAgent =
   ({ boot = bootOk, issues = [] } = {}) =>
   (prompt, opts) => {
@@ -327,8 +318,6 @@ test("T-001 issue が 1 件以上あるだけで NotReady になった run の g
 
 test("T-002 build と tests が fail で issue が 0 件の run の gate_reason に issue の件数が入らない", async () => {
   const failBoot = { ...bootOk, build: "fail" };
-  // test-exec / adversarial are never invoked once build fails (dynamicOk gates them off);
-  // makeGateReasonAgent still stubs them, but the workflow never reaches those branches.
   const { result } = await runWorkflow(assertJs, {
     args: {},
     stubs: { agent: makeGateReasonAgent({ boot: failBoot }) },
@@ -345,9 +334,8 @@ test("T-002 build と tests が fail で issue が 0 件の run の gate_reason 
   );
 });
 
-// A repository with no build concept reaches the Ready branch with buildCol "skipped" (bootstrap
-// reports install ok + build skipped, so envFail stays false). A hardcoded "build pass" there
-// would contradict the `build` field of the same return object.
+// A repository with no build concept reaches Ready with buildCol "skipped" (install ok + build
+// skipped keeps envFail false). A hardcoded "build pass" would contradict the sibling `build`.
 test("T-003 a Ready run whose build was skipped does not report build as passing", async () => {
   const skippedBoot = { ...bootOk, build: "skipped" };
   const { result } = await runWorkflow(assertJs, {

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -278,16 +278,21 @@ test("T-008 assert running a nested audit with no challenge stub receives challe
 // rather than failing it. boot.build: "fail" is the closest reachable state (buildCol "fail",
 // testsCol forced to "skipped"), and it already NotReady's the gate on build alone, which is
 // what this scenario needs: a non-issue cause with zero issues.
-const makeSynthAgent = (issues) => (prompt, opts) => {
-  const label = opts && opts.label;
-  if (label === "bootstrap") return bootOk;
-  if (label === "test-exec") return { outcome: "pass", passed: 1, failed: 0 };
-  if (label === "adversarial") return { ran: true, tests: [] };
-  if (label === "codex-review") return { ran: true, findings: [] };
-  if (label === "synthesize") return { issues, root_causes: [], report: "ok" };
-  if (label === "cleanup") return {};
-  return undefined;
-};
+// T-001 and T-002 differ only in which stage return values they need to override (boot for
+// T-002's failed build, issues for T-001's issue count); the rest of the label dispatch is
+// shared, so one factory takes both as overrides instead of duplicating it per test.
+const makeGateReasonAgent =
+  ({ boot = bootOk, issues = [] } = {}) =>
+  (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "bootstrap") return boot;
+    if (label === "test-exec") return { outcome: "pass", passed: 1, failed: 0 };
+    if (label === "adversarial") return { ran: true, tests: [] };
+    if (label === "codex-review") return { ran: true, findings: [] };
+    if (label === "synthesize") return { issues, root_causes: [], report: "ok" };
+    if (label === "cleanup") return {};
+    return undefined;
+  };
 
 test("T-001 issue が 1 件以上あるだけで NotReady になった run の gate_reason に issue の件数が入る", async () => {
   const issues = [
@@ -296,7 +301,7 @@ test("T-001 issue が 1 件以上あるだけで NotReady になった run の g
   ];
   const { result } = await runWorkflow(assertJs, {
     args: {},
-    stubs: { agent: makeSynthAgent(issues) },
+    stubs: { agent: makeGateReasonAgent({ issues }) },
   });
   assert.equal(
     result.gate,
@@ -322,19 +327,11 @@ test("T-001 issue が 1 件以上あるだけで NotReady になった run の g
 
 test("T-002 build と tests が fail で issue が 0 件の run の gate_reason に issue の件数が入らない", async () => {
   const failBoot = { ...bootOk, build: "fail" };
-  const agentStub = (prompt, opts) => {
-    const label = opts && opts.label;
-    if (label === "bootstrap") return failBoot;
-    if (label === "codex-review") return { ran: true, findings: [] };
-    if (label === "synthesize") return { issues: [], root_causes: [], report: "ok" };
-    if (label === "cleanup") return {};
-    // test-exec / adversarial are never invoked once build fails (dynamicOk gates them off);
-    // no stub branch needed for those labels.
-    return undefined;
-  };
+  // test-exec / adversarial are never invoked once build fails (dynamicOk gates them off);
+  // makeGateReasonAgent still stubs them, but the workflow never reaches those branches.
   const { result } = await runWorkflow(assertJs, {
     args: {},
-    stubs: { agent: agentStub },
+    stubs: { agent: makeGateReasonAgent({ boot: failBoot }) },
   });
   assert.equal(result.gate, "NotReady", "a failed build gates NotReady with zero issues");
   assert.ok(


### PR DESCRIPTION
## What & Why

assert の返り値は `gate: "NotReady"` だけを返し、どの条件が成立して止まったのかを読み手が issues 配列などから逆算する必要があった。この PR で `gate_reason` を返り値に追加し、NotReady を受け取った人間が、止まった理由が issue の件数であって severity でも disposition でもないことを返り値から読み取れるようにする。

## Review focus

- gate 判定の 3 分岐（NotReady/Ready/Ready (caveat)）それぞれで、成立した条件を `gateReason` に積む箇所を見てほしい
- T-001（issue 起因の NotReady）と T-002（build fail 起因の NotReady）が、想定どおり gate_reason の内容を分けて検証しているか

## Changes

- `gate_reason`（文字列配列）を assert の返り値に追加。NotReady/Ready/Ready (caveat) の各分岐で、その分岐に到達した根拠だけを積む
- T-001/T-002 のテスト用 agent スタブを、boot と issues の上書きだけを受け取る 1 つのファクトリに統合（label 分岐の重複を解消）

## How to Test

```
node --test workflows/assert/tests/assert.degradation.test.js
```

T-001/T-002 が pass し、gate_reason に issue 件数のみ／build fail のみが入ることを確認する。


---

_下は build workflow の自動検証結果。plan との突合までで、コードの欠陥を探すレビューはしていない。PR の本筋からは外れるので任意だが、status 行の逸脱件数が非ゼロなら見る。_

Closes #416

<details>
<summary><code>verify tests=pass gates=pass</code> · <code>scope-deviations 0</code> · <code>missing-tests 0</code> · <code>conformance 2</code></summary>

**Issue 適合性 (独立レビュー)**
- `[medium] wrong` Ready 分岐において、gateReason.push("build pass", `tests ${testsCol}`, "0 issues") は "build pass" という文字列リテラルを buildCol から導出せず、そのままハードコードしている。workflows/assert/bootstrap.py は、install が ok/skip かつ build が "skipped"（"no build concept"）で worktree_ok が true という到達可能な状態を記述している。この場合 envFail は false、buildCol は "skipped" のまま、dynamicOk は true となり、テストが通った実行結果は buildCol が "skipped" のままで Ready 分岐に到達する。この実行では gate_reason が文字どおり "build pass" と述べる一方、同じ戻り値オブジェクトの `build` フィールドは "skipped" であり、隣接フィールドと矛盾し、成立していない条件を誤って報告している。
  `workflows/assert.js:601 (mirrored at .ja/workflows/assert.js:~590)` · spec: gate の判定と同じ箇所で、成立した条件を並べた gate_reason を script が組み立てて返り値に足す。
- `[low] missing` buildCol === "fail" は dynamicOk を false に強制し、それが testsCol を "skipped" に強制する（workflows/assert.js の line 290、および dynamicOk に依存する tCol の代入による）。そのため、build:"fail" と tests:"fail" が同時に成立する実行は、実際のワークフローを通じては構造的に到達不能である。T-002 は代わりに build-fail / tests-skipped の実行を代用しており、コード内コメントはこれを到達可能な最も近い状態として記録している。しかし、両フィールドが同時に失敗するという文字どおりの AC 状態は、いずれのテストによっても未検証のまま残っている。
  `workflows/assert/tests/assert.degradation.test.js T-002 (also workflows/assert.js:290 dynamicOk gate)` · spec: build と tests が fail で issue が 0 件の run の gate_reason に issue の件数が入らない

</details>
