### PR TITLE
[Feature] audit の返り値に ask と info のチャネルを足す

### DIFF
--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -123,7 +123,7 @@ const writeSnapshot = async ({
   challengeRan,
   verifyRan,
   tally,
-  needsContext,
+  ask,
   zeroReviewerFiles,
 }) => {
   phase("Snapshot");
@@ -139,8 +139,9 @@ const writeSnapshot = async ({
     verify_ran: verifyRan,
     tally,
     // 同じ finding は raw_findings 側に verdict つきで載る。ここは raw_findings から
-    // 導けない why だけの側表にする。
-    needs_context: needsContext && needsContext.map(({ id, why }) => ({ id, why })),
+    // 導けない why だけの側表にする。ask は既にこの {id, why} の形なので、needsContext から
+    // 作り直さずそのまま使う。
+    needs_context: ask,
     zero_reviewer_files: zeroReviewerFiles,
   });
   const written = await agent(
@@ -170,7 +171,7 @@ const writeSnapshot = async ({
     raw_findings: rawFindings.length,
     findings: findings.length,
     skipped: skipped.length,
-    needs_context: needsContext ? needsContext.length : 0,
+    needs_context: ask ? ask.length : 0,
     zero_reviewer_files: zeroReviewerFiles ? zeroReviewerFiles.length : 0,
   };
   if (!written) {
@@ -913,7 +914,7 @@ const snapshot = await writeSnapshot({
   // fail-open した run は degraded 印だけを残し件数を書かない、が plan の contract。
   // undefined を渡すと JSON.stringify がキーごと落とす。
   tally: challengeRan ? tally : undefined,
-  needsContext,
+  ask,
   zeroReviewerFiles,
 });
 return {

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -139,8 +139,7 @@ const writeSnapshot = async ({
     verify_ran: verifyRan,
     tally,
     // 同じ finding は raw_findings 側に verdict つきで載る。ここは raw_findings から
-    // 導けない why だけの側表にする。ask は既にこの {id, why} の形なので、needsContext から
-    // 作り直さずそのまま使う。
+    // 導けない why だけの側表にする。
     needs_context: ask,
     zero_reviewer_files: zeroReviewerFiles,
   });
@@ -802,9 +801,8 @@ const [challenged, verified] = await parallel([
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
-// info は id だけを持つ。report を読む人間に渡すのは件数とどの finding かまでで、
-// finding の全文ではない。downgraded の finding は survivors に残ったままなので
-// (severity を下げるのは除外ではない)、こちらにも同じ理由で id だけを記録する。
+// id だけを持つ。判定済みの finding の全文は、生きている指摘と同じ紙幅を report で占める。
+// downgraded は survivors に残るが、id はここにも記録する。
 const disputedIds = [];
 const downgradedIds = [];
 let noVerdict = 0;
@@ -837,9 +835,7 @@ for (const f of rawFindings) {
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
-// needsContext は既に why を持つ (上の分岐で書く)。ask はそれをそのまま使い、raw finding から
-// why を再導出しない。ask セクションと返り値の needs_context が、同じ id に対して
-// 別々の why を語ることがなくなる。
+// needsContext が既に持つ why をそのまま使うので、ask と needs_context が食い違わない。
 const ask = needsContext.map(({ id, why }) => ({ id, why }));
 const info = {
   disputed: { count: disputedIds.length, ids: disputedIds },

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -801,6 +801,11 @@ const [challenged, verified] = await parallel([
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
+// info は id だけを持つ。report を読む人間に渡すのは件数とどの finding かまでで、
+// finding の全文ではない。downgraded の finding は survivors に残ったままなので
+// (severity を下げるのは除外ではない)、こちらにも同じ理由で id だけを記録する。
+const disputedIds = [];
+const downgradedIds = [];
 let noVerdict = 0;
 for (const f of rawFindings) {
   const v = verdictById.get(f.id);
@@ -812,7 +817,10 @@ for (const f of rawFindings) {
     survivors.push({ ...f });
     continue;
   }
-  if (v.verdict === "disputed") continue;
+  if (v.verdict === "disputed") {
+    disputedIds.push(f.id);
+    continue;
+  }
   if (v.verdict === "needs_context") {
     needsContext.push({ ...f, why: v.why || "" });
     continue;
@@ -822,11 +830,20 @@ for (const f of rawFindings) {
   // 「reviewer が severity を過大に付けるか」を測れなくなる。survivors は下げ後だけを持ち、
   // Integrate が merge した後は finding 単位で追えない。
   if (severity !== f.severity) f.downgraded_to = severity;
+  if (v.verdict === "downgraded") downgradedIds.push(f.id);
   survivors.push({ ...f, severity });
 }
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
+// needsContext は既に why を持つ (上の分岐で書く)。ask はそれをそのまま使い、raw finding から
+// why を再導出しない。ask セクションと返り値の needs_context が、同じ id に対して
+// 別々の why を語ることがなくなる。
+const ask = needsContext.map(({ id, why }) => ({ id, why }));
+const info = {
+  disputed: { count: disputedIds.length, ids: disputedIds },
+  downgraded: { count: downgradedIds.length, ids: downgradedIds },
+};
 // challenge_ran は「verdicts を返した run」と fail-open した run (verdictById が空になり、
 // 全 finding が no_verdict 経由で confirmed に落ちる) を区別する。verify は自由記述の
 // テキストを返すため、schema の形ではなく中身の有無で判定する。
@@ -904,6 +921,8 @@ return {
   findings: finalFindings,
   survivors,
   needs_context: needsContext,
+  ask,
+  info,
   challenge_ran: challengeRan,
   verify_ran: verifyRan,
   tally,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -145,8 +145,7 @@ const writeSnapshot = async ({
     verify_ran: verifyRan,
     tally,
     // The same findings already appear in raw_findings carrying their verdict. This side
-    // table holds only why, which raw_findings cannot supply. ask is already this {id, why}
-    // shape, so the payload takes it as is instead of re-deriving it from needsContext.
+    // table holds only why, which raw_findings cannot supply.
     needs_context: ask,
     zero_reviewer_files: zeroReviewerFiles,
   });
@@ -816,9 +815,8 @@ const [challenged, verified] = await parallel([
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
-// info stays id-only: a report reader gets the count and which finding, not the finding's
-// full text. downgraded's id is recorded here for the same reason, even though the finding
-// itself stays in survivors (a lowered severity is not a removal).
+// id-only: a judged finding's full text would take report space alongside live ones. A
+// downgraded id is recorded here even though the finding stays in survivors.
 const disputedIds = [];
 const downgradedIds = [];
 let noVerdict = 0;
@@ -852,9 +850,7 @@ for (const f of rawFindings) {
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
-// needsContext already carries why (the ternary above); ask reuses it rather than
-// re-deriving why from the raw finding, so the report's ask section and the return value's
-// needs_context can never state a different why for the same id.
+// Reusing the why needsContext already holds, so ask and needs_context cannot disagree.
 const ask = needsContext.map(({ id, why }) => ({ id, why }));
 const info = {
   disputed: { count: disputedIds.length, ids: disputedIds },

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -815,6 +815,11 @@ const [challenged, verified] = await parallel([
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
+// info stays id-only: a report reader gets the count and which finding, not the finding's
+// full text. downgraded's id is recorded here for the same reason, even though the finding
+// itself stays in survivors (a lowered severity is not a removal).
+const disputedIds = [];
+const downgradedIds = [];
 let noVerdict = 0;
 for (const f of rawFindings) {
   const v = verdictById.get(f.id);
@@ -826,7 +831,10 @@ for (const f of rawFindings) {
     survivors.push({ ...f });
     continue;
   }
-  if (v.verdict === "disputed") continue;
+  if (v.verdict === "disputed") {
+    disputedIds.push(f.id);
+    continue;
+  }
   if (v.verdict === "needs_context") {
     needsContext.push({ ...f, why: v.why || "" });
     continue;
@@ -837,11 +845,20 @@ for (const f of rawFindings) {
   // survivors carry only the lowered value, and after Integrate merges there is no
   // per-finding severity left to read.
   if (severity !== f.severity) f.downgraded_to = severity;
+  if (v.verdict === "downgraded") downgradedIds.push(f.id);
   survivors.push({ ...f, severity });
 }
 log(
   `triage: ${survivors.length} survived / ${needsContext.length} needs_context / no_verdict: ${noVerdict} (of ${rawFindings.length} total)`,
 );
+// needsContext already carries why (the ternary above); ask reuses it rather than
+// re-deriving why from the raw finding, so the report's ask section and the return value's
+// needs_context can never state a different why for the same id.
+const ask = needsContext.map(({ id, why }) => ({ id, why }));
+const info = {
+  disputed: { count: disputedIds.length, ids: disputedIds },
+  downgraded: { count: downgradedIds.length, ids: downgradedIds },
+};
 // challenge_ran separates a run that returned verdicts from the fail-open path (an empty
 // verdictById drops every finding to confirmed via no_verdict). verify returns free-form
 // text, so it is judged by whether content came back rather than by a schema shape.
@@ -920,6 +937,8 @@ return {
   findings: finalFindings,
   survivors,
   needs_context: needsContext,
+  ask,
+  info,
   challenge_ran: challengeRan,
   verify_ran: verifyRan,
   tally,

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -129,7 +129,7 @@ const writeSnapshot = async ({
   challengeRan,
   verifyRan,
   tally,
-  needsContext,
+  ask,
   zeroReviewerFiles,
 }) => {
   phase("Snapshot");
@@ -145,8 +145,9 @@ const writeSnapshot = async ({
     verify_ran: verifyRan,
     tally,
     // The same findings already appear in raw_findings carrying their verdict. This side
-    // table holds only why, which raw_findings cannot supply.
-    needs_context: needsContext && needsContext.map(({ id, why }) => ({ id, why })),
+    // table holds only why, which raw_findings cannot supply. ask is already this {id, why}
+    // shape, so the payload takes it as is instead of re-deriving it from needsContext.
+    needs_context: ask,
     zero_reviewer_files: zeroReviewerFiles,
   });
   const written = await agent(
@@ -178,7 +179,7 @@ const writeSnapshot = async ({
     raw_findings: rawFindings.length,
     findings: findings.length,
     skipped: skipped.length,
-    needs_context: needsContext ? needsContext.length : 0,
+    needs_context: ask ? ask.length : 0,
     zero_reviewer_files: zeroReviewerFiles ? zeroReviewerFiles.length : 0,
   };
   if (!written) {
@@ -929,7 +930,7 @@ const snapshot = await writeSnapshot({
   // The plan's contract: a fail-open run keeps the degraded mark and writes no counts.
   // Passing undefined makes JSON.stringify drop the key.
   tally: challengeRan ? tally : undefined,
-  needsContext,
+  ask,
   zeroReviewerFiles,
 });
 return {

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -160,9 +160,8 @@ test("T-004 leaves the reviewer name out of the input handed to the critic", asy
   assert.doesNotMatch(call.prompt, /"reviewer"/, "the critic input carries no reviewer name");
 });
 
-// needsContext already carries why (line 831's `{ ...f, why: v.why || "" }`); the ask section
-// reuses that value as is rather than re-deriving why from the raw finding.
-test("T-009 needs_context の finding が ask セクションに why 付きで返る", async () => {
+// ask reuses the why needsContext already carries, so the two can never disagree for one id.
+test("T-009 a needs_context finding returns in the ask section carrying its why", async () => {
   const { result } = await runChallenge({
     verdicts: [
       { id: "R-1", verdict: "confirmed" },
@@ -180,10 +179,9 @@ test("T-009 needs_context の finding が ask セクションに why 付きで�
   );
 });
 
-// The triage loop already drops a disputed id from survivors (T-001); info records that same
-// id and a count without the finding's summary/file/line, so a disputed finding's full text
-// never reaches the report.
-test("T-010 disputed の finding は全文を返さず件数と id だけが返る", async () => {
+// A disputed finding is a judged false positive, so its full text would take report space
+// alongside live findings. info records the id and the count instead.
+test("T-010 a disputed finding returns as a count and an id, never its full text", async () => {
   const { result } = await runChallenge({
     verdicts: [
       { id: "R-1", verdict: "disputed" },
@@ -198,5 +196,25 @@ test("T-010 disputed の finding は全文を返さず件数と id だけが返�
   assert.ok(
     !JSON.stringify(result.info).includes("security finding"),
     "the disputed finding's summary text does not leak into info",
+  );
+});
+
+// A downgraded finding stays in survivors at the lowered severity, so info naming it is not a
+// removal. Recording the id is what lets a reader see which finding the challenge re-scored.
+test("T-011 a downgraded finding is named in info while staying a survivor", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "downgraded", severity: "low" },
+      { id: "R-2", verdict: "confirmed" },
+    ],
+  });
+  assert.deepEqual(
+    result.info.downgraded,
+    { count: 1, ids: ["R-1"] },
+    "info.downgraded carries only the count and id of the re-scored finding",
+  );
+  assert.ok(
+    result.survivors.some((s) => s.id === "R-1"),
+    "the re-scored finding is still a survivor: a lowered severity is not a removal",
   );
 });

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -160,7 +160,6 @@ test("T-004 leaves the reviewer name out of the input handed to the critic", asy
   assert.doesNotMatch(call.prompt, /"reviewer"/, "the critic input carries no reviewer name");
 });
 
-// ask reuses the why needsContext already carries, so the two can never disagree for one id.
 test("T-009 a needs_context finding returns in the ask section carrying its why", async () => {
   const { result } = await runChallenge({
     verdicts: [
@@ -179,8 +178,6 @@ test("T-009 a needs_context finding returns in the ask section carrying its why"
   );
 });
 
-// A disputed finding is a judged false positive, so its full text would take report space
-// alongside live findings. info records the id and the count instead.
 test("T-010 a disputed finding returns as a count and an id, never its full text", async () => {
   const { result } = await runChallenge({
     verdicts: [
@@ -199,8 +196,7 @@ test("T-010 a disputed finding returns as a count and an id, never its full text
   );
 });
 
-// A downgraded finding stays in survivors at the lowered severity, so info naming it is not a
-// removal. Recording the id is what lets a reader see which finding the challenge re-scored.
+// info naming a finding is not a removal, which is why this asserts both sides.
 test("T-011 a downgraded finding is named in info while staying a survivor", async () => {
   const { result } = await runChallenge({
     verdicts: [

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -159,3 +159,44 @@ test("T-004 leaves the reviewer name out of the input handed to the critic", asy
   assert.match(call.prompt, /"id":"R-1"/, "the critic input carries the rawFindings id (R-N)");
   assert.doesNotMatch(call.prompt, /"reviewer"/, "the critic input carries no reviewer name");
 });
+
+// needsContext already carries why (line 831's `{ ...f, why: v.why || "" }`); the ask section
+// reuses that value as is rather than re-deriving why from the raw finding.
+test("T-009 needs_context の finding が ask セクションに why 付きで返る", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "confirmed" },
+      {
+        id: "R-2",
+        verdict: "needs_context",
+        why: "severity depends on whether this endpoint is internal-only",
+      },
+    ],
+  });
+  assert.deepEqual(
+    result.ask.map((a) => ({ id: a.id, why: a.why })),
+    [{ id: "R-2", why: "severity depends on whether this endpoint is internal-only" }],
+    "the ask section carries the needs_context finding's id and why",
+  );
+});
+
+// The triage loop already drops a disputed id from survivors (T-001); info records that same
+// id and a count without the finding's summary/file/line, so a disputed finding's full text
+// never reaches the report.
+test("T-010 disputed の finding は全文を返さず件数と id だけが返る", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "disputed" },
+      { id: "R-2", verdict: "confirmed" },
+    ],
+  });
+  assert.deepEqual(
+    result.info.disputed,
+    { count: 1, ids: ["R-1"] },
+    "info.disputed carries only the count and id of the disputed finding",
+  );
+  assert.ok(
+    !JSON.stringify(result.info).includes("security finding"),
+    "the disputed finding's summary text does not leak into info",
+  );
+});


### PR DESCRIPTION
## What & Why

audit の返り値が ask と info を別チャネルとして持ち、人間に判断を仰ぐ finding と処理済みの finding を read 側が区別できる。

これまで needs_context の finding は `needs_context` として返るものの survivors と同じ平面に並び、disputed と downgraded は `tally` の件数にしか現れず、どの finding がどう扱われたのか追えなかった。ask には needs_context の finding を why 付きでそのまま載せ、info には disputed と downgraded の件数と id だけを載せる。

## Review focus

- `workflows/audit.js` の triage ループ (disputedIds/downgradedIds の集計と ask/info の組み立て) を重点的に見てほしい
- `writeSnapshot` のパラメータ名を `needsContext` から `ask` に変えた箇所は、snapshot ペイロードの `needs_context` キー名と中身が変わっていないことの確認で足りる
- disposition の値そのものは gate の入力にしておらず、triage の生存判定 (survivors) は変えていない

## Design Decisions

- `ask` は `needsContext` から `{ id, why }` を再導出せず、needsContext が既に持つ配列をそのまま使う。raw finding から why を作り直す経路を残すと、ask セクションと返り値の `needs_context` が同じ id に対して別々の why を語りうるため
- info は disputed/downgraded の finding の全文 (summary/file/line) を持たず、件数と id だけにする。disputed は false positive と判定済みの finding であり、全文を返すと否定された指摘が report 上で生きている指摘と同じ長さを占めるため

## How to Test

1. `node --test workflows/audit/tests/audit.triage.test.js` を実行する
2. T-009 (`ask` に needs_context の finding が why 付きで載る) と T-010 (`info.disputed` が件数と id だけを持ち、finding の summary を含まない) を含む全テストが pass する


---

_下は build workflow の自動検証結果。plan との突合までで、コードの欠陥を探すレビューはしていない。PR の本筋からは外れるので任意だが、status 行の逸脱件数が非ゼロなら見る。_

Closes #418

<details>
<summary><code>verify tests=pass gates=pass</code> · <code>scope-deviations 0</code> · <code>missing-tests 0</code> · <code>conformance 1</code> · <code>structure 2</code></summary>

**Issue 適合性 (独立レビュー)**
- `[low] scope_creep` 未コミットの hunk は writeSnapshot の分割代入パラメータを needsContext から ask にリネームし、スナップショットのペイロードは needsContext から {id, why} を再導出せず ask を直接使うようになる。U-001 の契約が変更対象として名指すのは triage ループと戻り値のみだが、この hunk は Plan に記載のない writeSnapshot とスナップショットファイル間の内部データフローも書き換える。undefined・[]・要素ありの配列という 3 ケースで変更前後の出力が一致することを確認し、動作保存を検証済みである。したがって、これは機能的な逸脱ではなく、低重大度の境界超過にとどまる。
  `workflows/audit.js:129-150,182,933 (and .ja/workflows/audit.js mirror at the same relative lines)` · spec: ask と info の追加も返り値の読み方を変えるだけで、triage の生存判定は変えません

**参照モジュールからの構造逸脱**
- `[convention]` T-009 の test() 名は日本語(「needs_context の finding が ask セクションに why 付きで返る」)になっている。同じ英語側ファイル内のきょうだいテスト T-001 から T-008 は、いずれも英語名を使っている。同じブロック内のテスト自身のコメントとアサーションメッセージは英語のままである。そのため、このファイルの既存パターンを破っているのは test() 名だけである。
  `workflows/audit/tests/audit.triage.test.js:165` · ref: workflows/audit/tests/audit.triage.test.js:24 (T-001, e.g. "drops a finding from survivors when challenge returns disputed"); rules/conventions/MIRROR.md § Prose language ("Japanese under .ja/, English everywhere else. Covers comments, test names, and assertion messages")
- `[convention]` T-010 の test() 名は日本語(「disputed の finding は全文を返さず件数と id だけが返る」)になっている。同じ英語側ファイル内のきょうだいテスト T-001 から T-008 は、いずれも英語名を使っている。同じブロック内のテスト自身のコメントとアサーションメッセージは英語のままである。そのため、このファイルの既存パターンを破っているのは test() 名だけである。
  `workflows/audit/tests/audit.triage.test.js:186` · ref: workflows/audit/tests/audit.triage.test.js:24 (T-001, e.g. "drops a finding from survivors when challenge returns disputed"); rules/conventions/MIRROR.md § Prose language ("Japanese under .ja/, English everywhere else. Covers comments, test names, and assertion messages")

</details>
