### PR TITLE
テスト名の言語検出が拾う登録形式を広げる

### DIFF
--- a/tests/prose-language.test.js
+++ b/tests/prose-language.test.js
@@ -21,9 +21,11 @@ const trackedTests = async () => {
   return stdout.split("\n").filter((p) => p.trim() && !p.startsWith(".ja/"));
 };
 
-// A template literal would need the expression evaluated; no test here names itself with one.
-const testNames = (source) =>
-  [...source.matchAll(/^\s*test\(\s*"((?:[^"\\]|\\.)*)"/gm)].map((m) => m[1]);
+// Every registration form the runner accepts, in any of the three quote characters. A template
+// literal carrying an interpolation is read as its raw source, which is enough to spot the
+// language; evaluating it would need the surrounding scope.
+const REGISTRATION = /^\s*(?:test|it|describe)(?:\.\w+)?\(\s*(["'`])((?:[^\\]|\\.)*?)\1/gm;
+export const testNames = (source) => [...source.matchAll(REGISTRATION)].map((m) => m[2]);
 
 test("no test on the English side is named in Japanese", async () => {
   const offenders = [];
@@ -50,4 +52,29 @@ test("the id-numbering reference tells a plan to write T-NNN in English", async 
     const doc = await readFile(path, "utf8");
     assert.match(doc, /MIRROR\.md/, `${path} points at the rule that owns the prose language`);
   }
+});
+
+// The sweep is only as wide as this extractor. It missed two single-quoted names already in the
+// tree (build.behavior.test.js), so a Japanese name written in any form below passed unseen.
+test("testNames reads every registration form, not just a double-quoted test()", () => {
+  const source = [
+    'test("double quoted", () => {});',
+    "test('single quoted', () => {});",
+    'test.skip("skipped", () => {});',
+    "test.only('only', () => {});",
+    "test.todo(`todo`, () => {});",
+    "it('it form', () => {});",
+    'describe("describe form", () => {});',
+    '  test("indented", () => {});',
+  ].join("\n");
+  assert.deepEqual(testNames(source).sort(), [
+    "describe form",
+    "double quoted",
+    "indented",
+    "it form",
+    "only",
+    "single quoted",
+    "skipped",
+    "todo",
+  ]);
 });


### PR DESCRIPTION
## What & Why

日本語テスト名の検出が、シングルクォートやバッククォートで書かれた名前も拾うようになる。

`testNames` は `test("` で始まる二重引用符の名前しか拾っていなかった。実在する取りこぼしがあり、`workflows/build/tests/build.behavior.test.js` の `test(` 67 件のうち 65 件しか検査対象になっていない。同じファイル内でシングルクォートを使えば、日本語名を書いても #427 で入れた検出をすり抜ける。

## Review focus

- **正規表現の範囲**。`test` / `it` / `describe` と `.skip` などの派生を、3 種類の引用符すべてで拾う。`(["'\`])` の後方参照で閉じ引用符を対応させている
- **テンプレートリテラルの扱い**。補間を含む名前は生のソースとして読む。言語の判定にはそれで足りる。展開するには周囲のスコープが要るので、そこまでは踏み込んでいない
- `testNames` を export した点。この関数を直接検査するテストを足すためで、他に読み手はいない

## Changes

- 8 つの登録形式を並べた入力から全件を取り出せることを見るテストを追加。この関数の守備範囲が変わったことを、実ファイル依存でなく固定入力で固定する

## Scope

- Not included: アサーションメッセージとコメントの言語。#423 で範囲外とした判断を維持する
- Not included: `test(` を変数経由で呼ぶ形。このリポジトリに存在せず、静的に名前を取れない

## How to Test

1. `node --test tests/prose-language.test.js` を実行し、3 件とも pass することを確認する
2. `build.behavior.test.js` の `test('a plan carrying a non-seam unit with 4 files` の名前を日本語に変えると落ちることを確認する。修正前は落ちなかった
3. `node --test "tests/*.test.js"` で全件 pass することを確認する

## Related

- #427 で入れた検出の穴を塞ぐ
- この穴は #425 の実測で ground truth として仕込んだ finding の 1 つで、critic-audit が 6 回すべて confirmed にした
