### PR TITLE
chore(rumdl): 内容の側を直し、設定へ例外を足さずに 0 件へ落とす

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,3 +74,8 @@ jobs:
 
       - name: ruff format
         run: pipx run --spec ruff==0.16.4 ruff format --check .
+
+      # rumdl は JS 依存に無いので版を直に固定する。ruff と同じ形。`fmt` でなく `check` なのは、
+      # コードスパン内の末尾スペースと見出しレベルで、自動修正が内容を壊す実例が出たため (#329)。
+      - name: rumdl
+        run: pipx run --spec rumdl==0.2.58 rumdl check .

--- a/.ja/skills/qualify/SKILL.md
+++ b/.ja/skills/qualify/SKILL.md
@@ -27,7 +27,7 @@ needs-plan では着手の判断が変わらない一方、次の手は issue �
 
 Plan 節があるときは、build.js の判定条件を実行時に読んで適用し、違反した項目をすべて blocker として扱う。build が同じ条件で止まるため、重大度は blocker のままにする。条件を読めないまま検分を続けると、違反が無い状態と条件を当てていない状態を出力が区別できない。
 
-1. ugrep で ${CLAUDE_SKILL_DIR}/../../workflows/build.js を探し、`const validate = |const UNIT_CAPS = |const oversizedUnits = ` に一致する行の位置を特定する。いずれかがヒットしなければ、読めなかったアンカーを報告して停止する
+1. ugrep で ${CLAUDE_SKILL_DIR}/../../workflows/build.js を探し、`const validate =|const UNIT_CAPS =|const oversizedUnits =` に一致する行の位置を特定する。いずれかがヒットしなければ、読めなかったアンカーを報告して停止する
 2. Read でヒットした箇所を読む
 3. issue 本文の Plan 節を読んだ条件に当てて、違反を列挙する
 

--- a/.ja/skills/use-context-reviewer-security/references/frontend-taint-data.md
+++ b/.ja/skills/use-context-reviewer-security/references/frontend-taint-data.md
@@ -2,7 +2,7 @@
 
 source がオリジン境界をまたぐか、sink がナビゲーションまたは資格情報の永続化を行う taint パターン。regex マッチングを超えるデータフロー理解が必要で、guardrails の静的ルールを補完する。
 
-### 1. postMessage の origin 検証
+## 1. postMessage の origin 検証
 
 `window.addEventListener('message', handler)` から、ハンドラ内の DOM 操作、state 更新、ナビゲーションへ流れる。
 
@@ -23,7 +23,7 @@ window.addEventListener("message", (e) => {
 });
 ```
 
-### 2. URL パラメータからリダイレクトへのフロー
+## 2. URL パラメータからリダイレクトへのフロー
 
 `URLSearchParams`/`location.search`/`location.hash`/ルートパラメータから、`location.href`/`location.replace()`/`location.assign()`/`window.open()` へ流れる。
 
@@ -47,7 +47,7 @@ if (next) {
 }
 ```
 
-### 3. localStorage 内の JWT
+## 3. localStorage 内の JWT
 
 認証レスポンスやトークンリフレッシュから `localStorage.setItem('token', jwt)` や `sessionStorage.setItem('auth', jwt)` へ流れる。
 

--- a/.ja/skills/use-context-reviewer-security/references/frontend-taint-html.md
+++ b/.ja/skills/use-context-reviewer-security/references/frontend-taint-html.md
@@ -2,7 +2,7 @@
 
 sink がマークアップまたは属性を document へ書き込む taint パターン。regex マッチングを超えるデータフロー理解が必要で、guardrails の静的ルールを補完する。
 
-### 1. サニタイザなしの dangerouslySetInnerHTML
+## 1. サニタイザなしの dangerouslySetInnerHTML
 
 ユーザー入力、API レスポンス、URL パラメータから `dangerouslySetInnerHTML={{ __html: value }}` へ流れる。
 
@@ -20,7 +20,7 @@ sink がマークアップまたは属性を document へ書き込む taint パ�
 <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(apiResponse.body) }} />
 ```
 
-### 2. 関数引数から DOM メソッドへ
+## 2. 関数引数から DOM メソッドへ
 
 関数パラメータやコールバック引数から `innerHTML`, `outerHTML`, `insertAdjacentHTML()`, `document.write()` へ流れる。
 
@@ -42,7 +42,7 @@ function renderContent(html: string) {
 }
 ```
 
-### 3. javascript: URL を持つ href 変数
+## 3. javascript: URL を持つ href 変数
 
 ユーザー入力、データベース値、API レスポンスから `<a href={variable}>` や `location.href = variable` へ流れる。
 

--- a/agents/reviewers/reviewer-rust.md
+++ b/agents/reviewers/reviewer-rust.md
@@ -39,15 +39,15 @@ Rust code only (`*.rs`, `Cargo.toml`). Non-Rust code out of scope. For language-
 
 Allocation hot paths (`Vec::new()` in tight loops, redundant `String::from`) are reviewer-efficiency's domain. This reviewer flags only when the fix requires Rust-specific idiom guidance (e.g., `with_capacity`, `Cow<str>`, `&'static str`).
 
-| Concern                       | This reviewer (rust) | reviewer-design         | reviewer-silence         |
-| ----------------------------- | -------------------- | ----------------------- | ------------------------ |
-| Lens                          | Rust-idiomatic?      | Module earns interface? | Silent failure pattern?  |
-| `let _ = ` swallowed `Result` | Idiom violation      | Out of scope            | Empty handler equivalent |
-| `Box<dyn Trait>` overuse      | Trait design smell   | Out of scope            | Out of scope             |
-| `unsafe` without SAFETY       | Invariant gap        | Out of scope            | Out of scope             |
-| `clone()` abuse               | Ownership smell      | Out of scope            | Out of scope             |
-| async blocking call           | Boundary violation   | Out of scope            | Out of scope             |
-| Scope                         | `*.rs` only          | Any language            | Any language             |
+| Concern                      | This reviewer (rust) | reviewer-design         | reviewer-silence         |
+| ---------------------------- | -------------------- | ----------------------- | ------------------------ |
+| Lens                         | Rust-idiomatic?      | Module earns interface? | Silent failure pattern?  |
+| `let _ =` swallowed `Result` | Idiom violation      | Out of scope            | Empty handler equivalent |
+| `Box<dyn Trait>` overuse     | Trait design smell   | Out of scope            | Out of scope             |
+| `unsafe` without SAFETY      | Invariant gap        | Out of scope            | Out of scope             |
+| `clone()` abuse              | Ownership smell      | Out of scope            | Out of scope             |
+| async blocking call          | Boundary violation   | Out of scope            | Out of scope             |
+| Scope                        | `*.rs` only          | Any language            | Any language             |
 
 ## Tooling
 

--- a/docs/decisions/0001-code-command-responsibility-separation.md
+++ b/docs/decisions/0001-code-command-responsibility-separation.md
@@ -152,7 +152,7 @@ references/commands/code/
 ## References
 
 - [ADR 0002](./0002-fix-modularization-and-tdd-commonization.md) - 同様のパターンを `/fix` に適用
-- [Miller's Law](../../skills/applying-code-principles/SKILL.md) - 認知負荷原則
+- Miller's Law (`../../skills/applying-code-principles/SKILL.md`) - 認知負荷原則
 - [COMMANDS.md](../COMMANDS.md) - コマンドドキュメント
 
 ---

--- a/docs/decisions/0002-fix-modularization-and-tdd-commonization.md
+++ b/docs/decisions/0002-fix-modularization-and-tdd-commonization.md
@@ -315,9 +315,9 @@ references/commands/code/
 ## リファレンス
 
 - [ADR 0001](./0001-code-command-responsibility-separation.md) - `/code` モジュール化パターン
-- [ミラーの法則](../../skills/applying-code-principles/SKILL.md) - 認知負荷原則
-- [DRY原則](../../skills/applying-code-principles/SKILL.md) - 知識の重複
-- [SOLID原則](../../skills/applying-code-principles/SKILL.md) - SRP の適用
+- ミラーの法則 (`../../skills/applying-code-principles/SKILL.md`) - 認知負荷原則
+- DRY原則 (`../../skills/applying-code-principles/SKILL.md`) - 知識の重複
+- SOLID原則 (`../../skills/applying-code-principles/SKILL.md`) - SRP の適用
 - [COMMANDS.md](../COMMANDS.md) - コマンドドキュメント
 
 ## 将来の検討事項

--- a/docs/decisions/0003-marketplace.md
+++ b/docs/decisions/0003-marketplace.md
@@ -6,7 +6,7 @@ decision-makers: thkt
 
 # Marketplace構造の維持
 
-Technical Story: [SOW: Marketplace構造最適化](../../workspace/planning/20260103-marketplace-optimization/sow.md)
+Technical Story: SOW: Marketplace構造最適化 (`../../workspace/planning/20260103-marketplace-optimization/sow.md`)
 
 ## Context and Problem Statement
 
@@ -110,9 +110,9 @@ Chosen option: "Option A: Marketplace維持", because プラグインキャッ�
 
 ## References
 
-- [Research: Plugin System Verification](.claude/workspace/research/2026-01-03-plugin-system-verification.md)
+- Research: Plugin System Verification (`.claude/workspace/research/2026-01-03-plugin-system-verification.md`)
 - [Official Docs: Claude Code Plugins Reference](https://code.claude.com/docs/en/plugins-reference.md)
-- [Superseded SOW](../../workspace/planning/20260103-plugin-architecture/sow.md)
+- Superseded SOW (`../../workspace/planning/20260103-plugin-architecture/sow.md`)
 
 ---
 

--- a/docs/decisions/0004-skill-centric-architecture-restructuring.md
+++ b/docs/decisions/0004-skill-centric-architecture-restructuring.md
@@ -162,8 +162,8 @@ ADR 0001/0002/0003 から強制ルールを抽出：
 
 ## 関連ルール
 
-- [MODULARIZATION_RULES.md](../rules/workflows/MODULARIZATION_RULES.md)
-- [PLUGIN_ARCHITECTURE.md](../rules/conventions/PLUGIN_ARCHITECTURE.md)
+- `../rules/workflows/MODULARIZATION_RULES.md`
+- `../rules/conventions/PLUGIN_ARCHITECTURE.md`
 
 ## Reassessment Triggers
 

--- a/docs/decisions/0011-add-evidence-verifier-to-audit-pipeline.md
+++ b/docs/decisions/0011-add-evidence-verifier-to-audit-pipeline.md
@@ -91,7 +91,7 @@ After:
 5. Any + weak_evidence → challenger verdict 維持
 6. Verifier-only mode: verified→confirmed, weak_evidence→needs_context, unverifiable→exclude
 
-詳細は [team-integration.md](../agents/teams/team-integration.md)。
+詳細は `../agents/teams/team-integration.md`。
 
 ## Rollback Plan
 

--- a/docs/decisions/0013-adopt-hook-trinity-pattern-with-claude-reviews.md
+++ b/docs/decisions/0013-adopt-hook-trinity-pattern-with-claude-reviews.md
@@ -89,8 +89,8 @@ reviews     → PreToolUse(Skill)       → プロジェクト全体の分析
 
 ## References
 
-- [SOW](../workspace/planning/2026-02-22-claude-reviews/sow.md) (local planning artifact, not committed)
-- [Spec](../workspace/planning/2026-02-22-claude-reviews/spec.md) (local planning artifact, not committed)
+- SOW (`../workspace/planning/2026-02-22-claude-reviews/sow.md`) (local planning artifact, not committed)
+- Spec (`../workspace/planning/2026-02-22-claude-reviews/spec.md`) (local planning artifact, not committed)
 - ADR-0006: 決定論的処理のスクリプト化パターン
 - ADR-0009: IDR 生成の外部リポジトリ化（Rust）, 同様の Rust 外部化パターン
 

--- a/docs/decisions/0014-integrate-aidlc-design-separation-and-ops-reviewer.md
+++ b/docs/decisions/0014-integrate-aidlc-design-separation-and-ops-reviewer.md
@@ -92,8 +92,8 @@ reviewer-operations を作成し、既存の /audit Phase 4 でカバー。
 - [AI-DLC Method Definition](https://prod.d13rzhkk8cj2z0.amplifyapp.com/) (Amplify URL - may change; use GitHub repos as stable reference)
 - [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows)
 - [ikeisuke/ai-dlc-starter-kit](https://github.com/ikeisuke/ai-dlc-starter-kit)
-- [SOW](../workspace/planning/2026-02-22-aidlc-integration/sow.md) (local planning artifact, not committed)
-- [Spec](../workspace/planning/2026-02-22-aidlc-integration/spec.md) (local planning artifact, not committed)
+- SOW (`../workspace/planning/2026-02-22-aidlc-integration/sow.md`) (local planning artifact, not committed)
+- Spec (`../workspace/planning/2026-02-22-aidlc-integration/spec.md`) (local planning artifact, not committed)
 
 ## Reassessment Triggers
 

--- a/docs/decisions/0018-index-time-file-context-storage-for-explorer.md
+++ b/docs/decisions/0018-index-time-file-context-storage-for-explorer.md
@@ -46,7 +46,7 @@ indexing 時に import 文を `file_context` テーブルに保存。query 時�
 
 ## Decision Outcome
 
-**A: Index-time storage を採用。**
+A: Index-time storage を採用。
 
 最大の理由はデータ整合性。B では index 後にファイルが変更されると、DB 内のチャンク（旧コード）とディスクから読んだ imports（新コード）が食い違い、AI に不正確な文脈を渡すリスクがある。imports は表示専用データだが、不正確な表示は AI の判断を誤らせるため、整合性は非機能要件ではなく機能的な正しさの問題。
 

--- a/docs/decisions/0019-adopt-sqlite-reference-graph-for-impact-analysis.md
+++ b/docs/decisions/0019-adopt-sqlite-reference-graph-for-impact-analysis.md
@@ -54,7 +54,7 @@ Rust の petgraph crate でインメモリグラフを構築。DB には保存�
 
 ## Decision Outcome
 
-**Chosen option: A (SQLite Reference Graph)**
+Chosen option: A (SQLite Reference Graph)
 
 理由:
 

--- a/docs/decisions/0022-migrate-yomu-from-mcp-to-cli.md
+++ b/docs/decisions/0022-migrate-yomu-from-mcp-to-cli.md
@@ -64,7 +64,7 @@ CLI をデフォルトにしつつ、`yomu mcp` で既存 MCP サーバーモー
 
 ## Decision Outcome
 
-**Chosen option: Option 1 (Pure CLI)**
+Chosen option: Option 1 (Pure CLI)
 
 Occam's Razor:
 MCP の利点が yomu では薄く、CLI で同等の機能を提供できる。YAGNI: 後方互換や feature

--- a/docs/decisions/0041-fork-strategy-for-carte.md
+++ b/docs/decisions/0041-fork-strategy-for-carte.md
@@ -121,8 +121,8 @@ AS-003 (Canvas/Heptabase への移住判断) で撤退する場合、carte リ�
 
 ## Links
 
-- carte SOW: [~/.claude/workspace/planning/2026-04-19-carte/sow.md](../workspace/planning/2026-04-19-carte/sow.md)
-- carte Spec: [~/.claude/workspace/planning/2026-04-19-carte/spec.md](../workspace/planning/2026-04-19-carte/spec.md)
+- carte SOW: `~/.claude/workspace/planning/2026-04-19-carte/sow.md`
+- carte Spec: `~/.claude/workspace/planning/2026-04-19-carte/spec.md`
 - CCPlanView (fork source): /Users/thkt/GitHub/apps/CCPlanView
 - k1LoW/mo (CLI 起動パターンの参考): <https://github.com/k1LoW/mo>
 

--- a/skills/pr/templates/pr.md
+++ b/skills/pr/templates/pr.md
@@ -52,4 +52,4 @@ Preview URL: http://localhost:3000
 | Scope            | Auth token refresh is not included (separate PR)            | Omitted on large PRs (reviewer guesses boundary) |
 | Design Decisions | Used streaming to avoid OOM on large datasets               | Omitted (forces reviewer to guess why)           |
 | How to Test      | Click Export → verify .csv downloads with 3 rows            | Test the feature (vague)                         |
-| Preview URL      | Preview URL: http://localhost:3000/dashboard                | Missing despite UI changes                       |
+| Preview URL      | Preview URL: <http://localhost:3000/dashboard>              | Missing despite UI changes                       |

--- a/skills/qualify/SKILL.md
+++ b/skills/qualify/SKILL.md
@@ -27,7 +27,7 @@ Under needs-plan the decision to pick it up does not change, while the next step
 
 With a `## Plan` section, read build.js's own conditions at run time, apply them, and treat every violation as a blocker. Build stops on the same conditions, so every severity stays blocker. Carrying the inspection on without reading those conditions leaves the output unable to separate no violation from conditions never applied.
 
-1. Locate them by running ugrep over ${CLAUDE_SKILL_DIR}/../../workflows/build.js for the lines matching `const validate = |const UNIT_CAPS = |const oversizedUnits = `. When any of them goes unmatched, report the anchor you could not read and stop
+1. Locate them by running ugrep over ${CLAUDE_SKILL_DIR}/../../workflows/build.js for the lines matching `const validate =|const UNIT_CAPS =|const oversizedUnits =`. When any of them goes unmatched, report the anchor you could not read and stop
 2. Read the places it hits
 3. Apply what you read to the issue's Plan section and list the violations
 

--- a/skills/qualify/tests/contract.test.js
+++ b/skills/qualify/tests/contract.test.js
@@ -72,8 +72,8 @@ test("build's stop conditions are never copied into the skill body", () => {
       /\d/,
       `${lang}: no threshold or count is copied into Phase 2`,
     );
-    assert.match(doc, /const validate = /, `${lang}: a step locates validate at run time`);
-    assert.match(doc, /const oversizedUnits = /, `${lang}: oversizedUnits is among what gets read`);
+    assert.match(doc, /const validate =/, `${lang}: a step locates validate at run time`);
+    assert.match(doc, /const oversizedUnits =/, `${lang}: oversizedUnits is among what gets read`);
     assert.match(doc, /workflows\/build\.js/, `${lang}: it states that what to read is build.js`);
   });
 });

--- a/skills/think/references/id-numbering.md
+++ b/skills/think/references/id-numbering.md
@@ -14,4 +14,3 @@ Build's Load stops a duplicate id at the id cross-check. A number that disagrees
 Write a T-NNN statement in the language of the side the test lands on. `/think` settles that the sentence becomes the test name as written, so the plan's language is the test name's language.
 
 In a repo that pairs `.ja/` with an English side, tests live on the English side only (`rules/conventions/MIRROR.md`). A Japanese T-NNN handed there makes the implementer write a Japanese test name, exactly as instructed, and the name lands outside the convention. Keep T-NNN statements English even when the rest of the plan is Japanese.
-

--- a/skills/use-context-reviewer-security/references/frontend-taint-data.md
+++ b/skills/use-context-reviewer-security/references/frontend-taint-data.md
@@ -2,7 +2,7 @@
 
 Taint patterns whose source crosses an origin boundary or whose sink navigates or persists a credential. These require data flow understanding beyond regex pattern matching and complement the guardrails static rules.
 
-### 1. postMessage Origin Verification
+## 1. postMessage Origin Verification
 
 Flows from `window.addEventListener('message', handler)` into DOM manipulation, a state update, or navigation inside the handler.
 
@@ -23,7 +23,7 @@ window.addEventListener("message", (e) => {
 });
 ```
 
-### 2. URL Parameter to Redirect Flow
+## 2. URL Parameter to Redirect Flow
 
 Flows from `URLSearchParams`, `location.search`, `location.hash`, or route params into `location.href`, `location.replace()`, `location.assign()`, or `window.open()`.
 
@@ -47,7 +47,7 @@ if (next) {
 }
 ```
 
-### 3. JWT in localStorage
+## 3. JWT in localStorage
 
 Flows from an authentication response or a token refresh into `localStorage.setItem('token', jwt)` or `sessionStorage.setItem('auth', jwt)`.
 

--- a/skills/use-context-reviewer-security/references/frontend-taint-html.md
+++ b/skills/use-context-reviewer-security/references/frontend-taint-html.md
@@ -2,7 +2,7 @@
 
 Taint patterns whose sink writes markup or an attribute into the document. These require data flow understanding beyond regex pattern matching and complement the guardrails static rules.
 
-### 1. dangerouslySetInnerHTML without Sanitizer
+## 1. dangerouslySetInnerHTML without Sanitizer
 
 Flows from user input, an API response, or a URL parameter into `dangerouslySetInnerHTML={{ __html: value }}`.
 
@@ -20,7 +20,7 @@ Flows from user input, an API response, or a URL parameter into `dangerouslySetI
 <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(apiResponse.body) }} />
 ```
 
-### 2. Function Argument to DOM Method
+## 2. Function Argument to DOM Method
 
 Flows from a function parameter or a callback argument into `innerHTML`, `outerHTML`, `insertAdjacentHTML()`, or `document.write()`.
 
@@ -42,7 +42,7 @@ function renderContent(html: string) {
 }
 ```
 
-### 3. href Variable with javascript: URL
+## 3. href Variable with javascript: URL
 
 Flows from user input, a database value, or an API response into `<a href={variable}>` or `location.href = variable`.
 


### PR DESCRIPTION
## Summary

#329 の 3 段のうち 1 と 2 を行った。416 ファイル 27 件が 0 件になった。**`.rumdl.toml` には例外を 1 つも足していない。** hook 本体 (3 段目) は保留のまま。

```toml
[global]
disable = ["MD013", "MD014"]
```

| ルール | 件数 | 直し方 |
| --- | --- | --- |
| MD057 壊れた相対リンク | 16 | `[ラベル](パス)` を ラベル (`パス`) へ |
| MD001 見出しレベルの飛び | 4 | `###` を `##` へ (3 個とも) |
| MD036 見出し代わりの強調 | 3 | 太字を外し MADR テンプレートへ戻す |
| MD038 コードスパン内のスペース | 2 | 末尾スペースを外す |
| MD012 連続する空行 | 1 | EOF の余分な空行を削る |
| MD034 裸の URL | 1 | `.ja` 側に合わせて `<...>` で囲む |

## 例外を作らずに済んだ根拠

最初は `[per-file-ignores]` で 3 つの除外を書いた。1 件ずつ当たると、どれも内容の側の欠陥だった。

### MD036 は雛形から外れていた

`skills/dr/templates/madr-template.md:35` は `Chosen option: "{chosen option}", because {...}.` を**素の散文**で書く。太字は雛形に無い。3 件を素の散文へ戻した。

### MD038 は末尾スペースを外せた

`.ja/skills/qualify/SKILL.md` の ugrep パターンを `build.js` に当てて確かめた。

```
$ ugrep -c "const validate = |const UNIT_CAPS = |const oversizedUnits = " workflows/build.js
3
$ ugrep -c "const validate =|const UNIT_CAPS =|const oversizedUnits =" workflows/build.js
3
```

`skills/qualify/tests/contract.test.js` が SKILL.md 側の期待としてこの文字列を持っていたので、そちらも揃えた。build.js の実文字列を見る 2 本は触っていない。

`agents/reviewers/reviewer-rust.md:45` の `` `let _ = ` `` は表のセルで、末尾スペースは体裁だけだった。`` `let _ =` `` にした。英語側だけが末尾スペースを持ち、`.ja` は既に持たなかった。

### MD057 は 1 種類ではなかった

| 参照先 | 件数 | 正体 |
| --- | --- | --- |
| `workspace/planning/...`、`workspace/research/...` | 10 | DR-0090 が untracked と決めた場所 |
| `skills/applying-code-principles/SKILL.md` | 4 | 削除済み。後継なし |
| `rules/workflows/MODULARIZATION_RULES.md`、`rules/conventions/PLUGIN_ARCHITECTURE.md` | 2 | 削除済み。後継なし |

`find` で 4 つの参照先を探し、どれも後継が無いことを確かめた。16 件とも解決しないリンクで、DR は accepted な記録なので文言とパスは残す。link 記法だけを外した。

```diff
-- [Miller's Law](../../skills/applying-code-principles/SKILL.md) - 認知負荷原則
+- Miller's Law (`../../skills/applying-code-principles/SKILL.md`) - 認知負荷原則
```

ラベルがパスの basename と重なる 5 行は、ラベルを落としてパスだけ残した。

```diff
-- [MODULARIZATION_RULES.md](../rules/workflows/MODULARIZATION_RULES.md)
+- `../rules/workflows/MODULARIZATION_RULES.md`
```

## 自動修正は 2 回とも使えなかった

### MD001

`rumdl fmt` は `### 1. postMessage...` の先頭 1 個だけを `##` にする。`skills/use-context-reviewer-security/references/` の兄弟 5 ファイルは `##` を使い、`frontend-taint-data.md` と `frontend-taint-html.md` だけが `###` を 3 個ずつ持つ。先頭だけ直すとファイル内が混在し、直す前より悪くなる。3 個とも手で直した。

### prettier

見出しを直したあと prettier をかけると、コードブロック内の JS 例が折り返された。

```diff
-  if (url.origin === location.origin && ALLOWED_PATHS.some((p) => url.pathname.startsWith(p))) {
+  if (
+    url.origin === location.origin &&
+    ALLOWED_PATHS.some((p) => url.pathname.startsWith(p))
+  ) {
```

例として読ませる断片なので戻した。この 4 ファイルは見出しの 3 行だけを変えている。

## Testing

`rumdl check .` が 416 ファイルで `Success: No issues found`。495 テスト緑、textlint 緑、変更した Markdown は prettier 緑。

## CI のゲートに載せた

0 件を保つ機構が他に無い。issue の Alternatives は「CI でのみ検査する」を「修正が PR レビュー時まで遅れる」として退けているが、それは hook の代わりとしての却下で、hook が保留の今は CI が唯一の選択肢になる。

```yaml
- name: rumdl
  run: pipx run --spec rumdl==0.2.58 rumdl check .
```

`fmt` でなく `check` にした。上の 2 例で自動修正が内容を壊している。exit code は違反ゼロで 0、違反ありで 1 を返すことを確かめた。ruff と同じ `pipx run --spec` の形で版を固定する。

Refs #329

https://claude.ai/code/session_01WKMAvw3AWjxKTW29eeJeKq
