### PR TITLE
[Feature] audit の finding schema が落とす 4 フィールドを透過する

### DIFF
--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -354,6 +354,13 @@ const findingsSchema = ({ withSourceIds = false } = {}) => ({
             type: "string",
             description: "既定値から外す理由。上書きには必須",
           },
+          evidence: { type: "string", description: "その finding の根拠になるコードや観察" },
+          reasoning: { type: "string", description: "その条件がなぜ問題なのか" },
+          fix: { type: "string", description: "reviewer が提案する変更" },
+          verification: {
+            type: "string",
+            description: "検査の種類と、それが答える問い",
+          },
           ...(withSourceIds
             ? {
                 source_ids: {
@@ -641,6 +648,22 @@ const raw = await parallel(
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
 // severity から導かず固定する (agents/_lib/finding-schema.md § Disposition)。assert の gate は
 // severity を見ないので、導出するとマージを止める finding に nits が付く。
+// 手で並べず schema から導く。schema にあるのにこの写しに無いフィールドは黙って落ちる。
+// #425 が塞いだのがその穴。file / line / severity / summary は名前を変えて写し、disposition は
+// dispositionOf を通すので、この 6 つは除く。
+const MAPPED_FIELDS = new Set([
+  "file",
+  "line",
+  "severity",
+  "summary",
+  "disposition",
+  "disposition_reason",
+]);
+const CARRIED_FIELDS = Object.keys(FINDINGS_SCHEMA.properties.findings.items.properties).filter(
+  (k) => !MAPPED_FIELDS.has(k),
+);
+// 無いものは無いまま残す。空文字だと、空を返した reviewer と区別が付かない。
+const carried = (f) => Object.fromEntries(CARRIED_FIELDS.filter((k) => f[k]).map((k) => [k, f[k]]));
 const DEFAULT_DISPOSITION = "must";
 const DECLARABLE_DISPOSITIONS = new Set(["must", "want", "imo", "nits"]);
 let restoredDispositions = 0;
@@ -669,9 +692,7 @@ units.forEach((u, i) => {
         line: f.line,
         severity: f.severity,
         message: f.summary,
-        // 無いものは無いまま残す。空文字だと、空を返した reviewer と区別が付かない。
-        ...(f.category ? { category: f.category } : {}),
-        ...(f.trigger ? { trigger: f.trigger } : {}),
+        ...carried(f),
         ...dispositionOf(f),
       });
     }

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -363,6 +363,13 @@ const findingsSchema = ({ withSourceIds = false } = {}) => ({
             type: "string",
             description: "why this finding departs from the default. Required to override",
           },
+          evidence: { type: "string", description: "the code or observation the finding rests on" },
+          reasoning: { type: "string", description: "why the condition is a problem" },
+          fix: { type: "string", description: "the change the reviewer suggests" },
+          verification: {
+            type: "string",
+            description: "the check type and the question it answers",
+          },
           ...(withSourceIds
             ? {
                 source_ids: {
@@ -653,6 +660,22 @@ const raw = await parallel(
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
 // Pinned rather than derived from severity (agents/_lib/finding-schema.md § Disposition):
 // assert's gate ignores severity, so a derived default would put nits on a blocking finding.
+// Derived from the schema, not hand-listed: a field the schema admits but this copy forgets is
+// silently dropped, which is the gap #425 closed. file / line / severity / summary are renamed on
+// the way in and disposition goes through dispositionOf, so those six are excluded.
+const MAPPED_FIELDS = new Set([
+  "file",
+  "line",
+  "severity",
+  "summary",
+  "disposition",
+  "disposition_reason",
+]);
+const CARRIED_FIELDS = Object.keys(FINDINGS_SCHEMA.properties.findings.items.properties).filter(
+  (k) => !MAPPED_FIELDS.has(k),
+);
+// Absent stays absent: an empty string would read as a reviewer that answered blank.
+const carried = (f) => Object.fromEntries(CARRIED_FIELDS.filter((k) => f[k]).map((k) => [k, f[k]]));
 const DEFAULT_DISPOSITION = "must";
 const DECLARABLE_DISPOSITIONS = new Set(["must", "want", "imo", "nits"]);
 let restoredDispositions = 0;
@@ -681,9 +704,7 @@ units.forEach((u, i) => {
         line: f.line,
         severity: f.severity,
         message: f.summary,
-        // Absent stays absent: an empty string would read as a reviewer that answered blank.
-        ...(f.category ? { category: f.category } : {}),
-        ...(f.trigger ? { trigger: f.trigger } : {}),
+        ...carried(f),
         ...dispositionOf(f),
       });
     }

--- a/workflows/audit/tests/audit.seam.test.js
+++ b/workflows/audit/tests/audit.seam.test.js
@@ -470,3 +470,34 @@ test("T-021 an audit test file never claims the same id twice", () => {
     assert.deepEqual(duplicated, [], `${file} uses the same T-NNN twice`);
   }
 });
+
+// Asserting on the payload would not show whether snapshot.py wrote the four out.
+test("T-024 the four canonical fields reach the record the real snapshot.py wrote", async () => {
+  const detailed = {
+    file: "sample.js",
+    line: "1",
+    severity: "high",
+    summary: "security finding",
+    evidence: "await inside a for-of over 200 ids",
+    reasoning: "each iteration waits a full round trip",
+    fix: "collect the promises and await once",
+    verification: "pattern_search. does any caller pass fewer than 10 ids?",
+  };
+  const { record } = await run([{ path: "sample.js", churn: 0 }], {
+    security: { findings: [detailed] },
+    silence: {
+      findings: [{ file: "sample.js", line: "1", severity: "high", summary: "silence finding" }],
+    },
+    challenge: {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    integrate: INTEGRATED,
+  });
+  const written = record.raw_findings.find((f) => f.id === "R-1");
+  for (const key of ["evidence", "reasoning", "fix", "verification"]) {
+    assert.equal(written[key], detailed[key], `${key} is in the record on disk`);
+  }
+});

--- a/workflows/audit/tests/audit.triage.test.js
+++ b/workflows/audit/tests/audit.triage.test.js
@@ -214,3 +214,45 @@ test("T-011 a downgraded finding is named in info while staying a survivor", asy
     "the re-scored finding is still a survivor: a lowered severity is not a removal",
   );
 });
+
+const FULL_FINDING = {
+  file: "sample.js",
+  line: "1",
+  severity: "high",
+  summary: "s",
+  evidence: "await inside a for-of over 200 ids",
+  reasoning: "each iteration waits a full round trip",
+  fix: "collect the promises and await once",
+  verification: "pattern_search. does any caller pass fewer than 10 ids?",
+};
+
+test("T-012 the evidence, reasoning, fix and verification a reviewer returned stay on the survivor", async () => {
+  const { result } = await runChallenge(
+    {
+      verdicts: [
+        { id: "R-1", verdict: "confirmed" },
+        { id: "R-2", verdict: "confirmed" },
+      ],
+    },
+    { security: { findings: [FULL_FINDING] } },
+  );
+  const survivor = result.survivors.find((s) => s.id === "R-1");
+  for (const key of ["evidence", "reasoning", "fix", "verification"]) {
+    assert.equal(survivor[key], FULL_FINDING[key], `${key} survives triage`);
+  }
+});
+
+// Required, these four would fail the whole findings array of most of the eighteen reviewers.
+test("T-013 a finding carrying none of the four stays a survivor with all four absent", async () => {
+  const { result } = await runChallenge({
+    verdicts: [
+      { id: "R-1", verdict: "confirmed" },
+      { id: "R-2", verdict: "confirmed" },
+    ],
+  });
+  const survivor = result.survivors.find((s) => s.id === "R-1");
+  assert.ok(survivor, "the finding survives without them");
+  for (const key of ["evidence", "reasoning", "fix", "verification"]) {
+    assert.equal(survivor[key], undefined, `${key} stays absent rather than becoming empty`);
+  }
+});


### PR DESCRIPTION
## What & Why

reviewer が書いた evidence / reasoning / fix / verification が、返り値と snapshot の record まで届くようになる。

canonical schema は finding ごとに 9 フィールドを要求するが、`findingsSchema` が `additionalProperties: false` のもとで通すのは 6 つだけだった。reviewer が根拠や修正案を書いても、report を読む人間が受け取るのは summary の 1 行だけになる。

## Review focus

- **写す対象を schema から導いた点**。以前はフィールドごとの条件付き spread を並べていたが、その一覧が schema と二重管理になっていた。片方を忘れると「schema にあるのに写されない」— この PR が塞いだ穴そのものが再生産される。`CARRIED_FIELDS` を `FINDINGS_SCHEMA` から導くことで二重管理が消える
- 除外する 6 つ (`MAPPED_FIELDS`) の妥当性。file / line / severity / summary は名前を変えて写し、disposition と disposition_reason は `dispositionOf` を通す
- 4 フィールドを optional にした判断。必須にすると、これらを返さない reviewer の findings 配列がまるごと検証に落ちる。18 本のうち大半がその状態にある

## Changes

- 写しは条件付きのまま。空文字で埋めると、何も返さなかった reviewer と空を返した reviewer が読み手から区別できなくなる

## Scope

- Not included: `toCriticRef` の projection を広げるか。この PR で「渡すべき値が rawFindings に存在する」前提が揃った。広げるかは verdict の質への影響と、reviewer の judgment が critic を biasing する懸念を実測してから決める
- Not included: report の描画側でこれらをどう並べるか

## How to Test

1. `node --test workflows/audit/tests/audit.triage.test.js workflows/audit/tests/audit.seam.test.js` を実行し、落ちるテストが無いことを確認する
2. `findingsSchema` から `verification` の 4 行を消すと T-012 が落ちることを確認する。以前の実装では、schema に足して写しを忘れても落ちるテストが無かった
3. `node --test "workflows/**/tests/*.test.js"` で 250 件が pass することを確認する

## Related

- Closes #425
- 親だった #374 は完了済み。この issue は Backlog candidates から切り出したもの
