### PR TITLE
[Feature] reviewer が disposition を上書きでき、統合後も最も強い値が残る

### DIFF
--- a/.ja/agents/reviewers/reviewer-design.md
+++ b/.ja/agents/reviewers/reviewer-design.md
@@ -61,12 +61,13 @@ Phase 1 が同じ浅いパターンを 3 箇所以上で検出したら、~/.cla
 
 ~/.claude/agents/_lib/finding-schema.md に従う。モジュールが見つからないときは "No modules to review" を報告する。混在言語の対象は言語ごとにレビューし、黙ってスキップしない。共通ガード (glob 結果なし、ツールエラー) は ~/.claude/agents/_lib/finding-schema.md のデフォルトに従う。
 
-| フィールド   | 値                                                                             |
-| ------------ | ------------------------------------------------------------------------------ |
-| Prefix       | DP                                                                             |
-| カテゴリ     | module-depth (単一カテゴリ。サブタイプは evidence に記載)                      |
-| Severity     | high / medium / low                                                            |
-| Verification | deletion_trace。モジュールを削除したら呼び出し箇所で何が再出現するかを明示する |
+| フィールド   | 値                                                                                                                                             |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Prefix       | DP                                                                                                                                             |
+| カテゴリ     | module-depth (単一カテゴリ。サブタイプは evidence に記載)                                                                                      |
+| Severity     | high / medium / low                                                                                                                            |
+| Disposition  | reviewer によるデフォルトの上書き。上書き時は disposition_reason を伴う。詳細は `~/.claude/agents/_lib/finding-schema.md` § Disposition を参照 |
+| Verification | deletion_trace。モジュールを削除したら呼び出し箇所で何が再出現するかを明示する                                                                 |
 
 ```markdown
 ## Summary

--- a/.ja/agents/reviewers/reviewer-readability.md
+++ b/.ja/agents/reviewers/reviewer-readability.md
@@ -49,13 +49,14 @@ background: true
 
 ~/.claude/agents/_lib/finding-schema.md に従う。コードが見つからないときは "No code to review" を報告する。共通ガード (glob 空、tool エラー) は ~/.claude/agents/_lib/finding-schema.md のデフォルトに従う。
 
-| フィールド   | 値                                                                                                     |
-| ------------ | ------------------------------------------------------------------------------------------------------ |
-| Prefix       | CQ                                                                                                     |
-| カテゴリ     | structure / readability                                                                                |
-| Severity     | high / medium / low                                                                                    |
-| Verification | pattern_search または hotpath_analysis。このパターンは広範に存在するかクリティカルパスにあるか         |
-| Extra        | subcategory (waste / naming / complexity / comments / ai_smell、任意、category/subcategory として付加) |
+| フィールド   | 値                                                                                                                                             |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Prefix       | CQ                                                                                                                                             |
+| カテゴリ     | structure / readability                                                                                                                        |
+| Severity     | high / medium / low                                                                                                                            |
+| Disposition  | reviewer によるデフォルトの上書き。上書き時は disposition_reason を伴う。詳細は `~/.claude/agents/_lib/finding-schema.md` § Disposition を参照 |
+| Verification | pattern_search または hotpath_analysis。このパターンは広範に存在するかクリティカルパスにあるか                                                 |
+| Extra        | subcategory (waste / naming / complexity / comments / ai_smell、任意、category/subcategory として付加)                                         |
 
 ```markdown
 ## Summary

--- a/.ja/agents/reviewers/reviewer-reuse.md
+++ b/.ja/agents/reviewers/reviewer-reuse.md
@@ -54,12 +54,13 @@ background: true
 
 ~/.claude/agents/\_lib/finding-schema.md に従う。コードが見つからないときは "No code to review" を報告する。共通ガード (glob 空、tool エラー) は ~/.claude/agents/\_lib/finding-schema.md のデフォルトに従う。Evidence は新規コードと既存ユーティリティを `New: file:line snippet / Existing: file:line snippet` として対にする。stdlib/native カテゴリは repo 内に対がないので `Existing:` の代わりに置き換える API/機能名を書く (例: `Use: Intl.DateTimeFormat`、`Use: <input type="date">`)。
 
-| フィールド   | 値                                                                               |
-| ------------ | -------------------------------------------------------------------------------- |
-| Prefix       | REUSE                                                                            |
-| カテゴリ     | utility / pattern / inline / unused_import / stdlib / native                     |
-| Severity     | high / medium / low                                                              |
-| Verification | pattern_search。既存ユーティリティが新規コードのすべてのエッジケースを網羅するか |
+| フィールド   | 値                                                                                                                                             |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Prefix       | REUSE                                                                                                                                          |
+| カテゴリ     | utility / pattern / inline / unused_import / stdlib / native                                                                                   |
+| Severity     | high / medium / low                                                                                                                            |
+| Disposition  | reviewer によるデフォルトの上書き。上書き時は disposition_reason を伴う。詳細は `~/.claude/agents/_lib/finding-schema.md` § Disposition を参照 |
+| Verification | pattern_search。既存ユーティリティが新規コードのすべてのエッジケースを網羅するか                                                               |
 
 ```markdown
 ## Summary

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -869,10 +869,22 @@ const integrated = await agent(
 // フォールバック先を triage 前の findings にすると、id が付く前の配列に落ちるので、
 // challenge が disputed と判定した finding を黙って呼び戻すことになる。
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// Integrate が読む projection は disposition を含まないので、ここで既定値を当て直す。
-const finalFindings = integratedFindings.map((f) =>
-  f.disposition ? f : { ...f, disposition: DEFAULT_DISPOSITION },
-);
+// toCriticRef は Integrate に渡す前に disposition を落とすので、Integrate が返す disposition
+// は survivors 由来ではなく、ここでは信用しない。script が source_ids から再算出する。全順序
+// (must > want > imo > nits) は agents/_lib/finding-schema.md § Disposition に定義済みなので
+// 再掲しない。
+const DISPOSITION_RANK = { must: 4, want: 3, imo: 2, nits: 1 };
+const dispositionById = new Map(rawFindings.map((f) => [f.id, f.disposition]));
+const consolidatedDisposition = (sourceIds) =>
+  (Array.isArray(sourceIds) ? sourceIds : []).reduce((strongest, id) => {
+    const d = dispositionById.get(id);
+    if (!d) return strongest;
+    return !strongest || DISPOSITION_RANK[d] > DISPOSITION_RANK[strongest] ? d : strongest;
+  }, null) || DEFAULT_DISPOSITION;
+const finalFindings = integratedFindings.map((f) => ({
+  ...f,
+  disposition: consolidatedDisposition(f.source_ids),
+}));
 const snapshot = await writeSnapshot({
   preFlight,
   rawFindings,

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -869,10 +869,9 @@ const integrated = await agent(
 // フォールバック先を triage 前の findings にすると、id が付く前の配列に落ちるので、
 // challenge が disputed と判定した finding を黙って呼び戻すことになる。
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// toCriticRef は Integrate に渡す前に disposition を落とすので、Integrate が返す disposition
-// は survivors 由来ではなく、ここでは信用しない。script が source_ids から再算出する。強さの
-// 全順序 (must > want > imo > nits、agents/_lib/finding-schema.md § Disposition と一致) は
-// DECLARABLE_DISPOSITIONS の並びを単一の情報源とし、ここで別の数値として再掲しない。
+// toCriticRef は Integrate に渡す前に disposition を落とすので、Integrate が返す値は
+// survivors 由来ではなく信用しない。順位は DECLARABLE_DISPOSITIONS から導き、
+// agents/_lib/finding-schema.md が持つ全順序をここへ書き写さない。
 const DISPOSITION_RANK = Object.fromEntries(
   [...DECLARABLE_DISPOSITIONS].map((d, i) => [d, DECLARABLE_DISPOSITIONS.size - i]),
 );

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -870,10 +870,12 @@ const integrated = await agent(
 // challenge が disputed と判定した finding を黙って呼び戻すことになる。
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
 // toCriticRef は Integrate に渡す前に disposition を落とすので、Integrate が返す disposition
-// は survivors 由来ではなく、ここでは信用しない。script が source_ids から再算出する。全順序
-// (must > want > imo > nits) は agents/_lib/finding-schema.md § Disposition に定義済みなので
-// 再掲しない。
-const DISPOSITION_RANK = { must: 4, want: 3, imo: 2, nits: 1 };
+// は survivors 由来ではなく、ここでは信用しない。script が source_ids から再算出する。強さの
+// 全順序 (must > want > imo > nits、agents/_lib/finding-schema.md § Disposition と一致) は
+// DECLARABLE_DISPOSITIONS の並びを単一の情報源とし、ここで別の数値として再掲しない。
+const DISPOSITION_RANK = Object.fromEntries(
+  [...DECLARABLE_DISPOSITIONS].map((d, i) => [d, DECLARABLE_DISPOSITIONS.size - i]),
+);
 const dispositionById = new Map(rawFindings.map((f) => [f.id, f.disposition]));
 const consolidatedDisposition = (sourceIds) =>
   (Array.isArray(sourceIds) ? sourceIds : []).reduce((strongest, id) => {

--- a/agents/reviewers/reviewer-design.md
+++ b/agents/reviewers/reviewer-design.md
@@ -61,12 +61,13 @@ See `~/.claude/agents/_lib/calibration-examples.md` section DP.
 
 Follow ~/.claude/agents/_lib/finding-schema.md. When no modules are found, report "No modules to review". Review mixed-language targets per language and do not silently skip. Common guards (glob empty, tool error) follow ~/.claude/agents/_lib/finding-schema.md defaults.
 
-| Field        | Value                                                                         |
-| ------------ | ----------------------------------------------------------------------------- |
-| Prefix       | DP                                                                            |
-| Category     | module-depth (single category; record subtype in evidence)                    |
-| Severity     | high / medium / low                                                           |
-| Verification | deletion_trace. State what reappears at call sites when the module is deleted |
+| Field        | Value                                                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Prefix       | DP                                                                                                                                |
+| Category     | module-depth (single category; record subtype in evidence)                                                                        |
+| Severity     | high / medium / low                                                                                                               |
+| Disposition  | Reviewer-settable override of the default, with a disposition_reason. See `~/.claude/agents/_lib/finding-schema.md` § Disposition |
+| Verification | deletion_trace. State what reappears at call sites when the module is deleted                                                     |
 
 ```markdown
 ## Summary

--- a/agents/reviewers/reviewer-readability.md
+++ b/agents/reviewers/reviewer-readability.md
@@ -49,13 +49,14 @@ See `~/.claude/agents/_lib/calibration-examples.md` section CQ.
 
 Follow ~/.claude/agents/_lib/finding-schema.md. When no code is found, report "No code to review". Common guards (glob empty, tool error) follow ~/.claude/agents/_lib/finding-schema.md defaults.
 
-| Field        | Value                                                                                                       |
-| ------------ | ----------------------------------------------------------------------------------------------------------- |
-| Prefix       | CQ                                                                                                          |
-| Categories   | structure / readability                                                                                     |
-| Severity     | high / medium / low                                                                                         |
-| Verification | pattern_search or hotpath_analysis. Is this pattern widespread or in a critical path?                       |
-| Extra        | subcategory (waste / naming / complexity / comments / ai_smell, optional, appended as category/subcategory) |
+| Field        | Value                                                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Prefix       | CQ                                                                                                                                |
+| Categories   | structure / readability                                                                                                           |
+| Severity     | high / medium / low                                                                                                               |
+| Disposition  | Reviewer-settable override of the default, with a disposition_reason. See `~/.claude/agents/_lib/finding-schema.md` § Disposition |
+| Verification | pattern_search or hotpath_analysis. Is this pattern widespread or in a critical path?                                             |
+| Extra        | subcategory (waste / naming / complexity / comments / ai_smell, optional, appended as category/subcategory)                       |
 
 ```markdown
 ## Summary

--- a/agents/reviewers/reviewer-reuse.md
+++ b/agents/reviewers/reviewer-reuse.md
@@ -54,12 +54,13 @@ See `~/.claude/agents/_lib/calibration-examples.md` section REUSE.
 
 Follow ~/.claude/agents/\_lib/finding-schema.md. When no code is found, report "No code to review". Common guards (glob empty, tool error) follow ~/.claude/agents/\_lib/finding-schema.md defaults. Evidence pairs new code and existing utility as `New: file:line snippet / Existing: file:line snippet`. stdlib/native categories have no repo-side pair, so replace `Existing:` with the API/feature name (e.g. `Use: Intl.DateTimeFormat`, `Use: <input type="date">`).
 
-| Field        | Value                                                                       |
-| ------------ | --------------------------------------------------------------------------- |
-| Prefix       | REUSE                                                                       |
-| Categories   | utility / pattern / inline / unused_import / stdlib / native                |
-| Severity     | high / medium / low                                                         |
-| Verification | pattern_search. Does the existing utility cover all edge cases of new code? |
+| Field        | Value                                                                                                                             |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Prefix       | REUSE                                                                                                                             |
+| Categories   | utility / pattern / inline / unused_import / stdlib / native                                                                      |
+| Severity     | high / medium / low                                                                                                               |
+| Disposition  | Reviewer-settable override of the default, with a disposition_reason. See `~/.claude/agents/_lib/finding-schema.md` § Disposition |
+| Verification | pattern_search. Does the existing utility cover all edge cases of new code?                                                       |
 
 ```markdown
 ## Summary

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -887,9 +887,12 @@ const integrated = await agent(
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
 // toCriticRef strips disposition before Integrate ever sees a finding, so whatever disposition
 // Integrate returns is not sourced from the survivors and is not trusted here. The script
-// re-derives it from source_ids instead: the total order (must > want > imo > nits) is defined
-// in agents/_lib/finding-schema.md § Disposition and not restated here.
-const DISPOSITION_RANK = { must: 4, want: 3, imo: 2, nits: 1 };
+// re-derives it from source_ids instead: the strength order (must > want > imo > nits, matching
+// agents/_lib/finding-schema.md § Disposition) has one source, DECLARABLE_DISPOSITIONS's
+// ordering, rather than a second hand-written copy here.
+const DISPOSITION_RANK = Object.fromEntries(
+  [...DECLARABLE_DISPOSITIONS].map((d, i) => [d, DECLARABLE_DISPOSITIONS.size - i]),
+);
 const dispositionById = new Map(rawFindings.map((f) => [f.id, f.disposition]));
 const consolidatedDisposition = (sourceIds) =>
   (Array.isArray(sourceIds) ? sourceIds : []).reduce((strongest, id) => {

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -885,11 +885,9 @@ const integrated = await agent(
 // Falling back to the pre-triage findings array would land on the state before ids were
 // assigned, silently readmitting findings the challenge pass had disputed.
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// toCriticRef strips disposition before Integrate ever sees a finding, so whatever disposition
-// Integrate returns is not sourced from the survivors and is not trusted here. The script
-// re-derives it from source_ids instead: the strength order (must > want > imo > nits, matching
-// agents/_lib/finding-schema.md § Disposition) has one source, DECLARABLE_DISPOSITIONS's
-// ordering, rather than a second hand-written copy here.
+// toCriticRef strips disposition before Integrate sees a finding, so what Integrate returns is
+// not sourced from the survivors and is not trusted. The rank derives from
+// DECLARABLE_DISPOSITIONS rather than restating the order agents/_lib/finding-schema.md owns.
 const DISPOSITION_RANK = Object.fromEntries(
   [...DECLARABLE_DISPOSITIONS].map((d, i) => [d, DECLARABLE_DISPOSITIONS.size - i]),
 );

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -885,10 +885,22 @@ const integrated = await agent(
 // Falling back to the pre-triage findings array would land on the state before ids were
 // assigned, silently readmitting findings the challenge pass had disputed.
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// Integrate reads a projection carrying no disposition, so the default is applied again here.
-const finalFindings = integratedFindings.map((f) =>
-  f.disposition ? f : { ...f, disposition: DEFAULT_DISPOSITION },
-);
+// toCriticRef strips disposition before Integrate ever sees a finding, so whatever disposition
+// Integrate returns is not sourced from the survivors and is not trusted here. The script
+// re-derives it from source_ids instead: the total order (must > want > imo > nits) is defined
+// in agents/_lib/finding-schema.md § Disposition and not restated here.
+const DISPOSITION_RANK = { must: 4, want: 3, imo: 2, nits: 1 };
+const dispositionById = new Map(rawFindings.map((f) => [f.id, f.disposition]));
+const consolidatedDisposition = (sourceIds) =>
+  (Array.isArray(sourceIds) ? sourceIds : []).reduce((strongest, id) => {
+    const d = dispositionById.get(id);
+    if (!d) return strongest;
+    return !strongest || DISPOSITION_RANK[d] > DISPOSITION_RANK[strongest] ? d : strongest;
+  }, null) || DEFAULT_DISPOSITION;
+const finalFindings = integratedFindings.map((f) => ({
+  ...f,
+  disposition: consolidatedDisposition(f.source_ids),
+}));
 const snapshot = await writeSnapshot({
   preFlight,
   rawFindings,

--- a/workflows/audit/tests/audit.integrate.test.js
+++ b/workflows/audit/tests/audit.integrate.test.js
@@ -142,10 +142,8 @@ test("T-011 ends with as many findings as survivors when Integrate returns every
   }
 });
 
-// toCriticRef strips disposition before Integrate ever sees a finding (agents/_lib/finding-schema.md
-// § Disposition Consolidation: the script, not the agent, owns the merged value). Each case below
-// has Integrate return a disposition the script must not trust, so a pass that merely keeps
-// whatever Integrate said would fail here even though it happens to output "must" by default.
+// Each case has Integrate return a disposition the script must not trust, so an implementation
+// that kept whatever Integrate said would fail here rather than pass by coincidence.
 test("T-024 imo と must を統合した finding の disposition が must になる", async () => {
   const { result } = await run({
     security: {
@@ -172,8 +170,7 @@ test("T-024 imo と must を統合した finding の disposition が must にな
           severity: "high",
           summary: "root cause absorbing both findings",
           source_ids: ["R-1", "R-2"],
-          // Deliberately not the expected value: Integrate's own projection carries no
-          // disposition, so nothing it returns here should survive into the result.
+          // Deliberately not the expected value: nothing Integrate returns should survive.
           disposition: "nits",
         },
       ],
@@ -213,5 +210,41 @@ test("T-025 統合元が全て既定値のままなら統合後の disposition �
     result.findings[0].disposition,
     "must",
     "neither R-1 nor R-2 declared an override, so both stayed at the default must and the consolidated value is must, not the want Integrate returned",
+  );
+});
+
+// T-024 and T-025 both expect the default, so a consolidation hardcoded to must would pass
+// both. This is the case the Outcome names: two declared values merging, where the winner is
+// the stronger declared one rather than the default.
+test("T-026 want と imo を統合した finding の disposition が want になる", async () => {
+  const declared = (summary, disposition) => ({
+    file: "sample.js",
+    line: "1",
+    severity: "high",
+    summary,
+    disposition,
+    disposition_reason: "author preference",
+  });
+  const { result } = await run({
+    security: { findings: [declared("security finding", "imo")] },
+    silence: { findings: [declared("silence finding", "want")] },
+    challenge: BOTH_CONFIRMED,
+    integrate: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "root cause absorbing both findings",
+          source_ids: ["R-1", "R-2"],
+          disposition: "nits",
+        },
+      ],
+    },
+  });
+  assert.equal(
+    result.findings[0].disposition,
+    "want",
+    "want outranks imo, so neither the weaker source nor the default decides the merged value",
   );
 });

--- a/workflows/audit/tests/audit.integrate.test.js
+++ b/workflows/audit/tests/audit.integrate.test.js
@@ -141,3 +141,77 @@ test("T-011 ends with as many findings as survivors when Integrate returns every
     );
   }
 });
+
+// toCriticRef strips disposition before Integrate ever sees a finding (agents/_lib/finding-schema.md
+// § Disposition Consolidation: the script, not the agent, owns the merged value). Each case below
+// has Integrate return a disposition the script must not trust, so a pass that merely keeps
+// whatever Integrate said would fail here even though it happens to output "must" by default.
+test("T-024 imo と must を統合した finding の disposition が must になる", async () => {
+  const { result } = await run({
+    security: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+    },
+    silence: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "silence finding",
+          disposition: "imo",
+          disposition_reason: "author preference",
+        },
+      ],
+    },
+    challenge: BOTH_CONFIRMED,
+    integrate: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "root cause absorbing both findings",
+          source_ids: ["R-1", "R-2"],
+          // Deliberately not the expected value: Integrate's own projection carries no
+          // disposition, so nothing it returns here should survive into the result.
+          disposition: "nits",
+        },
+      ],
+    },
+  });
+  assert.equal(
+    result.findings[0].disposition,
+    "must",
+    "R-1 stayed at the default must and R-2 declared imo, so the consolidated value is the stronger of the two (must > imo), not the nits Integrate returned",
+  );
+});
+
+test("T-025 統合元が全て既定値のままなら統合後の disposition も must になる", async () => {
+  const { result } = await run({
+    security: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+    },
+    silence: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+    },
+    challenge: BOTH_CONFIRMED,
+    integrate: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "root cause absorbing both findings",
+          source_ids: ["R-1", "R-2"],
+          // Same deliberate mismatch as T-024, here against sources that both stayed default.
+          disposition: "want",
+        },
+      ],
+    },
+  });
+  assert.equal(
+    result.findings[0].disposition,
+    "must",
+    "neither R-1 nor R-2 declared an override, so both stayed at the default must and the consolidated value is must, not the want Integrate returned",
+  );
+});

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -164,11 +164,8 @@ test("T-022 a run where no reviewer declares a disposition returns every finding
   );
 });
 
-// Companion to T-022: there the source stays at the default and the default must ride
-// through. Here one source declares a valid override (want, with disposition_reason), and
-// Integrate returns it unmerged (its own source_ids holds only that one id), so nothing
-// forces a stronger sibling to win. This is the plan's seam claim: a reviewer's disposition
-// survives triage and the real Integrate call all the way to the returned finding.
+// Companion to T-022, which rides the default through. Here the source declares an override.
+// Its source_ids holds one id, so no sibling competes; T-026 covers the merge itself.
 test("T-023 reviewer が上書きした disposition が Integrate 後の返り値にも残る", async () => {
   const { result, record } = await run([{ path: "sample.js", churn: 0 }], {
     security: {

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -164,6 +164,67 @@ test("T-022 a run where no reviewer declares a disposition returns every finding
   );
 });
 
+// Companion to T-022: there the source stays at the default and the default must ride
+// through. Here one source declares a valid override (want, with disposition_reason), and
+// Integrate returns it unmerged (its own source_ids holds only that one id), so nothing
+// forces a stronger sibling to win. This is the plan's seam claim: a reviewer's disposition
+// survives triage and the real Integrate call all the way to the returned finding.
+test("T-023 reviewer が上書きした disposition が Integrate 後の返り値にも残る", async () => {
+  const { result, record } = await run([{ path: "sample.js", churn: 0 }], {
+    security: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "security finding" }],
+    },
+    silence: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "2",
+          severity: "high",
+          summary: "silence finding",
+          disposition: "want",
+          disposition_reason: "author preference",
+        },
+      ],
+    },
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    integrate: {
+      findings: [
+        {
+          file: "sample.js",
+          line: "1",
+          severity: "high",
+          summary: "security finding",
+          source_ids: ["R-1"],
+        },
+        {
+          file: "sample.js",
+          line: "2",
+          severity: "high",
+          summary: "silence finding",
+          source_ids: ["R-2"],
+        },
+      ],
+    },
+  });
+  const overridden = result.findings.find((f) => (f.source_ids || []).includes("R-2"));
+  assert.ok(overridden, "the R-2 finding (silence, disposition want) rides the returned findings");
+  assert.equal(
+    overridden.disposition,
+    "want",
+    "reviewer が申告した want が、triage と実物の Integrate 呼び出しを経た返り値でも既定の must に落ちずに残る",
+  );
+  assert.equal(
+    record.raw_findings.find((f) => f.id === "R-2").disposition,
+    "want",
+    "同じ上書きが、実物の snapshot.py が書き出した record の raw_findings にも残る",
+  );
+});
+
 // T-001 in the degradation file stops at reading the prompt. This carries the same finding to
 // the real snapshot.py and checks the count in the record on disk does not shrink. An attacker
 // does not know the nonce, so the only forgeable thing is a fixed string carrying none.


### PR DESCRIPTION
## What & Why

これまで audit の 3 本の reviewer (reviewer-design / reviewer-readability / reviewer-reuse) は disposition (must/want/imo/nits) を宣言する手段を持たず、finding は一律 `must` として扱われていた。本 PR で reviewer が理由付きで disposition を申告できるようにし、複数 finding を統合した後もその申告のうち最も強い値が返り値に残るようにする。

## Review focus

- `workflows/audit.js` の `dispositionOf` (宣言の検証: 未宣言 / 未知の値 / reason 欠落はすべて `must` に丸める) と `consolidatedDisposition` (Integrate 後の再算出) の対応関係
- `workflows/audit/tests/audit.seam.test.js` T-023 は実物の audit.js 本体を実行して申告値が最終的な返り値まで残ることを検証している。integrate stub の `source_ids` の作り方を見ておくと通りやすい

## Changes

- reviewer-design / reviewer-readability / reviewer-reuse の出力テーブルに Disposition 行を追加し、`disposition` + `disposition_reason` を宣言できるようにした
- `workflows/audit.js` に `dispositionOf` を追加し、宣言が `DECLARABLE_DISPOSITIONS` に含まれず理由も伴わない場合はデフォルト (`must`) に丸める。理由なしの上書きは検証されない好みに過ぎないため、通さない
- Integrate は finding から disposition を剥がした射影しか見ないため、Integrate が返す disposition は信用せず、`consolidatedDisposition` が `source_ids` から `rawFindings` の申告値を逆引きして統合後の最強値を再算出する

## Design Decisions

- 強さの全順序 (must > want > imo > nits) をハードコードの数値テーブルとして持つ代わりに、宣言可能な値の集合 `DECLARABLE_DISPOSITIONS` (Set の挿入順) から `DISPOSITION_RANK` を導出する形にした。順序の情報源を 1 か所 (`DECLARABLE_DISPOSITIONS` の並び) に絞り、`agents/_lib/finding-schema.md` § Disposition との整合をコード側とコメント側で二重に手書きしない
- デフォルト disposition (`must`) は severity から導出せず定数として固定した。assert の gate は severity を見ないため、severity から導出すると本来 blocking であるべき finding に nits が付きかねない


---

_下は build workflow の自動検証結果。plan との突合までで、コードの欠陥を探すレビューはしていない。PR の本筋からは外れるので任意だが、status 行の逸脱件数が非ゼロなら見る。_

Closes #417

<details>
<summary><code>verify tests=pass gates=pass</code> · <code>scope-deviations 0</code> · <code>missing-tests 0</code> · <code>untouched-plan-files 1</code> · <code>conformance 2</code></summary>

**一度も変更されていない plan の files**
- `workflows/audit/tests/_fixtures.js`

**Issue 適合性 (独立レビュー)**
- `[low] wrong` コード自体は DECLARABLE_DISPOSITIONS から DISPOSITION_RANK を導出しており、二つ目のテーブルを持たないため、この制約は守られている。しかし追加されたコメントは強さの順序を散文で書き出している。引用は次の通り: "the strength order (must > want > imo > nits, matching agents/_lib/finding-schema.md § Disposition)"。これは契約が禁じる同一の言い換えであり、スキーマの順序が将来変更された場合にサイレントにドリフトする。
  `workflows/audit.js:888-892 and .ja/workflows/audit.js (mirrored comment)` · spec: 全順序は `agents/_lib/finding-schema.md` § Disposition の Consolidation 行に定義済みなので再掲しない (U-004 contract)
- `[medium] missing` 新規テスト3件のいずれも、勝者が宣言された(非デフォルトの)値となる複数ソースのマージを検証していない。T-024 は default+imo をマージして must を期待し、T-025 は二つの default をマージして must を期待する。T-023 自身のコメントも、その source_ids が単一の id しか持たないため("so nothing forces a stronger sibling to win")、より強い sibling が勝つ状況を強制しないと認めている。Outcome/Testing-Decisions のテキストが挙げるシナリオ(例: want+imo が want にマージされる)は一度も実行されていない。ただしこれは列挙された3件の Acceptance Criteria の範囲外であり、それが high ではなく medium である理由である。
  `workflows/audit/tests/audit.integrate.test.js T-024/T-025, workflows/audit/tests/audit.seam.test.js T-023` · spec: Outcome: 複数 finding を統合した後もその申告のうち最も強い値が返り値に残る / Testing Decisions: reviewer が申告した値が、統合を経ても弱い側に丸められずに返り値まで届くこと

**異常 (Red 未確認)**
- U-005 (no-red): T-023 の対象行動 (reviewer が上書きした disposition が triage と実物の Integrate 呼び出しを経て返り値にも残る) は workflows/audit.js の dispositionOf (行659-668) と consolidatedDisposition (行892-899) により既に実装済みで、追加実装なしにテストが green で通る。
  <details><summary>根拠 6 件</summary>

  - node --test workflows/audit/tests/audit.integrate.test.js workflows/audit/tests/audit.seam.test.js の実行結果: tests 21, pass 21, fail 0 (T-023 含む)
  - workflows/audit/tests/audit.seam.test.js T-023 (silence findings に disposition: "want", disposition_reason: "author preference" を持たせ、integrate stub が source_ids: ["R-2"] を単独で返す) が result.findings と record.raw_findings 双方で disposition === "want" を具体値で assert しており、空アサーションではない
  - workflows/audit.js:659-668 dispositionOf が f.disposition / f.disposition_reason (reviewer 申告) を検証し rawFindings に反映する
  - workflows/audit.js:892-899 consolidatedDisposition が source_ids から dispositionById 経由で最強値を導出し、Integrate の返り値には依存しない設計 (コメント: toCriticRef strips disposition before Integrate ever sees a finding)
  - workflows/audit.js:902 disposition: consolidatedDisposition(f.source_ids) が finalFindings 生成時に適用され、そのまま return される
  - workflows/audit/tests/audit.seam.test.js の run() は runWorkflow(auditJs, ...) で agent 応答のみ stub し、実物の audit.js 本体および実物の workflows/audit/snapshot.py (python3 subprocess) を実行している

  </details>

</details>
