### PR TITLE
assert の gate 結果を記録して severity 分布を数えられるようにする

### DIFF
--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -81,14 +81,22 @@ const SEVERITY_MAP = {
   low: "low",
 };
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
+// `if (!sev) continue;` (P3 または未知の severity) を通って落ちた finding は、mergeIssues の
+// 返り値配列だけを見ても痕跡が残らない。WORKFLOWS.md § Degradation recording は loss
+// granularity を主チャネル (workflow の返り値) に残すことを要求するので、mergeIssues は
+// issues と並べて dropped 件数も返す。
 const mergeIssues = (findings) => {
   const groups = new Map();
+  let dropped = 0;
   for (const f of findings) {
     const key = String(f.severity || "")
       .trim()
       .replace(/^\[|\]$/g, "");
     const sev = SEVERITY_MAP[key] === undefined ? null : SEVERITY_MAP[key];
-    if (!sev) continue;
+    if (!sev) {
+      dropped++;
+      continue;
+    }
     const sources = Array.isArray(f.source) ? f.source : f.source ? [f.source] : [];
     const k = `${f.file || ""}:${f.line || 0}`;
     const prev = groups.get(k);
@@ -101,12 +109,13 @@ const mergeIssues = (findings) => {
       groups.set(k, { ...f, severity: sev, source: prev.source });
     }
   }
-  return [...groups.values()].sort(
+  const issues = [...groups.values()].sort(
     (a, b) =>
       SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity] ||
       String(a.file || "").localeCompare(String(b.file || "")) ||
       (a.line || 0) - (b.line || 0),
   );
+  return { issues, dropped };
 };
 
 const BOOTSTRAP_SCHEMA = {
@@ -296,6 +305,9 @@ let gate = "NotReady";
 // 原因を導けない。実際に成立した条件を並べる。
 const gateReason = [];
 let issues = [];
+// mergeIssues が `if (!sev) continue;` で落とした件数。WORKFLOWS.md § Degradation recording:
+// 返り値が loss granularity の主チャネルなので、issues を縮めるだけでなく result.dropped に乗せる。
+let dropped = 0;
 let testsCol = "skipped";
 let adversarialSummary = {
   total: 0,
@@ -569,7 +581,7 @@ try {
     },
   );
   // enhancer が stall したら統合前の素材から fail-close で issues を組む
-  issues = mergeIssues(synth ? synth.issues : [...auditFindings, ...promoted]);
+  ({ issues, dropped } = mergeIssues(synth ? synth.issues : [...auditFindings, ...promoted]));
 
   // gate 規則。build smoke fail / test fail / issues 1 件以上は
   // NotReady。severity は修正優先度のヒントに留まり、gate には影響しない。caveat は issues 0 を
@@ -616,6 +628,7 @@ return {
   build: buildCol,
   tests: testsCol,
   issues,
+  dropped,
   root_causes: (synth && synth.root_causes) || [],
   adversarial: adversarialSummary,
   outcome_ref: boot.outcome === "absent" ? "absent" : "present",

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -81,10 +81,6 @@ const SEVERITY_MAP = {
   low: "low",
 };
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
-// `if (!sev) continue;` (P3 または未知の severity) を通って落ちた finding は、mergeIssues の
-// 返り値配列だけを見ても痕跡が残らない。WORKFLOWS.md § Degradation recording は loss
-// granularity を主チャネル (workflow の返り値) に残すことを要求するので、mergeIssues は
-// issues と並べて dropped 件数も返す。
 const mergeIssues = (findings) => {
   const groups = new Map();
   let dropped = 0;
@@ -305,8 +301,8 @@ let gate = "NotReady";
 // 原因を導けない。実際に成立した条件を並べる。
 const gateReason = [];
 let issues = [];
-// mergeIssues が `if (!sev) continue;` で落とした件数。WORKFLOWS.md § Degradation recording:
-// 返り値が loss granularity の主チャネルなので、issues を縮めるだけでなく result.dropped に乗せる。
+// `if (!sev) continue;` で落ちた finding は、返り値の issues に痕跡を残さない。
+// WORKFLOWS.md § Degradation recording はその件数を返り値へ載せることを求める。
 let dropped = 0;
 let testsCol = "skipped";
 let adversarialSummary = {
@@ -319,19 +315,13 @@ let adversarialSummary = {
 let synth = null;
 let codexReview = null;
 let audit = null;
-// ここで宣言する (try 内の使用箇所で const にしない) のは、run record を書き込む地点が
-// Synthesize より前の throw でも読めるようにするため。その場合は Synthesize 前の既定値
-// (false) のまま残る。
+// try 内で const にしない。記録は finally から書くので、Synthesize より前の throw では
+// スコープ外になる。
 let challengeStalled = false;
 let auditDegraded = false;
 
-// ---- Run recording: 確定した run ごとに 1 行、build.js の recordRun (workflows/build.js の
-// recordRun closure) に倣う ----
-// payload はこの closure の外側スコープの let から組み立てるため、呼び出し時点でこれらの
-// 変数が持っていた値 (早期 throw 時の Synthesize 前の既定値を含む) を常に反映する。
-// record.py は payload をそのまま複製するので、ここでキーを増やしても向こう側の変更は不要。
-// record.py はこの workflow に同梱されるため、上の worktree.py / bootstrap.py と同じ
-// SCRIPTS の bundled() path で解決する (WORKFLOWS.md § Reference notation)。
+// ---- Run recording: 確定した run ごとに 1 行。build.js の recordRun に倣う ----
+// record.py は payload をそのまま複製するので、ここでキーを増やしても向こう側は変えなくてよい。
 const RECORD_SCHEMA = {
   type: "object",
   additionalProperties: false,

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -357,21 +357,28 @@ const recordRun = async () => {
     challenge_stalled: challengeStalled,
     audit_degraded: auditDegraded,
   };
-  const written = await agent(
-    anchor(
-      `assert の 1 run を記録する。値を判断・要約・編集しない。手順は、(1) 次の JSON を一時ファイルへそのまま書く。` +
-        `(2) \`python3 ${SCRIPTS}/record.py < <tempfile>\` を実行する。` +
-        `(3) script の stdout の path をそのまま返す。` +
-        `script は {"path":...} を print する。\n` +
-        `入力 JSON は次のとおり。\n${JSON.stringify(payload)}`,
-    ),
-    {
-      label: "record",
-      agentType: "general-purpose",
-      schema: RECORD_SCHEMA,
-      model: "haiku",
-    },
-  );
+  // recordRun は finally の中で走るので、ここで throw すると try が投げていた例外を置き換え、
+  // run の本当の失敗が recorder の失敗の裏に隠れる。
+  let written = null;
+  try {
+    written = await agent(
+      anchor(
+        `assert の 1 run を記録する。値を判断・要約・編集しない。手順は、(1) 次の JSON を一時ファイルへそのまま書く。` +
+          `(2) \`python3 ${SCRIPTS}/record.py < <tempfile>\` を実行する。` +
+          `(3) script の stdout の path をそのまま返す。` +
+          `script は {"path":...} を print する。\n` +
+          `入力 JSON は次のとおり。\n${JSON.stringify(payload)}`,
+      ),
+      {
+        label: "record",
+        agentType: "general-purpose",
+        schema: RECORD_SCHEMA,
+        model: "haiku",
+      },
+    );
+  } catch {
+    written = null;
+  }
   const path = String((written && written.path) || "").trim();
   // 記録は assert を gate しないので、relay 失敗は run を止めず fail-open する。
   if (!path) {

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -319,6 +319,67 @@ let adversarialSummary = {
 let synth = null;
 let codexReview = null;
 let audit = null;
+// ここで宣言する (try 内の使用箇所で const にしない) のは、run record を書き込む地点が
+// Synthesize より前の throw でも読めるようにするため。その場合は Synthesize 前の既定値
+// (false) のまま残る。
+let challengeStalled = false;
+let auditDegraded = false;
+
+// ---- Run recording: 確定した run ごとに 1 行、build.js の recordRun (workflows/build.js の
+// recordRun closure) に倣う ----
+// payload はこの closure の外側スコープの let から組み立てるため、呼び出し時点でこれらの
+// 変数が持っていた値 (早期 throw 時の Synthesize 前の既定値を含む) を常に反映する。
+// record.py は payload をそのまま複製するので、ここでキーを増やしても向こう側の変更は不要。
+// record.py はこの workflow に同梱されるため、上の worktree.py / bootstrap.py と同じ
+// SCRIPTS の bundled() path で解決する (WORKFLOWS.md § Reference notation)。
+const RECORD_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["path"],
+  properties: {
+    path: { type: "string", description: "record.py の stdout JSON から得た path をそのまま" },
+  },
+};
+const recordRun = async () => {
+  const issueCounts = {};
+  for (const i of issues) {
+    const sev = i.severity || "unknown";
+    issueCounts[sev] = (issueCounts[sev] || 0) + 1;
+  }
+  const payload = {
+    gate,
+    gate_reason: gateReason,
+    build: buildCol,
+    tests: testsCol,
+    mode: boot.mode,
+    issue_counts: issueCounts,
+    dropped_findings: dropped,
+    challenge_stalled: challengeStalled,
+    audit_degraded: auditDegraded,
+  };
+  const written = await agent(
+    anchor(
+      `assert の 1 run を記録する。値を判断・要約・編集しない。手順は、(1) 次の JSON を一時ファイルへそのまま書く。` +
+        `(2) \`python3 ${SCRIPTS}/record.py < <tempfile>\` を実行する。` +
+        `(3) script の stdout の path をそのまま返す。` +
+        `script は {"path":...} を print する。\n` +
+        `入力 JSON は次のとおり。\n${JSON.stringify(payload)}`,
+    ),
+    {
+      label: "record",
+      agentType: "general-purpose",
+      schema: RECORD_SCHEMA,
+      model: "haiku",
+    },
+  );
+  const path = String((written && written.path) || "").trim();
+  // 記録は assert を gate しないので、relay 失敗は run を止めず fail-open する。
+  if (!path) {
+    log(
+      `run の行が書けなかった (recorder が path を返さなかった) ため、この run は assert-runs.jsonl から抜けている。`,
+    );
+  }
+};
 
 try {
   // ---- Evidence: audit ∥ Codex review ∥ test 実行 ∥ adversarial 生成 ----
@@ -551,12 +612,12 @@ try {
 
   // ---- Synthesize: enhancer-evidence 統合 -> script が gate 判定 ----
   phase("Synthesize");
-  const challengeStalled = codexFindings.length > 0 && !challenged && !verified;
+  challengeStalled = codexFindings.length > 0 && !challenged && !verified;
   // 入れ子の audit workflow 自身の challenge_ran は「challenge が verdicts を返した run」と
   // 「fail-open (challenge が走らず audit.js が全件 confirmed のまま通した run)」を区別する
   // 値。findings が 0 件の早期 return も challenge_ran=false を返すため degraded に含める。
   // reviewer が何も出さず challenge も走らなかった run が issues 0 件のまま Ready に届く穴を塞ぐ。
-  const auditDegraded = !!audit && audit.challenge_ran === false;
+  auditDegraded = !!audit && audit.challenge_ran === false;
   const auditFindingsIntro = auditDegraded
     ? "入れ子の audit workflow の challenge stage が走らなかった (fail-open) ため、以下の findings は未検証として扱う。そのまま issues に含めてよいが、report で表面化する。"
     : "audit workflow の統合済み findings (critic 検証済み。そのまま issues に含める) は次のとおり。";
@@ -617,6 +678,9 @@ try {
       model: "sonnet",
     },
   );
+  // finally に置く (try 直後ではない) のは、try 内の throw でも行を残すため。finally block は
+  // throw が workflow の外へ伝播する前に走る。
+  await recordRun();
 }
 
 log(`Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length})`);

--- a/.ja/workflows/assert/record.py
+++ b/.ja/workflows/assert/record.py
@@ -1,0 +1,54 @@
+"""Usage: record.py   (assert の run payload JSON を stdin で受ける)
+
+assert の 1 実行を $HOME/.claude/history/assert-runs.jsonl へ 1 行追記する。
+
+stdin:  JSON {gate, gate_reason, build, tests, mode, issue_counts, dropped_findings}
+        キーは row にそのまま写す。assert は 1 run 1 行 (build と違い run_id で row を
+        結び付ける必要が無い) なので、row は payload が渡したもの以外の既定値を持たない。
+stdout: {path} の JSON 1 行。
+exit 0 は成功。exit 1 は payload が parse 不能 (何も書かない)。
+
+row に追加される解決済みフィールド:
+  generated_at  UTC ISO-8601
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn, cast
+
+HISTORY_DIR = Path.home() / ".claude" / "history"
+# audit のような run ごとのファイルでなく 1 本に固定する。集計が jsonl を 1 本読むだけで済む。
+RUNS_PATH = HISTORY_DIR / "assert-runs.jsonl"
+
+
+def fail(message: str) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    raw_stdin = sys.stdin.read()
+    try:
+        loaded = cast("object", json.loads(raw_stdin))
+    except ValueError as exc:
+        fail(f"unparseable payload: {exc}")
+    if not isinstance(loaded, dict):
+        fail("payload must be a JSON object")
+    payload = cast("dict[str, object]", loaded)
+
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    row = {
+        **payload,
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    with RUNS_PATH.open("a") as fh:
+        _ = fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(json.dumps({"path": str(RUNS_PATH)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -82,10 +82,6 @@ const SEVERITY_MAP = {
   low: "low",
 };
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
-// Findings that fall through `if (!sev) continue;` (P3 or an unrecognized severity) leave
-// mergeIssues's return array with no trace of the loss. WORKFLOWS.md § Degradation recording
-// requires that count on the primary channel (the workflow return value), so mergeIssues
-// reports it alongside issues rather than only shrinking the array silently.
 const mergeIssues = (findings) => {
   const groups = new Map();
   let dropped = 0;
@@ -307,9 +303,8 @@ let gate = "NotReady";
 // findings alone. These are the conditions that actually held.
 const gateReason = [];
 let issues = [];
-// Count of findings mergeIssues dropped via `if (!sev) continue;` (P3 or an unrecognized
-// severity). WORKFLOWS.md § Degradation recording: the return value is the primary channel
-// for loss granularity, so this rides on result.dropped rather than only shrinking issues.
+// A finding dropped by `if (!sev) continue;` leaves no trace in the returned issues array.
+// WORKFLOWS.md § Degradation recording puts that count on the return value.
 let dropped = 0;
 let testsCol = "skipped";
 let adversarialSummary = {
@@ -322,19 +317,13 @@ let adversarialSummary = {
 let synth = null;
 let codexReview = null;
 let audit = null;
-// Declared here (not `const` at their point of use inside try) so the point that writes the
-// run record can read them even when the throw that ends the run lands before Synthesize sets
-// them; they then keep their pre-Synthesize default (false).
+// Not `const` inside the try: the record is written from the finally block, which a throw
+// before Synthesize would otherwise reach with these out of scope.
 let challengeStalled = false;
 let auditDegraded = false;
 
 // ---- Run recording: one jsonl row per settled run, modeled on build.js's recordRun ----
-// (workflows/build.js, the recordRun closure). The payload is assembled from the closure's
-// outer-scope lets, so it always reflects whatever those variables held at call time, including
-// their pre-Synthesize defaults on an early throw. record.py copies the payload verbatim, so a
-// key added here needs no matching change there. record.py ships under workflows/assert/, so it
-// resolves through the same SCRIPTS bundled() path as worktree.py / bootstrap.py above
-// (WORKFLOWS.md § Reference notation).
+// record.py copies the payload verbatim, so a key added here needs no change there.
 const RECORD_SCHEMA = {
   type: "object",
   additionalProperties: false,

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -360,21 +360,28 @@ const recordRun = async () => {
     challenge_stalled: challengeStalled,
     audit_degraded: auditDegraded,
   };
-  const written = await agent(
-    anchor(
-      `Record one assert run; do not judge, summarize, or edit any value. The steps are, (1) write this exact JSON to a temp file; ` +
-        `(2) run \`python3 ${SCRIPTS}/record.py < <tempfile>\`; ` +
-        `(3) return the script's stdout path verbatim. ` +
-        `The script prints {"path":...}.\n` +
-        `The input JSON is as follows.\n${JSON.stringify(payload)}`,
-    ),
-    {
-      label: "record",
-      agentType: "general-purpose",
-      schema: RECORD_SCHEMA,
-      model: "haiku",
-    },
-  );
+  // recordRun runs in the finally block, so a throw here would replace whatever the try block
+  // was throwing and hide the run's real failure behind a recorder failure.
+  let written = null;
+  try {
+    written = await agent(
+      anchor(
+        `Record one assert run; do not judge, summarize, or edit any value. The steps are, (1) write this exact JSON to a temp file; ` +
+          `(2) run \`python3 ${SCRIPTS}/record.py < <tempfile>\`; ` +
+          `(3) return the script's stdout path verbatim. ` +
+          `The script prints {"path":...}.\n` +
+          `The input JSON is as follows.\n${JSON.stringify(payload)}`,
+      ),
+      {
+        label: "record",
+        agentType: "general-purpose",
+        schema: RECORD_SCHEMA,
+        model: "haiku",
+      },
+    );
+  } catch {
+    written = null;
+  }
   const path = String((written && written.path) || "").trim();
   // Recording never gates assert, so a failed relay falls open instead of stopping the run.
   if (!path) {

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -322,6 +322,67 @@ let adversarialSummary = {
 let synth = null;
 let codexReview = null;
 let audit = null;
+// Declared here (not `const` at their point of use inside try) so the point that writes the
+// run record can read them even when the throw that ends the run lands before Synthesize sets
+// them; they then keep their pre-Synthesize default (false).
+let challengeStalled = false;
+let auditDegraded = false;
+
+// ---- Run recording: one jsonl row per settled run, modeled on build.js's recordRun ----
+// (workflows/build.js, the recordRun closure). The payload is assembled from the closure's
+// outer-scope lets, so it always reflects whatever those variables held at call time, including
+// their pre-Synthesize defaults on an early throw. record.py copies the payload verbatim, so a
+// key added here needs no matching change there. record.py ships under workflows/assert/, so it
+// resolves through the same SCRIPTS bundled() path as worktree.py / bootstrap.py above
+// (WORKFLOWS.md § Reference notation).
+const RECORD_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["path"],
+  properties: {
+    path: { type: "string", description: "path from record.py's stdout JSON, verbatim" },
+  },
+};
+const recordRun = async () => {
+  const issueCounts = {};
+  for (const i of issues) {
+    const sev = i.severity || "unknown";
+    issueCounts[sev] = (issueCounts[sev] || 0) + 1;
+  }
+  const payload = {
+    gate,
+    gate_reason: gateReason,
+    build: buildCol,
+    tests: testsCol,
+    mode: boot.mode,
+    issue_counts: issueCounts,
+    dropped_findings: dropped,
+    challenge_stalled: challengeStalled,
+    audit_degraded: auditDegraded,
+  };
+  const written = await agent(
+    anchor(
+      `Record one assert run; do not judge, summarize, or edit any value. The steps are, (1) write this exact JSON to a temp file; ` +
+        `(2) run \`python3 ${SCRIPTS}/record.py < <tempfile>\`; ` +
+        `(3) return the script's stdout path verbatim. ` +
+        `The script prints {"path":...}.\n` +
+        `The input JSON is as follows.\n${JSON.stringify(payload)}`,
+    ),
+    {
+      label: "record",
+      agentType: "general-purpose",
+      schema: RECORD_SCHEMA,
+      model: "haiku",
+    },
+  );
+  const path = String((written && written.path) || "").trim();
+  // Recording never gates assert, so a failed relay falls open instead of stopping the run.
+  if (!path) {
+    log(
+      `The run row was not written (the recorder returned no path), so this run is missing from assert-runs.jsonl.`,
+    );
+  }
+};
 
 try {
   // ---- Evidence: audit ∥ Codex review ∥ test run ∥ adversarial generation ----
@@ -563,13 +624,13 @@ try {
 
   // ---- Synthesize: enhancer-evidence integration -> script decides the gate ----
   phase("Synthesize");
-  const challengeStalled = codexFindings.length > 0 && !challenged && !verified;
+  challengeStalled = codexFindings.length > 0 && !challenged && !verified;
   // The nested audit workflow's own challenge_ran distinguishes "challenge produced
   // verdicts" from "fail-open (challenge did not run, so audit.js let all findings through
   // as confirmed)". The zero-findings early return carries challenge_ran=false too and
   // counts as degraded, closing the hole where a run whose reviewers found nothing and
   // whose challenge never ran still reaches Ready with zero issues.
-  const auditDegraded = !!audit && audit.challenge_ran === false;
+  auditDegraded = !!audit && audit.challenge_ran === false;
   const auditFindingsIntro = auditDegraded
     ? "The nested audit workflow's challenge stage did not run (fail-open), so treat the following findings as unverified; include them in issues as-is but flag this in the report."
     : "The integrated findings from the audit workflow (critic-verified; include them in issues as-is) are as follows.";
@@ -630,6 +691,9 @@ try {
       model: "sonnet",
     },
   );
+  // Placed in finally (not after the try block) so a throw inside try still leaves a row: the
+  // finally block runs before the throw propagates out of the workflow.
+  await recordRun();
 }
 
 log(`Gate: ${gate} (build=${buildCol}, tests=${testsCol}, issues=${issues.length})`);

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -82,14 +82,22 @@ const SEVERITY_MAP = {
   low: "low",
 };
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
+// Findings that fall through `if (!sev) continue;` (P3 or an unrecognized severity) leave
+// mergeIssues's return array with no trace of the loss. WORKFLOWS.md § Degradation recording
+// requires that count on the primary channel (the workflow return value), so mergeIssues
+// reports it alongside issues rather than only shrinking the array silently.
 const mergeIssues = (findings) => {
   const groups = new Map();
+  let dropped = 0;
   for (const f of findings) {
     const key = String(f.severity || "")
       .trim()
       .replace(/^\[|\]$/g, "");
     const sev = SEVERITY_MAP[key] === undefined ? null : SEVERITY_MAP[key];
-    if (!sev) continue;
+    if (!sev) {
+      dropped++;
+      continue;
+    }
     const sources = Array.isArray(f.source) ? f.source : f.source ? [f.source] : [];
     const k = `${f.file || ""}:${f.line || 0}`;
     const prev = groups.get(k);
@@ -102,12 +110,13 @@ const mergeIssues = (findings) => {
       groups.set(k, { ...f, severity: sev, source: prev.source });
     }
   }
-  return [...groups.values()].sort(
+  const issues = [...groups.values()].sort(
     (a, b) =>
       SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity] ||
       String(a.file || "").localeCompare(String(b.file || "")) ||
       (a.line || 0) - (b.line || 0),
   );
+  return { issues, dropped };
 };
 
 const BOOTSTRAP_SCHEMA = {
@@ -298,6 +307,10 @@ let gate = "NotReady";
 // findings alone. These are the conditions that actually held.
 const gateReason = [];
 let issues = [];
+// Count of findings mergeIssues dropped via `if (!sev) continue;` (P3 or an unrecognized
+// severity). WORKFLOWS.md § Degradation recording: the return value is the primary channel
+// for loss granularity, so this rides on result.dropped rather than only shrinking issues.
+let dropped = 0;
 let testsCol = "skipped";
 let adversarialSummary = {
   total: 0,
@@ -581,7 +594,7 @@ try {
     },
   );
   // if the enhancer stalls, assemble issues fail-close from the pre-integration material
-  issues = mergeIssues(synth ? synth.issues : [...auditFindings, ...promoted]);
+  ({ issues, dropped } = mergeIssues(synth ? synth.issues : [...auditFindings, ...promoted]));
 
   // Gate rule. Build smoke fail / test fail / one or more
   // issues means NotReady. Severity remains a fix-priority hint and never affects the
@@ -628,6 +641,7 @@ return {
   build: buildCol,
   tests: testsCol,
   issues,
+  dropped,
   root_causes: (synth && synth.root_causes) || [],
   adversarial: adversarialSummary,
   outcome_ref: boot.outcome === "absent" ? "absent" : "present",

--- a/workflows/assert/record.py
+++ b/workflows/assert/record.py
@@ -1,0 +1,55 @@
+"""Usage: record.py   (assert run payload JSON on stdin)
+
+Append one assert run to $HOME/.claude/history/assert-runs.jsonl.
+
+stdin:  JSON {gate, gate_reason, build, tests, mode, issue_counts, dropped_findings}
+        Every key is copied to the row verbatim. assert is 1 run 1 line (unlike
+        build, no run_id joins rows), so the row carries no defaults beyond what
+        the payload supplies.
+stdout: one line of JSON, {path}.
+exit 0 on success. exit 1 on an unparseable payload (nothing written).
+
+Resolved fields, added to the row:
+  generated_at  UTC ISO-8601
+"""
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NoReturn, cast
+
+HISTORY_DIR = Path.home() / ".claude" / "history"
+# One fixed file, not audit's file per run: counting then reads a single jsonl.
+RUNS_PATH = HISTORY_DIR / "assert-runs.jsonl"
+
+
+def fail(message: str) -> NoReturn:
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def main() -> None:
+    raw_stdin = sys.stdin.read()
+    try:
+        loaded = cast("object", json.loads(raw_stdin))
+    except ValueError as exc:
+        fail(f"unparseable payload: {exc}")
+    if not isinstance(loaded, dict):
+        fail("payload must be a JSON object")
+    payload = cast("dict[str, object]", loaded)
+
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    row = {
+        **payload,
+        "generated_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+    with RUNS_PATH.open("a") as fh:
+        _ = fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(json.dumps({"path": str(RUNS_PATH)}))
+
+
+if __name__ == "__main__":
+    main()

--- a/workflows/assert/tests/_fixtures.js
+++ b/workflows/assert/tests/_fixtures.js
@@ -1,0 +1,24 @@
+// The bootstrap return value that makes dynamicOk true (worktree_ok true / install ok / build
+// pass). Shared by every test file in this directory that needs a bootstrap stage to succeed
+// (see workflows/audit/tests/_fixtures.js for the same per-directory sharing pattern).
+export const bootOk = {
+  codex_available: true,
+  mode: "target",
+  diff_kind: "",
+  scope_files: ["src/foo.js"],
+  outcome: "absent",
+  worktree_ok: true,
+  worktree_path: "/tmp/assert-wt",
+  install: "ok",
+  build: "pass",
+  reason: "",
+};
+
+// The calls this run made to the "record" label, in call order.
+export const recordCallsOf = (calls) =>
+  calls.agent.filter((c) => c.opts && c.opts.label === "record");
+
+// build.js's own recordRun puts the stringified payload on the prompt's last line (see
+// build/tests/build.behavior.test.js's T-008, "the payload is the prompt's last line, where
+// recordRun puts the stringified JSON"); assert's recorder is asked to mirror that exactly.
+export const recordPayloadOf = (call) => JSON.parse(call.prompt.trim().split("\n").pop());

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -351,3 +351,57 @@ test("T-003 a Ready run whose build was skipped does not report build as passing
   );
   assert.match(reasonText, /build skipped/, "gate_reason reports the build column it read");
 });
+
+// U-001: mergeIssues's `if (!sev) continue;` branch drops a finding whose severity SEVERITY_MAP
+// maps to null (P3) or does not carry at all (unknown severity), and up to now that drop left no
+// trace on the return value (WORKFLOWS.md § Degradation recording: loss granularity). The count
+// of findings dropped this way is read off the workflow's own return value (result.dropped),
+// since mergeIssues is a function local to the vm-evaluated script body and is not otherwise
+// observable from a test (see run-workflow.js's header comment on script evaluation).
+test("T-010 a finding whose severity is not in SEVERITY_MAP stays out of issues and is counted as dropped", async () => {
+  const droppedFinding = {
+    file: "a.js",
+    line: 10,
+    severity: "P4",
+    summary: "unrecognised severity",
+    source: ["audit"],
+  };
+  const keptFinding = {
+    file: "b.js",
+    line: 20,
+    severity: "high",
+    summary: "recognised severity",
+    source: ["audit"],
+  };
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: makeGateReasonAgent({ issues: [droppedFinding, keptFinding] }) },
+  });
+  assert.equal(result.issues.length, 1, "only the recognised-severity finding reaches issues");
+  assert.ok(
+    !result.issues.some((i) => i.file === "a.js" && i.line === 10),
+    "the finding with an unrecognised severity (P4) stays out of issues",
+  );
+  assert.equal(
+    result.dropped,
+    1,
+    "the finding dropped for its unrecognised severity is counted on the return value",
+  );
+});
+
+test("T-011 a run whose findings all carry a recognised severity reports zero dropped findings", async () => {
+  const issues = [
+    { file: "a.js", line: 10, severity: "high", summary: "x", source: ["audit"] },
+    { file: "b.js", line: 20, severity: "medium", summary: "y", source: ["audit"] },
+  ];
+  const { result } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: makeGateReasonAgent({ issues }) },
+  });
+  assert.equal(result.issues.length, 2, "both recognised-severity findings reach issues");
+  assert.equal(
+    result.dropped,
+    0,
+    "a run whose findings all carry a recognised severity reports zero dropped findings",
+  );
+});

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -489,3 +489,47 @@ test("T-015 the row carries challenge_stalled and audit_degraded as booleans", a
     "the nested audit workflow's challenge stage failed open this run",
   );
 });
+
+// The Testing Decisions clause asks for both sides of the gate to leave a row. T-012 and T-016
+// drive runs carrying issues, so only NotReady was covered.
+test("T-016 a Ready-gated run appends exactly one record row", async () => {
+  const { result, calls } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: (prompt, opts) => {
+        if (opts && opts.label === "record")
+          return { path: "/home/u/.claude/history/assert-runs.jsonl" };
+        return makeAgent({ ran: true, tests: [] })(prompt, opts);
+      },
+    },
+  });
+  assert.equal(result.gate, "Ready", "no issues and passing evidence gate Ready");
+  assert.equal(
+    recordCallsOf(calls).length,
+    1,
+    "a Ready run writes one row, same as a NotReady run",
+  );
+});
+
+// recordRun sits in the finally block, so a throw there replaces whatever the try block was
+// throwing. A recorder failure must not stop the run, and must not mask the real one either.
+test("T-017 a recorder that throws leaves the gate unchanged and names the unwritten row in log()", async () => {
+  const { result, logs } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: {
+      agent: (prompt, opts) => {
+        if (opts && opts.label === "record") throw new Error("recorder exploded");
+        return makeAgent({ ran: true, tests: [] })(prompt, opts);
+      },
+    },
+  });
+  assert.equal(
+    result.gate,
+    "Ready",
+    "a throwing recorder does not change the gate the run computed",
+  );
+  assert.ok(
+    logs.some((m) => /assert-runs\.jsonl/.test(m)),
+    "the unwritten row reaches log() naming the file it is missing from",
+  );
+});

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -405,3 +405,107 @@ test("T-011 a run whose findings all carry a recognised severity reports zero dr
     "a run whose findings all carry a recognised severity reports zero dropped findings",
   );
 });
+
+// U-003: assert records one row per settled run in $HOME/.claude/history/assert-runs.jsonl,
+// following build.js's recordRun (workflows/assert/record.py already accepts arbitrary payload
+// keys, so this unit only wires assert.js to build that payload and hand it to the agent that
+// runs the recorder). A failed record must not stop the run (WORKFLOWS.md § Degradation
+// recording), so a recorder returning nothing still lets the gate reach its own return value,
+// with the loss surfaced through log() instead.
+const recordCallsOf = (calls) => calls.agent.filter((c) => c.opts && c.opts.label === "record");
+
+// build.js's own recordRun puts the stringified payload on the prompt's last line (see
+// build/tests/build.behavior.test.js's T-008, "the payload is the prompt's last line, where
+// recordRun puts the stringified JSON"); assert's recorder is asked to mirror that exactly.
+const recordPayloadOf = (call) => JSON.parse(call.prompt.trim().split("\n").pop());
+
+test("T-012 a run that reaches a gate writes one row carrying that gate and the per-severity issue counts", async () => {
+  const issues = [
+    { file: "a.js", line: 10, severity: "high", summary: "x", source: ["audit"] },
+    { file: "b.js", line: 20, severity: "medium", summary: "y", source: ["audit"] },
+    { file: "c.js", line: 30, severity: "high", summary: "z", source: ["audit"] },
+  ];
+  const { result, calls } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: makeGateReasonAgent({ issues }) },
+  });
+  const records = recordCallsOf(calls);
+  assert.equal(records.length, 1, "the run writes exactly one record row");
+  const payload = recordPayloadOf(records[0]);
+  assert.equal(payload.gate, result.gate, "the row carries the gate this run reached");
+  assert.equal(
+    payload.issue_counts && payload.issue_counts.high,
+    2,
+    "the row's issue_counts.high matches the two high-severity issues",
+  );
+  assert.equal(
+    payload.issue_counts && payload.issue_counts.medium,
+    1,
+    "the row's issue_counts.medium matches the one medium-severity issue",
+  );
+});
+
+test("T-013 a recorder returning nothing leaves the gate unchanged and names the unwritten row in log()", async () => {
+  const { result, logs } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: makeAgent({ ran: true, tests: [] }) }, // the "record" label falls through to undefined
+  });
+  assert.equal(
+    result.gate,
+    "Ready",
+    "the gate this run computed from its own evidence is unchanged by a recorder that returns nothing",
+  );
+  assert.ok(
+    logs.some((m) => /assert-runs\.jsonl/.test(m)),
+    "the unwritten row reaches log() naming the file it is missing from",
+  );
+});
+
+test("T-014 a throw inside the try still leaves a row for that run", async () => {
+  const recordCalls = [];
+  const throwingAgent = (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "codex-review") throw new Error("codex review crashed");
+    if (label === "record") recordCalls.push(prompt);
+    return makeAgent({ ran: true, tests: [] })(prompt, opts);
+  };
+  await assert.rejects(
+    () => runWorkflow(assertJs, { args: {}, stubs: { agent: throwingAgent } }),
+    /codex review crashed/,
+    "the throw inside the try still propagates out of the workflow",
+  );
+  assert.equal(
+    recordCalls.length,
+    1,
+    "the record row is written from a point the finally block reaches before the throw propagates",
+  );
+});
+
+test("T-015 the row carries challenge_stalled and audit_degraded as booleans", async () => {
+  const stalledAgent = (prompt, opts) => {
+    const label = opts && opts.label;
+    if (label === "codex-review")
+      return { ran: true, findings: [{ file: "a.js", line: 1, severity: "P1", summary: "x" }] };
+    if (label === "challenge" || label === "verify") return undefined; // both stall
+    return makeAgent({ ran: true, tests: [] })(prompt, opts);
+  };
+  const { calls } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: stalledAgent, workflow: makeAuditWorkflowStub(false) },
+  });
+  const records = recordCallsOf(calls);
+  assert.equal(records.length, 1, "the run writes exactly one record row");
+  const payload = recordPayloadOf(records[0]);
+  assert.equal(typeof payload.challenge_stalled, "boolean", "challenge_stalled is a boolean");
+  assert.equal(typeof payload.audit_degraded, "boolean", "audit_degraded is a boolean");
+  assert.equal(
+    payload.challenge_stalled,
+    true,
+    "the Codex findings were unverified this run (challenge and verify both stalled)",
+  );
+  assert.equal(
+    payload.audit_degraded,
+    true,
+    "the nested audit workflow's challenge stage failed open this run",
+  );
+});

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -16,24 +16,10 @@ import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runWorkflow } from "../../_lib/run-workflow.js";
+import { bootOk, recordCallsOf, recordPayloadOf } from "./_fixtures.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const assertJs = join(here, "..", "..", "assert.js");
-
-// The bootstrap return value that makes dynamicOk true (worktree_ok true / install ok / build
-// pass).
-const bootOk = {
-  codex_available: true,
-  mode: "target",
-  diff_kind: "",
-  scope_files: ["src/foo.js"],
-  outcome: "absent",
-  worktree_ok: true,
-  worktree_path: "/tmp/assert-wt",
-  install: "ok",
-  build: "pass",
-  reason: "",
-};
 
 // The shortest agent stub carrying every stage but adversarial. advReturn is injected as the
 // adversarial stage's return value (null = stall, { ran: true, tests: [] } = genuine no-tests).
@@ -412,12 +398,6 @@ test("T-011 a run whose findings all carry a recognised severity reports zero dr
 // runs the recorder). A failed record must not stop the run (WORKFLOWS.md § Degradation
 // recording), so a recorder returning nothing still lets the gate reach its own return value,
 // with the loss surfaced through log() instead.
-const recordCallsOf = (calls) => calls.agent.filter((c) => c.opts && c.opts.label === "record");
-
-// build.js's own recordRun puts the stringified payload on the prompt's last line (see
-// build/tests/build.behavior.test.js's T-008, "the payload is the prompt's last line, where
-// recordRun puts the stringified JSON"); assert's recorder is asked to mirror that exactly.
-const recordPayloadOf = (call) => JSON.parse(call.prompt.trim().split("\n").pop());
 
 test("T-012 a run that reaches a gate writes one row carrying that gate and the per-severity issue counts", async () => {
   const issues = [

--- a/workflows/assert/tests/assert.record.seam.test.js
+++ b/workflows/assert/tests/assert.record.seam.test.js
@@ -1,0 +1,107 @@
+// This carries assert's own returned issues all the way to the real
+// workflows/assert/record.py's written row, mirroring workflows/audit/tests/audit.seam.test.js's
+// runSnapshot pattern (see that file's header comment): only agent responses are faked, and the
+// recorder script itself really runs, so what gets asserted is the row on disk rather than the
+// payload the run assembled. Whether Synthesize's issues and recordRun's issue_counts actually
+// stay in step shows up on no other path but this one.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+import { runWorkflow } from "../../_lib/run-workflow.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const assertJs = join(here, "..", "..", "assert.js");
+const recordPy = join(here, "..", "record.py");
+
+// record.py's HISTORY_DIR derives from $HOME/.claude/history (see record.py). Each run points
+// HOME at an isolated temporary directory, so the real user's history is never rewritten and
+// records never mix between tests.
+const runRecord = (payload) => {
+  const home = mkdtempSync(join(tmpdir(), "assert-record-seam-"));
+  try {
+    const res = spawnSync("python3", [recordPy], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      env: { ...process.env, HOME: home },
+    });
+    assert.equal(res.status, 0, `record.py exits 0 (stderr: ${res.stderr})`);
+    // stdout is one JSON line of {path}. record.py is 1 run 1 line, so the file holds
+    // exactly the one row this run appended.
+    const out = JSON.parse(res.stdout);
+    const lines = readFileSync(out.path, "utf8").trim().split("\n");
+    return JSON.parse(lines[lines.length - 1]);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+};
+
+// The bootstrap return value that makes dynamicOk true (worktree_ok true / install ok / build
+// pass), lifted from assert.degradation.test.js's bootOk.
+const bootOk = {
+  codex_available: true,
+  mode: "target",
+  diff_kind: "",
+  scope_files: ["src/foo.js"],
+  outcome: "absent",
+  worktree_ok: true,
+  worktree_path: "/tmp/assert-wt",
+  install: "ok",
+  build: "pass",
+  reason: "",
+};
+
+// Every stage but "record" answers with a fixed fake, so the run reaches its own gate/issues
+// deterministically. "record" is left unstubbed (falls through to undefined) so its payload is
+// read off calls.agent instead of being fabricated, then carried to the real record.py below.
+const agentStub = (issues) => (prompt, opts) => {
+  const label = opts && opts.label;
+  if (label === "bootstrap") return bootOk;
+  if (label === "test-exec") return { outcome: "pass", passed: 1, failed: 0 };
+  if (label === "adversarial") return { ran: true, tests: [] };
+  if (label === "codex-review") return { ran: true, findings: [] };
+  if (label === "synthesize") return { issues, root_causes: [], report: "ok" };
+  if (label === "cleanup") return {};
+  return undefined;
+};
+
+// assert.js's own recordRun puts the stringified payload on the prompt's last line, the same
+// form build.js's recordRun uses (see workflows/assert/tests/assert.degradation.test.js's
+// recordPayloadOf).
+const recordPayloadOf = (call) => JSON.parse(call.prompt.trim().split("\n").pop());
+
+// The per-severity tally computed straight from the returned issues, independent of
+// recordRun's own issueCounts loop, so this does not simply re-check recordRun against itself.
+const tallyBySeverity = (issues) => {
+  const counts = {};
+  for (const i of issues) counts[i.severity] = (counts[i.severity] || 0) + 1;
+  return counts;
+};
+
+test("T-016 the row the real record.py wrote carries the same per-severity counts as the returned issues", async () => {
+  const issues = [
+    { file: "a.js", line: 10, severity: "high", summary: "x", source: ["audit"] },
+    { file: "b.js", line: 20, severity: "medium", summary: "y", source: ["audit"] },
+    { file: "c.js", line: 30, severity: "high", summary: "z", source: ["audit"] },
+  ];
+  const { result, calls } = await runWorkflow(assertJs, {
+    args: {},
+    stubs: { agent: agentStub(issues) },
+  });
+  assert.ok(result.issues.length > 0, "the run returns issues to tally against");
+
+  const records = calls.agent.filter((c) => c.opts && c.opts.label === "record");
+  assert.equal(records.length, 1, "the run calls the recorder exactly once");
+  const payload = recordPayloadOf(records[0]);
+
+  const row = runRecord(payload);
+  assert.deepEqual(
+    row.issue_counts,
+    tallyBySeverity(result.issues),
+    "the per-severity counts in the row the real record.py wrote to disk match a tally taken " +
+      "straight off assert's own returned issues",
+  );
+});

--- a/workflows/assert/tests/assert.record.seam.test.js
+++ b/workflows/assert/tests/assert.record.seam.test.js
@@ -12,6 +12,7 @@ import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { spawnSync } from "node:child_process";
 import { runWorkflow } from "../../_lib/run-workflow.js";
+import { bootOk, recordCallsOf, recordPayloadOf } from "./_fixtures.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const assertJs = join(here, "..", "..", "assert.js");
@@ -39,21 +40,6 @@ const runRecord = (payload) => {
   }
 };
 
-// The bootstrap return value that makes dynamicOk true (worktree_ok true / install ok / build
-// pass), lifted from assert.degradation.test.js's bootOk.
-const bootOk = {
-  codex_available: true,
-  mode: "target",
-  diff_kind: "",
-  scope_files: ["src/foo.js"],
-  outcome: "absent",
-  worktree_ok: true,
-  worktree_path: "/tmp/assert-wt",
-  install: "ok",
-  build: "pass",
-  reason: "",
-};
-
 // Every stage but "record" answers with a fixed fake, so the run reaches its own gate/issues
 // deterministically. "record" is left unstubbed (falls through to undefined) so its payload is
 // read off calls.agent instead of being fabricated, then carried to the real record.py below.
@@ -67,11 +53,6 @@ const agentStub = (issues) => (prompt, opts) => {
   if (label === "cleanup") return {};
   return undefined;
 };
-
-// assert.js's own recordRun puts the stringified payload on the prompt's last line, the same
-// form build.js's recordRun uses (see workflows/assert/tests/assert.degradation.test.js's
-// recordPayloadOf).
-const recordPayloadOf = (call) => JSON.parse(call.prompt.trim().split("\n").pop());
 
 // The per-severity tally computed straight from the returned issues, independent of
 // recordRun's own issueCounts loop, so this does not simply re-check recordRun against itself.
@@ -93,7 +74,7 @@ test("T-016 the row the real record.py wrote carries the same per-severity count
   });
   assert.ok(result.issues.length > 0, "the run returns issues to tally against");
 
-  const records = calls.agent.filter((c) => c.opts && c.opts.label === "record");
+  const records = recordCallsOf(calls);
   assert.equal(records.length, 1, "the run calls the recorder exactly once");
   const payload = recordPayloadOf(records[0]);
 

--- a/workflows/assert/tests/assert.record.seam.test.js
+++ b/workflows/assert/tests/assert.record.seam.test.js
@@ -1,9 +1,6 @@
-// This carries assert's own returned issues all the way to the real
-// workflows/assert/record.py's written row, mirroring workflows/audit/tests/audit.seam.test.js's
-// runSnapshot pattern (see that file's header comment): only agent responses are faked, and the
-// recorder script itself really runs, so what gets asserted is the row on disk rather than the
-// payload the run assembled. Whether Synthesize's issues and recordRun's issue_counts actually
-// stay in step shows up on no other path but this one.
+// Only agent responses are faked; record.py really runs, so what is asserted is the row on disk
+// rather than the payload the run assembled. No other path shows whether Synthesize's issues and
+// recordRun's issue_counts stay in step.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
@@ -18,9 +15,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 const assertJs = join(here, "..", "..", "assert.js");
 const recordPy = join(here, "..", "record.py");
 
-// record.py's HISTORY_DIR derives from $HOME/.claude/history (see record.py). Each run points
-// HOME at an isolated temporary directory, so the real user's history is never rewritten and
-// records never mix between tests.
+// HISTORY_DIR derives from $HOME, so HOME points at a temporary directory: the real history is
+// never rewritten and records never mix between tests.
 const runRecord = (payload) => {
   const home = mkdtempSync(join(tmpdir(), "assert-record-seam-"));
   try {
@@ -30,8 +26,7 @@ const runRecord = (payload) => {
       env: { ...process.env, HOME: home },
     });
     assert.equal(res.status, 0, `record.py exits 0 (stderr: ${res.stderr})`);
-    // stdout is one JSON line of {path}. record.py is 1 run 1 line, so the file holds
-    // exactly the one row this run appended.
+    // record.py writes one row per run, so the file holds exactly what this run appended.
     const out = JSON.parse(res.stdout);
     const lines = readFileSync(out.path, "utf8").trim().split("\n");
     return JSON.parse(lines[lines.length - 1]);
@@ -40,9 +35,8 @@ const runRecord = (payload) => {
   }
 };
 
-// Every stage but "record" answers with a fixed fake, so the run reaches its own gate/issues
-// deterministically. "record" is left unstubbed (falls through to undefined) so its payload is
-// read off calls.agent instead of being fabricated, then carried to the real record.py below.
+// "record" is left unstubbed so its payload is read off calls.agent rather than fabricated,
+// then carried to the real record.py below.
 const agentStub = (issues) => (prompt, opts) => {
   const label = opts && opts.label;
   if (label === "bootstrap") return bootOk;

--- a/workflows/assert/tests/record_test.py
+++ b/workflows/assert/tests/record_test.py
@@ -21,9 +21,7 @@ from typing import cast
 HERE = Path(__file__).resolve().parent
 SCRIPT = HERE.parent / "record.py"
 
-# The keys an assert run's row carries: the gate verdict, its per-condition reasons, the
-# build/tests columns, the scope mode, the per-severity issue counts, and the dropped-findings
-# count, plus the recorder's own generated_at.
+# Every row carries these, so a reader never branches on the kind of run.
 ROW_FIELDS = {
     "gate",
     "gate_reason",

--- a/workflows/assert/tests/record_test.py
+++ b/workflows/assert/tests/record_test.py
@@ -1,0 +1,132 @@
+# pyright: reportUninitializedInstanceVariable=false
+"""Tests for workflows/assert/record.py (deterministic assert-run recorder).
+
+Run: python3 workflows/assert/tests/record_test.py
+
+The CLI contract (stdin JSON -> one appended line in assert-runs.jsonl, {path} JSON on
+stdout, exit 1 on a bad payload) is exercised via subprocess with an isolated HOME, so the
+developer's own history file is never touched. Unlike build/record.py, assert is 1 run 1
+line: no run_id is minted, and the row carries no defaults beyond what the payload supplies
+plus generated_at.
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "record.py"
+
+# The keys an assert run's row carries: the gate verdict, its per-condition reasons, the
+# build/tests columns, the scope mode, the per-severity issue counts, and the dropped-findings
+# count, plus the recorder's own generated_at.
+ROW_FIELDS = {
+    "gate",
+    "gate_reason",
+    "build",
+    "tests",
+    "mode",
+    "issue_counts",
+    "dropped_findings",
+    "generated_at",
+}
+
+PAYLOAD = {
+    "gate": "Ready",
+    "gate_reason": ["build pass", "tests pass", "0 issues"],
+    "build": "pass",
+    "tests": "pass",
+    "mode": "diff",
+    "issue_counts": {"critical": 0, "high": 0, "medium": 0, "low": 0},
+    "dropped_findings": 0,
+}
+
+
+def loaded(text: str) -> dict[str, object]:
+    """A parsed JSON object. Anything else fails the test here rather than downstream."""
+    value = cast("object", json.loads(text))
+    assert isinstance(value, dict)
+    return cast("dict[str, object]", value)
+
+
+class CliTest(unittest.TestCase):
+    def _run(self, payload: object, home: str) -> subprocess.CompletedProcess[str]:
+        # PATH="" keeps the run off any git binary, so nothing the script resolves
+        # depends on the checkout the test happens to run in.
+        env = {"HOME": str(home), "PATH": ""}
+        return subprocess.run(
+            [sys.executable, str(SCRIPT)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def _lines(self, path: Path) -> list[dict[str, object]]:
+        return [loaded(line) for line in path.read_text().splitlines() if line.strip()]
+
+    def test_a_payload_on_stdin_appends_exactly_one_line_to_assert_runs_jsonl(self) -> None:
+        """T-001: a payload on stdin appends exactly one line to assert-runs.jsonl."""
+        with tempfile.TemporaryDirectory() as home:
+            first = self._run(PAYLOAD, home)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            out_path = Path(str(loaded(first.stdout)["path"]))
+            self.assertEqual(out_path.name, "assert-runs.jsonl")
+            self.assertEqual(len(self._lines(out_path)), 1)
+
+            second = self._run(PAYLOAD, home)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertEqual(
+                str(loaded(second.stdout)["path"]),
+                str(out_path),
+                "the file name is fixed, so a second run appends instead of writing beside it",
+            )
+            self.assertEqual(
+                len(self._lines(out_path)),
+                2,
+                "assert is 1 run 1 line, so each call appends its own line rather than "
+                "joining a prior one",
+            )
+
+    def test_the_appended_line_carries_the_full_row_field_set(self) -> None:
+        """T-002: the appended line carries gate, gate_reason, build, tests, mode, the
+        per-severity issue counts, dropped_findings and generated_at."""
+        with tempfile.TemporaryDirectory() as home:
+            result = self._run(PAYLOAD, home)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            row = self._lines(Path(str(loaded(result.stdout)["path"])))[0]
+            self.assertEqual(ROW_FIELDS - set(row.keys()), set())
+            self.assertEqual(row["gate"], "Ready")
+            self.assertEqual(row["gate_reason"], ["build pass", "tests pass", "0 issues"])
+            self.assertEqual(row["build"], "pass")
+            self.assertEqual(row["tests"], "pass")
+            self.assertEqual(row["mode"], "diff")
+            self.assertEqual(row["issue_counts"], {"critical": 0, "high": 0, "medium": 0, "low": 0})
+            self.assertEqual(row["dropped_findings"], 0)
+            self.assertIsInstance(row["generated_at"], str)
+            self.assertTrue(cast("str", row["generated_at"]).endswith("Z"))
+
+    def test_an_unparseable_payload_exits_1_and_writes_nothing(self) -> None:
+        """T-003: an unparseable payload exits 1 and writes nothing."""
+        with tempfile.TemporaryDirectory() as home:
+            env = {"HOME": home, "PATH": ""}
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT)],
+                input="not json",
+                capture_output=True,
+                text=True,
+                env=env,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertEqual(result.stdout, "")
+            self.assertFalse((Path(home) / ".claude" / "history" / "assert-runs.jsonl").exists())
+
+
+if __name__ == "__main__":
+    _ = unittest.main()


### PR DESCRIPTION
## What & Why

assert の 1 実行が 1 行の記録として残り、その行から「issues だけで NotReady になり、その issue が low だけだった run」を数えられる。数える対象から漏れた finding の件数も同じ行に残る。

これまで assert の実行結果は都度の出力にしか残らず、gate の傾向や severity 分布を後から集計する手段がなかった。build.js の recordRun と同じ形で、assert.js にも履歴記録を追加した。

## Review focus

- `workflows/assert.js` の `recordRun`(履歴 1 行を組み立てて record.py へ渡す本体)と、`try` 内で `const` だった `challengeStalled`/`auditDegraded` を outer-scope の `let` に変えた箇所(finally からの早期 throw 時にも記録できるようにするための変更)
- `workflows/assert/tests/assert.record.seam.test.js` の T-016(assert.js の recordRun から実際の record.py までを通しで検証する継ぎ目テスト)

## Changes

- `mergeIssues` の戻り値を配列から `{ issues, dropped }` に変更し、`if (!sev) continue;` で捨てていた finding の件数を戻り値の主経路に載せた
- `recordRun` を `finally` 内で呼び、try 内の早期 throw でも記録が残るようにした
- recorder 自体が例外なく解決しつつパスを返さない場合は記録漏れを log に残し、run 自体は止めない

## Design Decisions

- 記録のペイロード組み立ては assert.js 側で完結させ、record.py はそれを検証してそのまま追記するだけに留めた(build.js の record.py との対称性を優先し、assert 固有のスキーマ知識を record.py に持たせない)

## How to Test

1. `node --test workflows/assert/tests/*.test.js`
2. `python3 workflows/assert/tests/record_test.py`
3. いずれも全件 pass すること


---

_下は build workflow の自動検証結果。plan との突合までで、コードの欠陥を探すレビューはしていない。PR の本筋からは外れるので任意だが、status 行の逸脱件数が非ゼロなら見る。_

Closes #424

<details>
<summary><code>verify tests=pass gates=pass</code> · <code>scope-deviations 1</code> · <code>missing-tests 0</code> · <code>conformance 3</code> · <code>structure 2</code></summary>

**Plan スコープ外の変更ファイル**
- `workflows/assert/tests/_fixtures.js`

**Issue 適合性 (独立レビュー)**
- `[medium] missing` Ready ゲートを通過したランがレコード行をちょうど1行追加することを検証するテストは存在しない。T-012 と T-016 は issues が存在する(NotReady)ランのみを実行し、T-013 はゲート "Ready" に到達するが result.gate とログのみを確認し、recordCallsOf(calls).length は一度も確認しない。finally ブロックの呼び出し箇所により実運用では成立しやすいと考えられる。しかし Testing Decisions の条項は Ready 側の検証を明示的に求めており、それを行うテストはない。
  `workflows/assert/tests/assert.degradation.test.js:T-012, T-013, T-016` · spec: この issue における「良い」の定義: Ready の run と NotReady の run の両方で、記録が 1 行ずつ増えること
- `[medium] wrong` recordRun の fail-open 処理は、record-label の agent 呼び出しが解決したがパスを返さない場合(written.path が空)にのみ対応する。`await agent(...)` 呼び出し自体はどの try/catch にもラップされておらず、それが throw すると例外は `finally` ブロックの外へ捕捉されずに伝播し、ログを残して継続する代わりにランを停止させる。T-013 は「recorder が何も返さない」失敗モードのみをテストし、recorder が throw するケースは扱わない。差分内のどのテストも record label 自体の throw ケースを網羅していない(T-014 の throw は codex-review ラベルに対するものである)。
  `workflows/assert.js:340-386 (recordRun), workflows/assert.js:696 (await recordRun() in finally)` · spec: 記録の失敗は assert を止めず、記録できなかったことが log に出る
- `[low] scope_creep` U-001 と U-003 は変更ファイルとして assert.degradation.test.js のみを、U-004 は assert.record.seam.test.js のみを列挙している。_fixtures.js はどのユニットのファイル一覧にも記載のない新規共有ヘルパーモジュールで、bootOk/recordCallsOf/recordPayloadOf を共有するために両テストファイルからインポートされている。これは妥当な抽出である(BOUNDARIES.md は呼び出し箇所が2以上になった時点でのヘルパー化を許容する)が、Plan が列挙した範囲を超えるファイルレベルのスコープ追加である。
  `workflows/assert/tests/_fixtures.js (untracked)` · spec: files: `workflows/assert.js`, `.ja/workflows/assert.js`, `workflows/assert/tests/assert.degradation.test.js`

**参照モジュールからの構造逸脱**
- `[convention]` 参照テストファイルは、record.py の `if not isinstance(loaded, dict)` 分岐を検証するため、パース可能だが非オブジェクトなペイロード(例: JSON 配列)の専用ケースを、パース不能な JSON のケースとは別に持つ。新規の workflows/assert/record.py も同じ isinstance-dict チェックをそのまま持つ。しかし workflows/assert/tests/record_test.py はパース不能な JSON のケース(test_an_unparseable_payload_exits_1_and_writes_nothing)しかテストしておらず、パース可能だが非オブジェクトなケースに対応するテストがない。
  `workflows/assert/tests/record_test.py:1-132` · ref: workflows/build/tests/record_test.py::test_non_object_payload_exits_1_and_writes_nothing
- `[naming]` 参照テストファイルでは各メソッド名は短い動詞句(test_appends_one_line_per_run)であり、T-NNN の条件/期待結果の記述は docstring 内に一度だけ存在する。新規ファイルのメソッド名は、同等の docstring に加えて、識別子自体にも記述全体を再度記載している(test_a_payload_on_stdin_appends_exactly_one_line_to_assert_runs_jsonl, test_the_appended_line_carries_the_full_row_field_set)。これにより、参照ファイルでは1箇所に留めている記述が2箇所に重複している。
  `workflows/assert/tests/record_test.py:67,85,121` · ref: workflows/build/tests/record_test.py::test_appends_one_line_per_run / test_appended_line_carries_every_row_field / test_unparseable_payload_exits_1_and_writes_nothing

**異常 (Red 未確認)**
- U-001 (scope-cut): workflows/assert/tests/record_test.py、および workflows/build/record.py の stdin/stdout + $HOME/.claude/history/ パターンをミラーする workflows/assert/*.py の履歴記録スクリプトは作成しなかった。理由は、これが U-001 が明記した契約(WORKFLOWS.md に基づく戻り値のみの degradation 記録)の範囲外であり、対象の3ファイルにも含まれず、T-010/T-011 でも行使されないためである。そのため、与えられた通りに実行するとテストコマンドの python3 の枝は「No such file or directory」で失敗する。
- U-004 (no-red): T-016 はすでに成立している。これは、U-002 の record.py がペイロードをそのまま複写し、U-003 の assert.js の recordRun が、戻り値の `issues` フィールドと同じ `issues` クロージャ変数から issue_counts を計算しているためであり、このユニットが規定する継ぎ目はすでにエンドツーエンドで配線済みである。
  <details><summary>根拠 6 件</summary>

  - node --test workflows/assert/tests/*.test.js: 19/19 pass including T-016 (workflows/assert/tests/assert.record.seam.test.js:84)
  - python3 workflows/assert/tests/record_test.py: 3/3 pass (OK)
  - T-016's own assertion is non-empty and independently derived: tallyBySeverity(result.issues) (assert.record.seam.test.js:78-82) is computed by the test itself from the workflow's returned issues, not by re-calling assert.js's issueCounts logic, so it is not a self-referential no-op check
  - T-016 exercises the real seam per contract: it calls runWorkflow(assertJs,...) (the real assert.js) and spawnSync('python3', [recordPy], ...) (the real record.py), per assert.record.seam.test.js:23-40,90-100
  - Mutation test: edited workflows/assert.js line 358 issue_counts: issueCounts -> issue_counts: {} via Edit tool, reran `node --test workflows/assert/tests/assert.record.seam.test.js`, T-016 failed with AssertionError expected {high:2,medium:1} actual {} — confirms the test is sensitive to a real break in the seam, not vacuously passing
  - Reverted workflows/assert.js via Edit tool back to issue_counts: issueCounts; reran full suite (node --test + python3 record_test.py), both green again; `git status --porcelain` shows only the untracked target test file, no other diff

  </details>

</details>
