### PR TITLE
[Feature] sqliConcat を戻し、脆弱 fixture は overrides で対象外にする

### DIFF
--- a/.guardrails.json
+++ b/.guardrails.json
@@ -1,7 +1,13 @@
 {
-  "_why": "sqliConcat off: use-context-reviewer-security の意図的な脆弱 fixture 3 本を Write できなくなるため。パス単位の除外は guardrails に存在しない",
   "diffAware": true,
   "rules": {
-    "sqliConcat": false
-  }
+    "sqliConcat": true
+  },
+  "overrides": [
+    {
+      "_why": "security reviewer の blind protocol 用に意図して脆弱に書いた fixture。ここだけ検査を外し、本番コードでは rule を効かせる",
+      "files": ["skills/use-context-reviewer-security/test/cases/**"],
+      "rules": { "sqliConcat": false }
+    }
+  ]
 }


### PR DESCRIPTION
## What & Why

SQL 文字列結合の検査が本番コードで効くようになる。

`sqliConcat` はリポジトリ全体で無効だった。理由は security reviewer の blind protocol 用に意図して脆弱に書いた fixture 3 本で、これを Write できなくなるため。guardrails 側にパス単位の上書きが無く、全体を切るしかなかった。0.22.0 が `overrides` を持つので、fixture のパスだけ外して本番コードでは戻す。

## Review focus

- **`files` の pattern の粒度**。`skills/use-context-reviewer-security/test/cases/**` は fixture ディレクトリ全体を指す。ここより広げると本番コードが漏れ、狭めると fixture の追加のたびに設定を触ることになる
- `_why` の置き場所。元はファイル冒頭にあり「リポジトリ全体で切っている理由」だったが、今は override そのものに付く

## Changes

- 変更は `.guardrails.json` の 1 ファイルのみ。コードには触れていない

## 実測

guardrails 0.22.0 に payload を直接流して確認した。

| 条件 | 結果 |
| --- | --- |
| overrides あり / fixture パス | 素通り。`override disabled rule(s) [sqliConcat] for pattern(s) [...]` を出力 |
| overrides あり / 通常パス | `✗ sqli-concat (guardrails) [HIGH]` で block |
| 対照: overrides 無し / `sqliConcat: true` / 通常パス | block される |
| 対照: 現行の `sqliConcat: false` / 通常パス | block されない |

## Scope

- Not included: 他の rule の override。今回外す必要があったのは `sqliConcat` だけ
- Not included: fixture の内容。意図して脆弱に書いたものなので変えない

## How to Test

1. `skills/use-context-reviewer-security/test/cases/vuln/sql-injection.ts` の全文を同じパスへ Write して block されないことを確認する
2. 同じ内容を `skills/` 配下の別のパスへ Write して block されることを確認する
3. `node --test "tests/*.test.js" ...` で全件 pass することを確認する

## Related

- Closes #378
- guardrails 側の `overrides` は thkt/guardrails#429
