### PR TITLE
refactor(agent): reviewer-prompt と reviewer-rust の表の後の段落を表の前へ移す

### DIFF
--- a/.ja/agents/reviewers/reviewer-prompt.md
+++ b/.ja/agents/reviewers/reviewer-prompt.md
@@ -18,6 +18,8 @@ background: true
 
 ## スコープ
 
+rules、skills、agents、templates 配下の LLM 向けプロンプトファイルの品質レビュー。
+
 | In Scope                   | Out of Scope                                                  |
 | -------------------------- | ------------------------------------------------------------- |
 | `workflows/*.js`           | 汎用的なコードロジック                                        |
@@ -26,8 +28,6 @@ background: true
 | `skills/*/references/*.md` | コンテンツの正確性 (ドメイン固有)                             |
 | `agents/**/*.md`           | セキュリティ懸念                                              |
 | `templates/**/*.md`        | .ja/ 翻訳 (ルール上、構造のみ対象)                            |
-
-rules、skills、agents、templates 配下の LLM 向けプロンプトファイルの品質レビュー。
 
 ## 解析フェーズ
 
@@ -50,6 +50,8 @@ rules、skills、agents、templates 配下の LLM 向けプロンプトファイ
 
 ### Phase 2: 構造
 
+しきい値は並列項目 3 つ以上。散文での 2 項目は許容。
+
 | パターン                                    | 推奨される構造                  |
 | ------------------------------------------- | ------------------------------- |
 | 一貫した key-value を持つ箇条書きリスト     | key/value 列のテーブル          |
@@ -58,9 +60,15 @@ rules、skills、agents、templates 配下の LLM 向けプロンプトファイ
 | アクションを伴うインライン条件              | 決定テーブル                    |
 | 順序依存性のない番号付きリスト              | テーブル (順序は意味を持たない) |
 
-しきい値は並列項目 3 つ以上。散文での 2 項目は許容。
-
 ### Phase 3: フォーマット準拠
+
+必須セクションは対象ごとに下表で決まる。テンプレート参照による Output は、その節があるものとして扱う。
+
+| 対象                     | 必須セクション                 |
+| ------------------------ | ------------------------------ |
+| reviewer エージェント    | title、Analysis Phases、Output |
+| その他のエージェント種別 | title、Output                  |
+| Skill                    | Input、Execution、Output       |
 
 | チェック             | ルール                                                                                  | 適用先                           |
 | -------------------- | --------------------------------------------------------------------------------------- | -------------------------------- |
@@ -68,10 +76,8 @@ rules、skills、agents、templates 配下の LLM 向けプロンプトファイ
 | Agent frontmatter    | name, description, tools, model (context は推奨)                                        | `agents/**/*.md`                 |
 | Skill frontmatter    | name, description (~/.claude/rules/conventions/SKILLS.md に従う)                        | `skills/*/SKILL.md`              |
 | Workflow degradation | 失敗/欠落 sub-result を喪失粒度で記録 (~/.claude/rules/conventions/WORKFLOWS.md に従う) | `workflows/*.js`                 |
-| セクション完全性     | 必須セクションの存在 (下記参照)                                                         | `agents/*.md`, `skills/SKILL.md` |
+| セクション完全性     | 必須セクション表を満たす                                                                | `agents/*.md`, `skills/SKILL.md` |
 | テーブル整列         | 一貫した列セパレータ、不揃いな行なし                                                    | All                              |
-
-reviewer エージェント (`agents/reviewers/`) の必須セクション: title, Analysis Phases, Output。他のエージェント種別 (generators, teams, architects): title, Output。Skill 必須セクション: Input, Execution, Output。テンプレート参照による Output は許容。
 
 ### Phase 4: 明瞭性
 

--- a/.ja/agents/reviewers/reviewer-rust.md
+++ b/.ja/agents/reviewers/reviewer-rust.md
@@ -35,6 +35,10 @@ Rust コードのみ (`*.rs`, `Cargo.toml`)。Rust 以外は対象外。言語�
 
 ## 関連 reviewer との区別
 
+`let _ = result_value` はこの reviewer (RU2 エラー規律) と reviewer-silence (SF1 catch 相当) の両方から finding を受ける場合があり、相補的であって重複ではない。
+
+allocation のホットパス (`Vec::new()` をタイトループ内、冗長な `String::from`) は reviewer-efficiency の管轄。この reviewer は Rust 固有の慣用句ガイダンスを伴う修正 (例: `with_capacity`、`Cow<str>`、`&'static str`) が必要な場合のみフラグする。
+
 | 観点                              | この reviewer (rust) | reviewer-design                      | reviewer-silence         |
 | --------------------------------- | -------------------- | ------------------------------------ | ------------------------ |
 | レンズ                            | Rust 慣用句的か      | モジュールがインタフェースに見合うか | サイレント障害パターンか |
@@ -45,11 +49,9 @@ Rust コードのみ (`*.rs`, `Cargo.toml`)。Rust 以外は対象外。言語�
 | async 内のブロッキング呼び出し    | 境界違反             | 対象外                               | 対象外                   |
 | スコープ                          | `*.rs` のみ          | 全言語                               | 全言語                   |
 
-`let _ = result_value` はこの reviewer (RU2 エラー規律) と reviewer-silence (SF1 catch 相当) の両方から finding を受ける場合があり、相補的であって重複ではない。
-
-allocation のホットパス (`Vec::new()` をタイトループ内、冗長な `String::from`) は reviewer-efficiency の管轄。この reviewer は Rust 固有の慣用句ガイダンスを伴う修正 (例: `with_capacity`、`Cow<str>`、`&'static str`) が必要な場合のみフラグする。
-
 ## ツール
+
+clippy を先に実行する。reviewer は clippy が拾えない領域 (設計判断、コンテキスト依存の慣用句、SAFETY 根拠の欠落、async 境界) に集中する。
 
 | ツール                                                                                | 用途                                                 |
 | ------------------------------------------------------------------------------------- | ---------------------------------------------------- |
@@ -58,8 +60,6 @@ allocation のホットパス (`Vec::new()` をタイトループ内、冗長な
 | `cargo metadata --format-version=1 --no-deps`                                         | workspace レイアウト、lints 設定の検出               |
 | `cargo tree --workspace --depth 1`                                                    | 直接依存の surface                                   |
 | `ugrep` / `bfs`                                                                       | `.rs` ファイル横断のパターン検索                     |
-
-clippy を先に実行する。reviewer は clippy が拾えない領域 (設計判断、コンテキスト依存の慣用句、SAFETY 根拠の欠落、async 境界) に集中する。
 
 > Note (2026-05-13): Claude Code changelog (`~/.claude/cache/changelog.md` の行 42 / 216 / 2430) によれば、`Bash(ls *)` `Bash(mkdir *)` `Bash(git log:*)` 等の空白入り matcher は prefix match として動作する。先の「空白でトークン化される」主張は scout dogfood で 1 回失敗した観察を過剰一般化したもので、真の原因はおそらくその時点で `settings.json` の allow rule に未登録だったため。`Bash(cargo clippy:*)` (狭いスコープ) も `Bash(cargo:*)` (install/publish 含む広いスコープ) もどちらも有効な syntax で、選択は信頼境界の設計判断であって matcher-parser の制約ではない。
 
@@ -80,6 +80,8 @@ reviewer 直感が外部仕様と矛盾する false-premise findings を防ぐ�
 
 ## finding 前のドキュメントスキャン
 
+これらのどれかに decision rationale が記録されていれば `documented?` を `No` ではなく `Partial` (引用付き) に格下げ。周辺コンテキスト全体が silent な時のみ `No` と断定。
+
 finding を `documented?: No` でフラグする前に、周辺コンテキストで rationale 記録を探す。
 
 | Scope                       | 確認対象                                                                               |
@@ -90,8 +92,6 @@ finding を `documented?: No` でフラグする前に、周辺コンテキス�
 | エラー文 / メッセージ文字列 | `.expect("...")`, `panic!("...")`, `error!("...")`、失敗モードを説明する format string |
 | Test 名                     | `fn test_<検証する仕様>` 形式。テスト名が rationale を記録することが多い               |
 | Test doc comment            | rustdoc 付きテスト関数は不変条件を記述することが多い                                   |
-
-これらのどれかに decision rationale が記録されていれば `documented?` を `No` ではなく `Partial` (引用付き) に格下げ。周辺コンテキスト全体が silent な時のみ `No` と断定。
 
 ## キャリブレーション
 

--- a/agents/reviewers/reviewer-prompt.md
+++ b/agents/reviewers/reviewer-prompt.md
@@ -18,6 +18,8 @@ Detect verbose prose where table form parses cleaner, format non-compliance, and
 
 ## Scope
 
+Quality review for LLM-facing prompt files under rules, skills, agents, and templates.
+
 | In Scope                   | Out of Scope                                                 |
 | -------------------------- | ------------------------------------------------------------ |
 | `workflows/*.js`           | General code logic                                           |
@@ -26,8 +28,6 @@ Detect verbose prose where table form parses cleaner, format non-compliance, and
 | `skills/*/references/*.md` | Content correctness (domain-specific)                        |
 | `agents/**/*.md`           | Security concerns                                            |
 | `templates/**/*.md`        | .ja/ translations (structure-only per rule)                  |
-
-Quality review for LLM-facing prompt files under rules, skills, agents, and templates.
 
 ## Analysis Phases
 
@@ -50,6 +50,8 @@ Quality review for LLM-facing prompt files under rules, skills, agents, and temp
 
 ### Phase 2: Structure
 
+Threshold 3+ parallel items. 2 items in prose is acceptable.
+
 | Pattern                                   | Suggested structure              |
 | ----------------------------------------- | -------------------------------- |
 | Bullet list with consistent key-value     | Table with key/value cols        |
@@ -58,9 +60,15 @@ Quality review for LLM-facing prompt files under rules, skills, agents, and temp
 | Inline conditions with actions            | Decision table                   |
 | Numbered list without ordering dependency | Table (order not semantic)       |
 
-Threshold 3+ parallel items. 2 items in prose is acceptable.
-
 ### Phase 3: Format Compliance
+
+Required sections are settled per target below. An Output given by template reference counts as the section being present.
+
+| Target            | Required sections              |
+| ----------------- | ------------------------------ |
+| Reviewer agent    | title, Analysis Phases, Output |
+| Other agent types | title, Output                  |
+| Skill             | Input, Execution, Output       |
 
 | Check                | Rule                                                                                                   | Applies to                       |
 | -------------------- | ------------------------------------------------------------------------------------------------------ | -------------------------------- |
@@ -68,10 +76,8 @@ Threshold 3+ parallel items. 2 items in prose is acceptable.
 | Agent frontmatter    | name, description, tools, model (context recommended)                                                  | `agents/**/*.md`                 |
 | Skill frontmatter    | name, description (per ~/.claude/rules/conventions/SKILLS.md)                                          | `skills/*/SKILL.md`              |
 | Workflow degradation | Failed/missing sub-results recorded at loss granularity (per ~/.claude/rules/conventions/WORKFLOWS.md) | `workflows/*.js`                 |
-| Section completeness | Required sections present (see below)                                                                  | `agents/*.md`, `skills/SKILL.md` |
+| Section completeness | Meets the required-sections table                                                                      | `agents/*.md`, `skills/SKILL.md` |
 | Table alignment      | Consistent column separators, no ragged rows                                                           | All                              |
-
-Reviewer agent (`agents/reviewers/`) required sections: title, Analysis Phases, Output. Other agent types (generators, teams, architects): title, Output. Skill required sections: Input, Execution, Output. Output via template reference is acceptable.
 
 ### Phase 4: Clarity
 

--- a/agents/reviewers/reviewer-rust.md
+++ b/agents/reviewers/reviewer-rust.md
@@ -35,6 +35,10 @@ Rust code only (`*.rs`, `Cargo.toml`). Non-Rust code out of scope. For language-
 
 ## Distinction from related reviewers
 
+`let _ = result_value` may receive findings from both this reviewer (RU2 error discipline) and reviewer-silence (SF1 catch equivalent). Complementary, not duplicate.
+
+Allocation hot paths (`Vec::new()` in tight loops, redundant `String::from`) are reviewer-efficiency's domain. This reviewer flags only when the fix requires Rust-specific idiom guidance (e.g., `with_capacity`, `Cow<str>`, `&'static str`).
+
 | Concern                       | This reviewer (rust) | reviewer-design         | reviewer-silence         |
 | ----------------------------- | -------------------- | ----------------------- | ------------------------ |
 | Lens                          | Rust-idiomatic?      | Module earns interface? | Silent failure pattern?  |
@@ -45,11 +49,9 @@ Rust code only (`*.rs`, `Cargo.toml`). Non-Rust code out of scope. For language-
 | async blocking call           | Boundary violation   | Out of scope            | Out of scope             |
 | Scope                         | `*.rs` only          | Any language            | Any language             |
 
-`let _ = result_value` may receive findings from both this reviewer (RU2 error discipline) and reviewer-silence (SF1 catch equivalent). Complementary, not duplicate.
-
-Allocation hot paths (`Vec::new()` in tight loops, redundant `String::from`) are reviewer-efficiency's domain. This reviewer flags only when the fix requires Rust-specific idiom guidance (e.g., `with_capacity`, `Cow<str>`, `&'static str`).
-
 ## Tooling
+
+Run clippy first. Reviewer focuses on issues clippy cannot catch (design judgment, idiom in context, missing SAFETY rationale, async boundary).
 
 | Tool                                                                                  | Purpose                                                |
 | ------------------------------------------------------------------------------------- | ------------------------------------------------------ |
@@ -58,8 +60,6 @@ Allocation hot paths (`Vec::new()` in tight loops, redundant `String::from`) are
 | `cargo metadata --format-version=1 --no-deps`                                         | Workspace layout, lints config detection               |
 | `cargo tree --workspace --depth 1`                                                    | Direct dependency surface                              |
 | `ugrep` / `bfs`                                                                       | Pattern search across `.rs` files                      |
-
-Run clippy first. Reviewer focuses on issues clippy cannot catch (design judgment, idiom in context, missing SAFETY rationale, async boundary).
 
 > Note (2026-05-13): per Claude Code changelog (entries at lines 42, 216, 2430 of `~/.claude/cache/changelog.md`), space-containing matchers such as `Bash(ls *)`, `Bash(mkdir *)`, and `Bash(git log:*)` are supported as prefix matches. The earlier "tokenizes on whitespace" claim was a false generalization from a single failed scout dogfood run; the real cause was likely a missing `settings.json` allow rule at that time. Either form (`Bash(cargo clippy:*)` for tight scope or `Bash(cargo:*)` for broader scope including install/publish) is valid syntax; pick by the trust boundary you want, not by a matcher-parser concern.
 
@@ -80,6 +80,8 @@ This guards against false-premise findings where the reviewer's intuition contra
 
 ## Pre-Finding Documentation Scan
 
+If any of these records the decision rationale, downgrade `documented?` to `Partial` (with citation) rather than `No`. Only assert `No` when the entire surrounding context is silent.
+
 Before flagging a finding as `documented?: No`, scan the surrounding context for existing rationale.
 
 | Scope                   | Look for                                                                                       |
@@ -90,8 +92,6 @@ Before flagging a finding as `documented?: No`, scan the surrounding context for
 | Error / message strings | `.expect("...")`, `panic!("...")`, `error!("...")`, format strings explaining the failure mode |
 | Test names              | `fn test_<spec_being_verified>` form. Test names often record the rationale                    |
 | Test doc comments       | Test functions with rustdoc often state the invariant being enforced                           |
-
-If any of these records the decision rationale, downgrade `documented?` to `Partial` (with citation) rather than `No`. Only assert `No` when the entire surrounding context is silent.
 
 ## Calibration
 


### PR DESCRIPTION
## Summary

`agents/reviewers/reviewer-prompt.md` と `reviewer-rust.md` を改修標準へ整列した。実際に外れていたのは MARKDOWN.md の「表の後に段落を置かない」1 点で、両ファイルに 3 件ずつあった。

18 reviewer を同じ検査にかけた結果が下表。

| reviewer | 変更前 | 変更後 |
| --- | --- | --- |
| reviewer-prompt | 3 | 0 |
| reviewer-rust | 3 | 0 |
| reviewer-conformance | 3 | 3 (対象外) |
| reviewer-silence | 1 | 1 (対象外) |
| 他 14 件 | 0 | 0 |

## Changes

| 対象 | 内容 |
| --- | --- |
| reviewer-rust (+`.ja`) | 関連 reviewer との区別、ツール、finding 前のドキュメントスキャンの 3 節で、説明を表の前へ移した |
| reviewer-prompt (+`.ja`) | スコープと Phase 2 の説明を表の前へ移した |
| reviewer-prompt (+`.ja`) | Phase 3 の必須セクションを散文から表にした。「(下記参照)」の前方参照も消えた |

## 完了条件の確認

| 条件 | 結果 |
| --- | --- |
| frontmatter 整備 | 変更前から name / description / tools / model / memory / background が揃っており、family の記法と一致 |
| H1 integral form | `# Prompt Reviewer` / `# Rust Reviewer`。family の 18 件と同形 |
| 本文 MARKDOWN.md 準拠 | 表の後の段落 6 件を解消。em-dash、行末コロン、`≠`、emoji は変更前から 0 件 |
| JA/EN parity | 表の行数 (62 / 48)、見出し数 (10 / 11)、行数 (114 / 122) が両言語で一致 |

`**bold**` は 3 件検出されたが、いずれもインラインコードとして規則そのものを引用したもの。MARKDOWN.md は「Anything inside a code block or inline code is out of scope」と定めるので違反ではない。

## 直さなかったもの

### `## Summary` の出力テンプレート

reviewer-prompt は 18 件で唯一 `## Summary` の markdown fence を持たない。ただし `workflows/audit.js` は reviewer 出力を `findingsSchema` の JSON schema で受け取り、markdown の Summary 表を読む箇所は無い。消費者がいないので追加しなかった。reviewer-prompt 自身の Phase 3 が定める必須セクションも title、Analysis Phases、Output の 3 つで、Summary を含まない。

### `### Phase N: 名前` のコロン

reviewer-prompt は 4 件持つ。MARKDOWN.md の該当規則は「Line-ending `:` or `Label: value` → Promote to a heading or a table」で、見出しは規則が指す移動先そのもの。reviewer-conformance も 1 件持ったまま close 済み。

### 100 行の上限

SUBAGENT.md は agent 本文を 100 行に制限するが、破っているのは 7 ファイル (`agents/_lib/calibration-examples.md` が 790 行)。この 2 件の完了条件に行数は無く、検査も存在しない。reviewer-prompt は表の追加で 108 行から 114 行になった。

## 別途の判断が要るもの

`reviewer-conformance` (3 件) と `reviewer-silence` (1 件) が同じ規則を破っている。どちらも #104 と対応する issue が「改修標準へ整列済み」として close されている。この監査はその判定と食い違うので、reopen するかどうかは判断を仰ぐ。

`.ja/agents/reviewers/reviewer-conformance.md` の H1 は `# Spec 適合性レビュアー` で、`.ja` 側で日本語 H1 を持つ唯一の reviewer でもある。

## Testing

- 監査スクリプトの前後比較を上表に載せた。対象 2 件が 0 になり、他 16 件は変わらない
- 490 テスト緑、textlint 緑、prettier 緑 (reviewer-conformance の warn は変更前から)

Closes #114
Closes #119

https://claude.ai/code/session_01WKMAvw3AWjxKTW29eeJeKq
