### PR TITLE
fix(workflows): host のエラーを本番と同じ形で script へ渡す

### DIFF
--- a/workflows/_lib/run-workflow.js
+++ b/workflows/_lib/run-workflow.js
@@ -43,6 +43,44 @@ const toHostRealmError = (err) => {
   return err;
 };
 
+// The own properties production leaves on an error it hands to the script, in the order it
+// writes them. Measured 2026-08-22 (#441): the object's prototype is null, so `e instanceof
+// Error` is false there and cause, errors and any custom property are gone. Handing a script
+// the host Error itself would let it branch on instanceof under test and take the other branch
+// in production.
+export const SCRIPT_ERROR_KEYS = ["name", "message", "stack", "toString"];
+
+// A non-Error throw is left as it is: what production does with one was not measured.
+const toScriptRealmError = (err) => {
+  if (!(err instanceof Error)) return err;
+  const supply = {
+    name: err.name,
+    message: err.message,
+    stack: typeof err.stack === "string" ? err.stack : `${err.name}: ${err.message}`,
+    toString: () => `${err.name}: ${err.message}`,
+  };
+  const shim = Object.create(null);
+  for (const key of SCRIPT_ERROR_KEYS) shim[key] = supply[key];
+  return shim;
+};
+
+// Every injected global is a host function called from vm code, so each is a place a host error
+// can reach the script.
+const asProductionThrow =
+  (fn) =>
+  (...callArgs) => {
+    try {
+      const out = fn(...callArgs);
+      return out instanceof Promise
+        ? out.catch((err) => {
+            throw toScriptRealmError(err);
+          })
+        : out;
+    } catch (err) {
+      throw toScriptRealmError(err);
+    }
+  };
+
 // Plain objects and arrays built inside the vm context carry that context's intrinsics
 // (its own Array.prototype, Object.prototype, ...), so a host-side assert.deepStrictEqual
 // sees them as structurally equal but not reference-equal to a host literal and fails.
@@ -129,22 +167,22 @@ export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
   const calls = { agent: [], workflow: [], phase: [] };
   const logs = [];
 
-  const agent = async (prompt, opts = {}) => {
+  const agent = asProductionThrow(async (prompt, opts = {}) => {
     const hostPrompt = rehome(prompt);
     const hostOpts = rehome(opts);
     calls.agent.push({ prompt: hostPrompt, opts: hostOpts });
     return stubs.agent ? stubs.agent(hostPrompt, hostOpts) : undefined;
-  };
-  const workflow = async (name, wfArgs) => {
+  });
+  const workflow = asProductionThrow(async (name, wfArgs) => {
     const hostArgs = rehome(wfArgs);
     calls.workflow.push({ name, args: hostArgs });
     return stubs.workflow ? stubs.workflow(name, hostArgs) : undefined;
-  };
+  });
   // The production contract both of these mirror: a thunk or stage that throws is left as null
   // at its own index, no compaction, no reordering, and the call itself never rejects.
   // Promise.all rejected the whole call, so a script whose thunk throws failed under test and
   // ran in production (#434).
-  const parallel = async (tasks) =>
+  const parallel = asProductionThrow(async (tasks) =>
     Promise.all(
       tasks.map(async (t) => {
         try {
@@ -153,9 +191,10 @@ export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
           return null;
         }
       }),
-    );
+    ),
+  );
   // Each item flows through all stages as (prev, originalItem, index).
-  const pipeline = async (items, ...stages) => {
+  const pipeline = asProductionThrow(async (items, ...stages) => {
     if (stubs.pipeline) return stubs.pipeline(items, ...stages);
     return Promise.all(
       items.map(async (item, index) => {
@@ -170,13 +209,13 @@ export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
         return prev;
       }),
     );
-  };
-  const phase = (title) => {
+  });
+  const phase = asProductionThrow((title) => {
     calls.phase.push(rehome(title));
-  };
-  const log = (message) => {
+  });
+  const log = asProductionThrow((message) => {
     logs.push(rehome(message));
-  };
+  });
 
   // The supply side of PRODUCTION_GLOBALS. budget holds the state of a run with no token
   // target, production's default, so a script branching on budget.total takes the same path

--- a/workflows/_lib/tests/run-workflow.test.js
+++ b/workflows/_lib/tests/run-workflow.test.js
@@ -7,7 +7,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { PRODUCTION_GLOBALS, runWorkflow } from "../run-workflow.js";
+import { PRODUCTION_GLOBALS, SCRIPT_ERROR_KEYS, runWorkflow } from "../run-workflow.js";
 
 // runWorkflow's contract reads the source from a file path (readFileSync), so the script body is
 // written to a temporary file first. Each test uses its own temporary directory so script files
@@ -170,5 +170,48 @@ test("T-014 a parallel whose thunk returns a rejected promise leaves null at tha
   await withScript(source, async (path) => {
     const { result } = await runWorkflow(path, { args: {} });
     assert.deepEqual(result.out, [null, 2]);
+  });
+});
+
+// A stub that throws is the harness's only host-origin error path, and production hands such an
+// error to the script as a null-prototype object carrying SCRIPT_ERROR_KEYS and nothing else.
+test("T-015 an error the harness throws into the script arrives in production's shape", async () => {
+  const source = `
+    try {
+      await agent("x");
+      return { caught: false };
+    } catch (e) {
+      return {
+        caught: true,
+        keys: Object.keys(e),
+        isError: e instanceof Error,
+        prototypeIsNull: Object.getPrototypeOf(e) === null,
+        stringified: e.toString(),
+        name: e.name,
+        message: e.message,
+        hasCause: "cause" in e,
+        code: e.code ?? null,
+      };
+    }
+  `;
+  await withScript(source, async (path) => {
+    const { result } = await runWorkflow(path, {
+      stubs: {
+        agent: () => {
+          const err = new TypeError("stub-failed", { cause: new RangeError("root") });
+          err.code = "E_CUSTOM";
+          throw err;
+        },
+      },
+    });
+    assert.equal(result.caught, true, "the throw reaches the script");
+    assert.deepEqual(result.keys, SCRIPT_ERROR_KEYS, "the own properties are the supplied list");
+    assert.equal(result.isError, false, "instanceof Error is false, as in production");
+    assert.equal(result.prototypeIsNull, true);
+    assert.equal(result.name, "TypeError", "the name crosses");
+    assert.equal(result.message, "stub-failed");
+    assert.equal(result.stringified, "TypeError: stub-failed");
+    assert.equal(result.hasCause, false, "cause does not cross, as in production");
+    assert.equal(result.code, null, "a custom property does not cross, as in production");
   });
 });


### PR DESCRIPTION
## Summary

harness が host のエラーを本物の `Error` のまま script へ渡していた。本番は prototype が null で `name`、`message`、`stack`、`toString` だけを持つオブジェクトに詰め替える (2026-08-22 実測、PR #440)。`catch (e) { e instanceof Error }` を書いた script はテストで true、本番で false になる。テストが本番より緩い向きの食い違い。

## Changes

| 対象 | 内容 |
| --- | --- |
| `SCRIPT_ERROR_KEYS` | 本番が残す own property の一覧を export する。詰め替えと検査の両方がこれを読む |
| `toScriptRealmError` | Error を prototype null のオブジェクトへ詰め替える。`toString()` は `<name>: <message>` を返す |
| `asProductionThrow` | 注入する 6 つのグローバルを定義時に包む。どれも vm から呼ばれる host 関数なので、どれもエラーの入口になる |
| T-015 | stub が throw したエラーを script が catch し、own property と `instanceof` と `toString()` を見る |

## Design Decisions

### 一覧を定数として持つ

`docs/wiki/harness-production-divergence.md` の定型手順 2 が「供給の一覧を実行側の定数として持ち、散文の契約に置かない」、定型手順 3 が「テストはその定数を読んで検査する」と定める。`PRODUCTION_GLOBALS` に前例がある。`SCRIPT_ERROR_KEYS` は詰め替えのループが読み、T-015 が `deepEqual` の期待値として読む。名前を書き写した箇所は無い。

### 呼び出し側でなく定義側で包む

`run(args, agent, workflow, parallel, pipeline, phase, log)` の引数順は `compileFunction` のパラメータ名一覧と手で揃えてある。呼び出し側に 2 つ目の手書きの一覧を並べると、ずれる余地が増える。各グローバルを定義時に 1 回だけ包み、呼び出し側は元のまま。

### 非 Error の throw は通す

本番が非 Error の throw をどう扱うかは測っていない。測った範囲だけを写す。

## Testing

- 破壊検査: `toScriptRealmError` の詰め替えを外して host の Error をそのまま返すと、T-015 だけが落ちる
- 488 テスト緑、oxlint 緑

Closes #441

https://claude.ai/code/session_01WKMAvw3AWjxKTW29eeJeKq
