### PR TITLE
refactor(agent): 表の後の段落を全て表の前へ移し、検査を足す

### DIFF
--- a/.ja/agents/_lib/finding-schema.md
+++ b/.ja/agents/_lib/finding-schema.md
@@ -28,12 +28,12 @@ integrator/leader が spawn した reviewer の `name:` frontmatter から `Agen
 
 これらは別フィールド。混ぜてはいけない。
 
+Trigger が Reasoning の冒頭句と同一なら、その finding は抽象すぎる。verifier が再現可能な観測条件として Trigger を書き直す。
+
 | Field     | 質問           | 例                                                                               |
 | --------- | -------------- | -------------------------------------------------------------------------------- |
 | Trigger   | いつ発火するか | "Bash tool 呼び出しのたび (PreToolUse hook が毎回走る)"                          |
 | Reasoning | なぜ悪いか     | "awk fork+exec がホットパスで 2-5ms かかり、case フィルタの短絡前にコストが入る" |
-
-Trigger が Reasoning の冒頭句と同一なら、その finding は抽象すぎる。verifier が再現可能な観測条件として Trigger を書き直す。
 
 ### 報告基準
 
@@ -69,6 +69,8 @@ Evidence, Trigger, Reasoning は具体的な言語を使う。
 
 Severity は影響の大きさを表す。Disposition は読んだ人間が次に何をするかを表す。マージを止めるべきか作者の判断に委ねてよいかは severity が答えない軸なので、2 つを 1 つの finding に並べて載せる。
 
+「併走する severity」は目安であって導出規則ではない。既定値は severity から導かず must に固定する。`workflows/assert.js` の gate は severity を見ず `issues.length > 0` だけで NotReady を出すので、severity 由来の既定値だと blocking な finding へ nits が付く。
+
 DR-0078 が定めた共通コア (Severity/Evidence/一行 claim/ID) に足す 1 本目の軸。この語彙は audit 側に閉じ、`/preview` へは戻さない (`skills/preview/tests/plan-alignment.test.js` が禁止している)。
 
 | 値   | 意味                                 | 併走する severity | 供給元                          |
@@ -79,8 +81,6 @@ DR-0078 が定めた共通コア (Severity/Evidence/一行 claim/ID) に足す 1
 | nits | 見た目の指摘。直すかは任意           | low               | 下記 3 本の reviewer            |
 | ask  | コードだけでは決まらない。人間に聞く | 対応なし          | critic の needs_context verdict |
 | info | 処理済み。記録として残す             | 対応なし          | triage の disputed / downgraded |
-
-「併走する severity」は目安であって導出規則ではない。既定値は severity から導かず must に固定する。`workflows/assert.js` の gate は severity を見ず `issues.length > 0` だけで NotReady を出すので、severity 由来の既定値だと blocking な finding へ nits が付く。
 
 | 規則          | 内容                                                                                                        |
 | ------------- | ----------------------------------------------------------------------------------------------------------- |
@@ -103,6 +103,8 @@ DR-0078 が定めた共通コア (Severity/Evidence/一行 claim/ID) に足す 1
 
 ### Context Test
 
+各 reviewer の Calibration セクションにドメイン別 REPORT/SKIP 例がある。迷ったら SKIP を優先。challenger は false negative を捕まえる存在だが、false positive は pipeline capacity を浪費する。
+
 | コンテキスト    | アクション                                                  |
 | --------------- | ----------------------------------------------------------- |
 | Cold path       | severity >= high でない限り除外                             |
@@ -110,8 +112,6 @@ DR-0078 が定めた共通コア (Severity/Evidence/一行 claim/ID) に足す 1
 | Framework idiom | framework/library の慣用に従う → 除外                       |
 | Indirect cover  | caller または integration test 経由でテスト済み → 除外 (TC) |
 | Semantic differ | 構造は似ているが business logic が異なる → 除外 (DRY)       |
-
-各 reviewer の Calibration セクションにドメイン別 REPORT/SKIP 例がある。迷ったら SKIP を優先。challenger は false negative を捕まえる存在だが、false positive は pipeline capacity を浪費する。
 
 ## Memory の用途
 
@@ -190,9 +190,9 @@ frontmatter に `memory` を持つ reviewer は、agent-memory を下表の線�
 
 reviewer 個別定義で上書きされない限り、すべての reviewer が以下を適用する。
 
+ドメイン特化のガード (入力欠如、依存利用不可) は各 reviewer 自身の `## Error Handling` セクションに残す。
+
 | Error        | アクション                                       |
 | ------------ | ------------------------------------------------ |
 | bfs 空       | 0 ファイル発見と報告; clean と推論しない         |
 | ツールエラー | エラーをログ、ファイルをスキップ、summary に記録 |
-
-ドメイン特化のガード (入力欠如、依存利用不可) は各 reviewer 自身の `## Error Handling` セクションに残す。

--- a/agents/_lib/finding-schema.md
+++ b/agents/_lib/finding-schema.md
@@ -28,12 +28,12 @@ The integrator/leader populates `Agent` from the spawning reviewer's `name:` fro
 
 These are distinct fields. Do not merge them.
 
+If Trigger is identical to Reasoning's opening clause, the finding is too abstract. Restate Trigger as an observable condition that a verifier could reproduce.
+
 | Field     | Question           | Example                                                                          |
 | --------- | ------------------ | -------------------------------------------------------------------------------- |
 | Trigger   | When does it fire? | "Every Bash tool call (PreToolUse hook runs on every invocation)"                |
 | Reasoning | Why is it bad?     | "awk fork+exec on hot path costs 2-5ms before the case filter can short-circuit" |
-
-If Trigger is identical to Reasoning's opening clause, the finding is too abstract. Restate Trigger as an observable condition that a verifier could reproduce.
 
 ### Reporting Bar
 
@@ -69,6 +69,8 @@ Evidence, Trigger, and Reasoning fields MUST use concrete language.
 
 Severity states how large the impact is. Disposition states what the reader does next. Whether a finding blocks a merge or is left to the author is an axis severity does not answer, so the two ride on one finding together.
 
+"Severity it rides with" is a guide, not a derivation rule. The default is pinned to must rather than derived from severity. `workflows/assert.js`'s gate ignores severity and returns NotReady on `issues.length > 0` alone, so a severity-derived default would put nits on a finding that blocks the merge.
+
 This is the first axis added to the common core DR-0078 settled (Severity / Evidence / one-line claim / ID). The vocabulary stays on the audit side and does not return to `/preview`, which `skills/preview/tests/plan-alignment.test.js` forbids.
 
 | Value | Meaning                                  | Severity it rides with | Supplied by                        |
@@ -79,8 +81,6 @@ This is the first axis added to the common core DR-0078 settled (Severity / Evid
 | nits  | Cosmetic. Fixing it is optional          | low                    | the 3 reviewers below              |
 | ask   | Undecidable from code alone. Ask a human | none                   | the critic's needs_context verdict |
 | info  | Already handled. Kept for the record     | none                   | triage's disputed / downgraded     |
-
-"Severity it rides with" is a guide, not a derivation rule. The default is pinned to must rather than derived from severity. `workflows/assert.js`'s gate ignores severity and returns NotReady on `issues.length > 0` alone, so a severity-derived default would put nits on a finding that blocks the merge.
 
 | Rule           | Content                                                                                                        |
 | -------------- | -------------------------------------------------------------------------------------------------------------- |
@@ -103,6 +103,8 @@ Apply in order. If any filter excludes, do not report.
 
 ### Context Test
 
+Each reviewer's Calibration section has domain-specific REPORT/SKIP examples. When uncertain, prefer SKIP. The challenger exists to catch false negatives, but false positives waste pipeline capacity.
+
 | Context         | Action                                                            |
 | --------------- | ----------------------------------------------------------------- |
 | Cold path       | Exclude unless severity >= high                                   |
@@ -110,8 +112,6 @@ Apply in order. If any filter excludes, do not report.
 | Framework idiom | Follows framework/library convention → exclude                    |
 | Indirect cover  | Tested through caller or integration test → exclude (TC)          |
 | Semantic differ | Structurally similar but different business logic → exclude (DRY) |
-
-Each reviewer's Calibration section has domain-specific REPORT/SKIP examples. When uncertain, prefer SKIP. The challenger exists to catch false negatives, but false positives waste pipeline capacity.
 
 ## Memory Usage
 
@@ -190,9 +190,9 @@ For example, "Unused import in 7 files" is one finding with severity from the wo
 
 All reviewers apply the following unless overridden in their own definition.
 
+Domain-specific guards (missing input, unavailable dependency) remain in each reviewer's own `## Error Handling` section.
+
 | Error             | Action                                   |
 | ----------------- | ---------------------------------------- |
 | bfs returns empty | Report 0 files found, do not infer clean |
 | Tool error        | Log error, skip file, note in summary    |
-
-Domain-specific guards (missing input, unavailable dependency) remain in each reviewer's own `## Error Handling` section.

--- a/agents/critics/critic-evidence.md
+++ b/agents/critics/critic-evidence.md
@@ -44,15 +44,13 @@ Pick the check that matches the finding category. The verification_hint may name
 
 ### Budget exhaustion handling
 
-Steps 3 and 4 share a budget of up to 5 files of Read/search combined per finding. Stop exploring once the budget is spent.
+Steps 3 and 4 share a budget of up to 5 files of Read/search combined per finding. Stop exploring once the budget is spent. Do not drop a budget-exhausted finding as inconclusive. Keep it as weak_evidence with `files checked` named in the evidence field.
 
 | Timing                       | Condition                                     | Action                                                                                  |
 | ---------------------------- | --------------------------------------------- | --------------------------------------------------------------------------------------- |
 | Before raw evidence (Step 3) | 5-file budget spent                           | verdict = weak_evidence, budget_exhausted = true, record only evidence collected so far |
 | During path trace (Step 4)   | Budget spent before the path was fully traced | verdict = weak_evidence, budget_exhausted = true, note how far the trace reached        |
 | Within budget                | Path traced to completion                     | budget_exhausted = false                                                                |
-
-Do not drop a budget-exhausted finding as inconclusive. Keep it as weak_evidence with `files checked` named in the evidence field.
 
 ## Verdicts
 

--- a/agents/enhancers/enhancer-evidence.md
+++ b/agents/enhancers/enhancer-evidence.md
@@ -165,6 +165,8 @@ Return `issues` / `root_causes` / `report` as structured output.
 
 ### issues
 
+When there are no issues, and when all inputs are empty, return an empty array `[]` (a valid result, not an error).
+
 | Field    | Type          | Value                                                                     |
 | -------- | ------------- | ------------------------------------------------------------------------- |
 | file     | string        | The file part of file:line                                                |
@@ -172,8 +174,6 @@ Return `issues` / `root_causes` / `report` as structured output.
 | severity | enum          | critical / high / medium / low. A fix-priority hint, does not affect Gate |
 | summary  | string        | The content of the issue and its basis                                    |
 | source   | array<string> | Subset of audit / codex / adversarial                                     |
-
-When there are no issues, and when all inputs are empty, return an empty array `[]` (a valid result, not an error).
 
 ### root_causes
 

--- a/tests/table-paragraph.test.js
+++ b/tests/table-paragraph.test.js
@@ -1,0 +1,71 @@
+// MARKDOWN.md § Do not puts a table's explanation before the table, so the reader holds the rule
+// before the rows it governs. skills/** (13 per language side) and docs/** (48) still carry
+// paragraphs below their tables and stay out of this scan until they are cleaned. workflows/ and
+// commands/ hold no markdown.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const SCANNED = ["agents", "rules"];
+
+const markdownUnder = async (dir) => {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const e of entries) {
+    const path = join(dir, e.name);
+    if (e.isDirectory()) out.push(...(await markdownUnder(path)));
+    else if (e.name.endsWith(".md")) out.push(path);
+  }
+  return out;
+};
+
+// A fenced block carries its own tables and prose, and MARKDOWN.md exempts code from every rule.
+const paragraphsAfterTables = (source) => {
+  const lines = source.split("\n");
+  const start = lines[0] === "---" ? lines.indexOf("---", 1) + 1 : 0;
+  const out = [];
+  let inTable = false;
+  let inFence = false;
+  for (let i = start; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith("```")) {
+      inFence = !inFence;
+      inTable = false;
+      continue;
+    }
+    if (inFence || !line) continue;
+    if (inTable && !/^[|#\-*>]/.test(line)) out.push({ line: i + 1, text: line });
+    inTable = line.startsWith("|");
+  }
+  return out;
+};
+
+test("no explanation sits below the table it explains", async () => {
+  const offenders = [];
+  for (const prefix of ["", ".ja"]) {
+    for (const dir of SCANNED) {
+      for (const path of await markdownUnder(join(root, prefix, dir))) {
+        for (const { line, text } of paragraphsAfterTables(await readFile(path, "utf8"))) {
+          offenders.push(`${relative(root, path)}:${line} ${text.slice(0, 70)}`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(offenders, [], `move the explanation above its table:\n${offenders.join("\n")}`);
+});
+
+// An empty scan reports the same zero offenders as a clean tree.
+test("the scan reaches the agent and rule files", async () => {
+  const counts = await Promise.all(
+    SCANNED.map(async (dir) => (await markdownUnder(join(root, dir))).length),
+  );
+  assert.ok(Math.min(...counts) > 0, `every scanned directory holds markdown: ${counts}`);
+});


### PR DESCRIPTION
## Summary

`agents/**` に残っていた「表の後の段落」10 件を表の前へ移し、`tests/table-paragraph.test.js` で今後の drift を止める。#445 の残りを片付けるもの。

| 対象 | 件数 | 位置 |
| --- | --- | --- |
| `agents/_lib/finding-schema.md` (両言語) | 8 | 36、83、114、198 |
| `agents/critics/critic-evidence.md` | 1 | 55 |
| `agents/enhancers/enhancer-evidence.md` | 1 | 176 |

走査後の `agents/**` と `rules/**` は 0 件。

## JA/EN parity を直した

後ろの 2 件は英語側にしか無かった。`.ja` 側はどちらも既に説明を表の前に置いている。MIRROR.md は `.ja` を canonical と定めるので、英語側を `.ja` の形へ寄せた。

| ファイル | 変更前 | 変更後 |
| --- | --- | --- |
| `critic-evidence.md` | ja 79 行 / en 81 行 | 79 / 79 |
| `enhancer-evidence.md` | 219 / 219 (176 行目の段落が ja に無い) | 219 / 219 (構造も一致) |

`critic-evidence.md` は `.ja` が 1 段落に収めていた内容を英語側が 2 つに割っていたので、1 段落へ戻した。

## 検査を足した

`tests/table-paragraph.test.js` が `agents/**` と `rules/**` の両言語側を走査する。

走査対象から外したものと、その件数を検査のコメントに書いた。

| 対象外 | 件数 | 理由 |
| --- | --- | --- |
| `skills/**` | 片側 13 件 | 未修正。別途片付ける |
| `docs/**` | 48 件 | 未修正。多くは MADR テンプレート由来 |
| `workflows/`、`commands/` | - | `.md` を持たない |

走査が 0 ファイルでも offenders は空になるので、対象ディレクトリが markdown を持つことを見る 2 本目を置いた。

## Testing

- 破壊検査: `finding-schema.md` の段落を表の後ろへ戻すと 1 本目だけが落ちる
- 492 テスト緑、oxlint / textlint 緑
- 変更した 4 ファイルは prettier 緑。`calibration-examples.md` など 6 ファイルの prettier warn は変更前からあり、グロブ整形で巻き込んだ分は戻した (TIDYINGS は編集したファイルに限る)

## Related

- #445 が残した 10 件を片付けた
- #104 と #121 は close 済みのまま
