### PR TITLE
wrapper skill の H1 を skill 名へ揃え、規約に書く

### DIFF
--- a/.ja/rules/conventions/SKILLS.md
+++ b/.ja/rules/conventions/SKILLS.md
@@ -20,6 +20,15 @@ paths:
 | false          | Agent 専用 | `use-context-<agent>` | use-context-reviewer-security                 |
 | false          | Workflow   | `use-workflow-<noun>` | use-workflow-tdd-cycle, use-workflow-pageshot |
 
+## H1
+
+読み手が開いた skill を、人が打つものかモデルだけが辿る wrapper かで見分けられるようにする。
+
+| user-invocable | H1                     | 例                                |
+| -------------- | ---------------------- | --------------------------------- |
+| true (既定)    | `/<name>` で始める     | `# /issue - GitHub Issue Generation` |
+| false          | skill 名そのもの       | `# use-cli-scout`                 |
+
 ## ディレクトリ構造
 
 すべてのスキルは `skills/` 直下に置き、共有フラグメントは `_lib/` 直下に置く。

--- a/.ja/skills/transcribe/SKILL.md
+++ b/.ja/skills/transcribe/SKILL.md
@@ -5,7 +5,7 @@ when_to_use: .xlsx / .xls / .ods ファイルのパスが渡された, Excel の
 allowed-tools: Bash(node:*) Read
 ---
 
-# transcribe
+# /transcribe - スプレッドシート読み取り
 
 Read ツールは xlsx を開けない。このリポジトリに入れた hucre をライブラリとして使い、シートを読む。
 

--- a/.ja/skills/use-context-reviewer-readability/SKILL.md
+++ b/.ja/skills/use-context-reviewer-readability/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# 可読性レビュー
+# use-context-reviewer-readability
 
 しきい値は、作業記憶や 1 画面集中といった認知限界と、McCabe complexity のような確立されたメトリクスに基づく。下表は推奨値で、検出表はそれを超えた全件でなく報告に値する逸脱だけを挙げる。関数引数の推奨は 3、検出は 5 超。
 

--- a/.ja/skills/use-context-reviewer-security/SKILL.md
+++ b/.ja/skills/use-context-reviewer-security/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# セキュリティ レビュー
+# use-context-reviewer-security
 
 ## 検出 (OWASP Top 10)
 

--- a/.ja/skills/use-context-reviewer-silence/SKILL.md
+++ b/.ja/skills/use-context-reviewer-silence/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# サイレント失敗レビュー
+# use-context-reviewer-silence
 
 ## 検出
 

--- a/.ja/skills/use-context-reviewer-testability/SKILL.md
+++ b/.ja/skills/use-context-reviewer-testability/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# テスト容易性レビュー
+# use-context-reviewer-testability
 
 ## 検出
 

--- a/.ja/skills/use-context-root-cause-analysis/SKILL.md
+++ b/.ja/skills/use-context-root-cause-analysis/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 user-invocable: false
 ---
 
-# 根本原因分析
+# use-context-root-cause-analysis
 
 ## 原則
 

--- a/.ja/skills/use-workflow-pageshot/SKILL.md
+++ b/.ja/skills/use-workflow-pageshot/SKILL.md
@@ -7,7 +7,7 @@ model: opus
 user-invocable: false
 ---
 
-# use-workflow-pageshot - PR スクリーンショット/動画ヘルパー
+# use-workflow-pageshot
 
 ## 入力
 

--- a/.ja/skills/use-workflow-tdd-cycle/SKILL.md
+++ b/.ja/skills/use-workflow-tdd-cycle/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 user-invocable: false
 ---
 
-# TDD サイクル
+# use-workflow-tdd-cycle
 
 公開 API を通して振る舞いをテストする。Mock はシステム境界でのみ。
 

--- a/rules/conventions/SKILLS.md
+++ b/rules/conventions/SKILLS.md
@@ -20,6 +20,15 @@ Name a skill after the operation it performs. Replace generic names like helper,
 | false          | Agent-only | `use-context-<agent>` | use-context-reviewer-security                 |
 | false          | Workflow   | `use-workflow-<noun>` | use-workflow-tdd-cycle, use-workflow-pageshot |
 
+## H1
+
+The H1 tells a reader which kind of skill they opened: one a person types, or a wrapper only the model reaches.
+
+| user-invocable | H1                            | Example                              |
+| -------------- | ----------------------------- | ------------------------------------ |
+| true (default) | Opens with `/<name>`          | `# /issue - GitHub Issue Generation` |
+| false          | The skill's own name          | `# use-cli-scout`                    |
+
 ## Directory structure
 
 All skills live directly under `skills/`, and shared fragments under `_lib/`.

--- a/skills/transcribe/SKILL.md
+++ b/skills/transcribe/SKILL.md
@@ -5,7 +5,7 @@ when_to_use: a path to a .xlsx / .xls / .ods file was given, read an Excel file,
 allowed-tools: Bash(node:*) Read
 ---
 
-# transcribe
+# /transcribe - Spreadsheet Reader
 
 The Read tool cannot open an xlsx. Use hucre, installed in this repository, as a library to read the sheets.
 

--- a/skills/use-context-reviewer-readability/SKILL.md
+++ b/skills/use-context-reviewer-readability/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# Readability Review
+# use-context-reviewer-readability
 
 Thresholds are based on cognitive limits such as working memory and one-screen focus, and established metrics such as McCabe complexity. The table below carries the recommended values; the detection table lists the deviations worth reporting rather than every crossing of them. Arguments are recommended at 3 and detected above 5.
 

--- a/skills/use-context-reviewer-security/SKILL.md
+++ b/skills/use-context-reviewer-security/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# Security Review
+# use-context-reviewer-security
 
 ## Detection (OWASP Top 10)
 

--- a/skills/use-context-reviewer-silence/SKILL.md
+++ b/skills/use-context-reviewer-silence/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# Silent Failure Review
+# use-context-reviewer-silence
 
 ## Detection
 

--- a/skills/use-context-reviewer-testability/SKILL.md
+++ b/skills/use-context-reviewer-testability/SKILL.md
@@ -8,7 +8,7 @@ context: fork
 user-invocable: false
 ---
 
-# Testability Review
+# use-context-reviewer-testability
 
 ## Detection
 

--- a/skills/use-context-root-cause-analysis/SKILL.md
+++ b/skills/use-context-root-cause-analysis/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 user-invocable: false
 ---
 
-# Root Cause Analysis
+# use-context-root-cause-analysis
 
 ## Principle
 

--- a/skills/use-workflow-pageshot/SKILL.md
+++ b/skills/use-workflow-pageshot/SKILL.md
@@ -7,7 +7,7 @@ model: opus
 user-invocable: false
 ---
 
-# use-workflow-pageshot - PR Screenshot/Video Helper
+# use-workflow-pageshot
 
 ## Input
 

--- a/skills/use-workflow-tdd-cycle/SKILL.md
+++ b/skills/use-workflow-tdd-cycle/SKILL.md
@@ -7,7 +7,7 @@ context: fork
 user-invocable: false
 ---
 
-# TDD Cycle
+# use-workflow-tdd-cycle
 
 Test behavior via public API. Mock only at system boundaries.
 

--- a/tests/skill-h1.test.js
+++ b/tests/skill-h1.test.js
@@ -1,0 +1,61 @@
+// SKILLS.md § H1 settles the two forms. Nothing enforced them, and the use-context-* /
+// use-workflow-* skills drifted to free-form titles while use-cli-* held (#79 #80 #81 #83 #84
+// #86 #89).
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const LANGS = ["ja", "en"];
+const at = (lang, ...parts) => join(root, ...(lang === "ja" ? [".ja"] : []), ...parts);
+
+// user-invocable defaults to true, so only an explicit false makes a skill a wrapper.
+const isWrapper = (doc) => /^user-invocable:\s*false\s*$/m.test(doc);
+const h1Of = (doc) => (doc.match(/^# (.+)$/m) || [])[1] || "";
+
+const skillDocs = async (lang) => {
+  const dir = at(lang, "skills");
+  const names = (await readdir(dir, { withFileTypes: true }))
+    .filter((e) => e.isDirectory() && !e.name.startsWith("_"))
+    .map((e) => e.name);
+  const out = [];
+  for (const name of names) {
+    try {
+      out.push({ name, doc: await readFile(join(dir, name, "SKILL.md"), "utf8") });
+    } catch {
+      // A directory with no SKILL.md is not a skill; the naming rules do not reach it.
+    }
+  }
+  return out;
+};
+
+const offendersWhere = async (select, holds) => {
+  const out = [];
+  for (const lang of LANGS) {
+    for (const { name, doc } of await skillDocs(lang)) {
+      if (!select(doc)) continue;
+      const h1 = h1Of(doc);
+      if (!holds(h1, name)) out.push(`${lang}: ${name} -> "${h1}"`);
+    }
+  }
+  return out;
+};
+
+test("a wrapper skill's H1 is its own name", async () => {
+  const offenders = await offendersWhere(isWrapper, (h1, name) => h1 === name);
+  assert.deepEqual(offenders, [], `a wrapper's H1 is its bare name:\n${offenders.join("\n")}`);
+});
+
+test("a user-invocable skill's H1 opens with its slash command", async () => {
+  const offenders = await offendersWhere(
+    (doc) => !isWrapper(doc),
+    (h1, name) => h1.startsWith(`/${name}`),
+  );
+  assert.deepEqual(
+    offenders,
+    [],
+    `a user-invocable skill's H1 opens with a slash and its name:\n${offenders.join("\n")}`,
+  );
+});


### PR DESCRIPTION
## What & Why

skill の H1 から、人が打つものかモデルだけが辿る wrapper かを見分けられるようになる。

`use-cli-*` は H1 に skill 名を置いているが、`use-context-*` と `use-workflow-*` は `# TDD Cycle` のような自由記述だった。`SKILLS.md` は命名を定めていて H1 には触れておらず、慣行だけが実装側にあったため、片方の family だけが取り残されていた。

## Review focus

- **形の根拠**。`SKILLS.md` に H1 の規定は無かったので、実装側の慣行を正とした。`/challenge` `/issue` など user-invocable 群がスラッシュ形、`use-cli-scout` など wrapper が素の名前
- **`transcribe` の変更**。7 件の対象外だが逆向きに外れていた。user-invocable なのに H1 が skill 名だったのでスラッシュ形へ直した。テストを全 skill 走査にした時点で出てきたもので、当初の測定では拾えていない

## Changes

- 検査は `user-invocable` の値で形を選ぶ。既定は true なので、明示的な false だけが wrapper

## Scope

- Not included: H1 のタイトル部分の文言。スラッシュ形の `- Title` 以降は各 skill の裁量に残す
- Not included: agent 側の H1。`SUBAGENT.md` が別に定めており、18 本すべて適合済み

## How to Test

1. `node --test tests/skill-h1.test.js` を実行し、2 件とも pass することを確認する
2. `skills/use-cli-scout/SKILL.md` の H1 を自由記述へ戻すと落ちることを確認する
3. `node --test "tests/*.test.js"` で全件 pass することを確認する

## Related

- Closes #79, #80, #81, #83, #84, #86, #89
