### PR TITLE
[Feature] reviewer-prompt の Severity 欠落を直し、routing との整合を検査する

### DIFF
--- a/.ja/agents/reviewers/reviewer-prompt.md
+++ b/.ja/agents/reviewers/reviewer-prompt.md
@@ -105,3 +105,4 @@ reviewer エージェント (`agents/reviewers/`) の必須セクション: titl
 | ---------- | ----------------------------------------------- |
 | Prefix     | PQ                                              |
 | カテゴリ   | token-efficiency / structure / format / clarity |
+| Severity   | high / medium / low                             |

--- a/agents/_lib/tests/calibration-wiring.test.js
+++ b/agents/_lib/tests/calibration-wiring.test.js
@@ -90,3 +90,34 @@ test("the code examples match between ja and en", () => {
   assert.equal(ja.length, en.length, "the code block counts match");
   ja.forEach((block, i) => assert.equal(block, en[i], `code block ${i + 1} matches`));
 });
+
+// A routed reviewer's findings are validated against audit.js's findingsSchema, whose severity
+// enum is the one finding-schema.md § Base Fields names (#426). A reviewer outside ROUTING
+// answers to another caller's schema, so the rule does not reach it. Where the row sits goes
+// unchecked: conformance carries it in its output template rather than an Output table.
+const routedReviewers = () => {
+  const source = readFileSync(join(root, "workflows", "audit.js"), "utf8");
+  const block = source.match(/const ROUTING = \{([\s\S]*?)\n\};/);
+  assert.ok(block, "audit.js declares a ROUTING table");
+  return new Set([...block[1].matchAll(/"([a-z-]+)"/g)].map((m) => m[1]));
+};
+
+// DR-0078 has blast_radius replace severity for reviewer-resilience, so either names the scale.
+const SEVERITY_ROW = /^\|\s*(Severity|blast_radius)\s*\|/m;
+
+test("every reviewer audit routes to states the severity scale it answers on", () => {
+  const offenders = [];
+  const routed = routedReviewers();
+  for (const lang of Object.keys(sides)) {
+    for (const name of routed) {
+      const file = join(sides[lang].rev, `reviewer-${name}.md`);
+      const doc = readFileSync(file, "utf8");
+      if (!SEVERITY_ROW.test(doc)) offenders.push(`${lang}: reviewer-${name}`);
+    }
+  }
+  assert.deepEqual(
+    offenders,
+    [],
+    `a routed reviewer must name its severity scale:\n${offenders.join("\n")}`,
+  );
+});

--- a/agents/reviewers/reviewer-prompt.md
+++ b/agents/reviewers/reviewer-prompt.md
@@ -105,3 +105,4 @@ Follow ~/.claude/agents/_lib/finding-schema.md. Skip files whose type does not m
 | ---------- | ----------------------------------------------- |
 | Prefix     | PQ                                              |
 | Categories | token-efficiency / structure / format / clarity |
+| Severity   | high / medium / low                             |


### PR DESCRIPTION
## What & Why

audit が起動する reviewer は、返した finding が `findingsSchema` の severity enum で検証される。`reviewer-prompt` はその ROUTING に入っているのに、Output 表が Prefix と Categories しか持たず、答えるべき尺度を伝えられないまま起動されていた。

## Review focus

- **検査の範囲を ROUTING に絞った判断**。`audit.js` の `ROUTING` を読み、そこに載る reviewer だけを対象にする。外にある reviewer (conformance / causation / readability) は別の呼び出し元の schema に答えるので、この規約は届かない
- **行の位置を見ない判断**。`reviewer-conformance.md:59` は Output 表でなく出力テンプレート側に Severity 行を持ち、`reviewer-resilience` は `blast_radius` で置換する (DR-0078)。書く場所は reviewer ごとに違うが、尺度を述べている点は変わらない

## Changes

- 値は `finding-schema.md` § Base Fields と同じ high, medium, low。一覧を再掲せず同じ値を書く形は、既存の reviewer の Output 表に倣った

## Scope

- Not included: reviewer-conformance の出力契約。issue 起票時は対象 2 本と書いたが、ROUTING を確認して 1 本に戻した。conformance は audit の reviewer ではなく `build.js` の Verify 段が `CONFORMANCE_SCHEMA` で起動する
- Not included: reviewer-resilience の blast_radius。DR-0078 の決定

## How to Test

1. `node --test agents/_lib/tests/calibration-wiring.test.js` を実行し、5 件とも pass することを確認する
2. `reviewer-prompt.md` から Severity 行を消すと落ちることを確認する
3. `audit.js` の ROUTING に Severity 行を持たない reviewer を足すと落ちることを確認する

## Related

- Closes #426
- #374 の Backlog candidates から切り出したもの
