### PR TITLE
[Feature] テスト harness の parallel を本番の never reject 契約へ揃える

### DIFF
--- a/workflows/_lib/run-workflow.js
+++ b/workflows/_lib/run-workflow.js
@@ -140,11 +140,21 @@ export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
     calls.workflow.push({ name, args: hostArgs });
     return stubs.workflow ? stubs.workflow(name, hostArgs) : undefined;
   };
+  // The production contract both of these mirror: a thunk or stage that throws is left as null
+  // at its own index, no compaction, no reordering, and the call itself never rejects.
+  // Promise.all rejected the whole call, so a script whose thunk throws failed under test and
+  // ran in production (#434).
   const parallel = async (tasks) =>
-    Promise.all(tasks.map((t) => (typeof t === "function" ? t() : t)));
-  // The default mirrors the production runtime contract: every item flows through all
-  // stages as (prev, originalItem, index), and an item whose stage throws is left as
-  // null at its original position (no compaction, no reordering).
+    Promise.all(
+      tasks.map(async (t) => {
+        try {
+          return await (typeof t === "function" ? t() : t);
+        } catch {
+          return null;
+        }
+      }),
+    );
+  // Each item flows through all stages as (prev, originalItem, index).
   const pipeline = async (items, ...stages) => {
     if (stubs.pipeline) return stubs.pipeline(items, ...stages);
     return Promise.all(

--- a/workflows/_lib/tests/run-workflow.test.js
+++ b/workflows/_lib/tests/run-workflow.test.js
@@ -148,3 +148,27 @@ test("T-012 setTimeout resumes after waiting, and clearTimeout cancels that resu
     },
   );
 });
+
+// Nothing pinned parallel against the contract, so it drifted to Promise.all and rejected (#434).
+test("T-013 a parallel whose thunk throws resolves rather than rejecting", async () => {
+  const source = `
+    const out = await parallel([() => 1, () => { throw new Error("boom"); }, () => 3]);
+    return { out };
+  `;
+  await withScript(source, async (path) => {
+    const { result } = await runWorkflow(path, { args: {} });
+    assert.deepEqual(result.out, [1, null, 3], "the throwing thunk leaves null at its own index");
+  });
+});
+
+// The contract draws no line between a throw and a returned rejection.
+test("T-014 a parallel whose thunk returns a rejected promise leaves null at that index", async () => {
+  const source = `
+    const out = await parallel([() => Promise.reject(new Error("boom")), () => 2]);
+    return { out };
+  `;
+  await withScript(source, async (path) => {
+    const { result } = await runWorkflow(path, { args: {} });
+    assert.deepEqual(result.out, [null, 2]);
+  });
+});

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -76,12 +76,9 @@ test("result.adversarial shows the stage as not run with a diagnostic reason whe
   );
 });
 
-test("result.adversarial shows a stall distinct from zero tests when the triage block throws", async () => {
-  // testRunP and adversarialP already carry .catch(() => null) on the agent side, so
-  // reproducing a block throw uses the triage verdict agent (label "triage:*"), which is
-  // awaited through parallel with no catch. The harness's parallel rejects when a thunk throws,
-  // so the IIFE throws as a whole and the outer .catch(() => null) folds triageRes to null.
-  // This pins that the stall marker survives in the summary for that entire throw class.
+test("a triage agent that throws promotes its test fail-close rather than excluding it", async () => {
+  // parallel resolves the throw to null (#434), so the IIFE does not throw and assert.js reads
+  // verdicts[i] as null, taking its documented fail-close branch.
   const failTest = {
     test_name: "t1",
     target: "src/foo.js:3",
@@ -94,14 +91,12 @@ test("result.adversarial shows a stall distinct from zero tests when the triage 
     if (label && label.startsWith("triage:")) throw new Error("triage agent crashed");
     return makeAgent({ ran: true, tests: [failTest] })(prompt, opts);
   };
-  const thrownRun = await runWorkflow(assertJs, { args: {}, stubs: { agent: throwingAgent } });
-  const adv = thrownRun.result && thrownRun.result.adversarial;
-  assert.ok(adv, "result.adversarial comes back on a throw too");
-  assert.equal(
-    adv.stall,
-    "triage stage threw / no output",
-    "a throw in the triage block is recorded as a stall, distinct from a clean zero",
-  );
+  const run = await runWorkflow(assertJs, { args: {}, stubs: { agent: throwingAgent } });
+  const adv = run.result && run.result.adversarial;
+  assert.ok(adv, "result.adversarial comes back with the triage verdict missing");
+  assert.equal(adv.promoted, 1, "the untriaged failure is promoted rather than dropped");
+  assert.equal(adv.excluded, 0, "nothing is excluded on a verdict nobody produced");
+  assert.equal(adv.stall, undefined, "the block did not throw, so no stall marker is set");
 });
 
 // U-002: on a run where the nested workflow("audit") failed open (challenge_ran=false), the
@@ -443,15 +438,17 @@ test("T-013 a recorder returning nothing leaves the gate unchanged and names the
 
 test("T-014 a throw inside the try still leaves a row for that run", async () => {
   const recordCalls = [];
+  // synthesize is awaited outside parallel, so its throw propagates; a throw inside a parallel
+  // thunk resolves to null instead and never reaches the try's boundary (#434).
   const throwingAgent = (prompt, opts) => {
     const label = opts && opts.label;
-    if (label === "codex-review") throw new Error("codex review crashed");
+    if (label === "synthesize") throw new Error("synthesize crashed");
     if (label === "record") recordCalls.push(prompt);
     return makeAgent({ ran: true, tests: [] })(prompt, opts);
   };
   await assert.rejects(
     () => runWorkflow(assertJs, { args: {}, stubs: { agent: throwingAgent } }),
-    /codex review crashed/,
+    /synthesize crashed/,
     "the throw inside the try still propagates out of the workflow",
   );
   assert.equal(


### PR DESCRIPTION
## What & Why

thunk が throw する workflow が、テストで落ちて本番で通る状態を解消する。

harness の `parallel` は `Promise.all` で、1 つでも throw すれば呼び出し全体が reject していた。本番の契約は「throw した thunk は結果配列のその位置で null に解決し、呼び出し自体は reject しない」で、同じファイルの `pipeline` は既にその形を写している。`parallel` にだけ写しが無かった。

## Review focus

- **既存テスト 2 件を書き直した判断**。どちらも harness の誤った契約に依存しており、本番では成立しない主張を pin していた。詳細は下記
- `parallel` の外にある agent と中にある agent の区別。実測で `bootstrap` / `synthesize` / `cleanup` は throw が伝播し、`codex-review` / `triage:*` / `record` は伝播しない

## Changes

- `assert.js` は 1 行も変えていない。null verdict の fail-close は元から正しく書かれていた。壊れていたのは harness とテストだけ

## 書き直したテスト 2 件

1 件目は、コメント自身が harness 依存を書いていた。

> The harness's parallel rejects when a thunk throws, so the IIFE throws as a whole and the outer `.catch(() => null)` folds triageRes to null.

本番では `parallel` が reject しないので IIFE は throw せず、`triageRes` は実体を持つ。`assert.js` は `verdicts[i]` が null の fail-close 分岐を通る。stall マーカーが立つという主張は本番で一度も真でなかったので、fail-close の promote を見る形へ変えた。

2 件目 (T-014) は `codex-review` を throw させていたが、これは `parallel` の thunk の中で伝播しない。`parallel` の外にある `synthesize` へ変えた。

## Scope

- Not included: `toHostRealmError` の復元 (#326)。本番の `parallel` が throw を握り潰す以上 AggregateError はホスト境界へ到達しないので、#326 の実測はこの PR が landed してから行う
- Not included: 本番の `parallel` の挙動そのもの

## How to Test

1. `node --test workflows/_lib/tests/run-workflow.test.js` を実行し、T-013 と T-014 が pass することを確認する
2. `parallel` を `Promise.all` に戻すと、この 2 件と assert 側の 2 件が落ちることを確認する
3. `node --test "workflows/**/tests/*.test.js"` で全件 pass することを確認する

## Related

- Closes #434
- #326 の critic-design が派生として検出した
