### PR TITLE
chore(docs): 表を説明する段落を表の前へ移し、検出器の導入文の誤検出を直す

### DIFF
--- a/.ja/docs/COMMANDS.md
+++ b/.ja/docs/COMMANDS.md
@@ -28,6 +28,8 @@ flowchart LR
 
 `Workflow({name: "build", args: {issue, repo, base?}})` で起動する。Plan 節付き issue を入力に、7 つの stage を決定論スクリプトとして実行する。判断の分担は「抽出と実装は LLM、検証と進行はスクリプト」で、LLM の出力は毎回スクリプト側の照合を通る。
 
+正しさの確認は plan 自身のアンカー (Preconditions、files スコープ、T-NNN 言明、conformance) との比較であり、範囲を定めない欠陥探索ではない。欠陥探索は draft PR への `/audit` が担う。
+
 | Stage      | 内容                                                                                                    |
 | ---------- | ------------------------------------------------------------------------------------------------------- |
 | Load       | issue 本文を逐語 fetch し、`## Plan` の U-NNN/T-NNN id を決定論収集。LLM 抽出の結果と id クロスチェック |
@@ -37,8 +39,6 @@ flowchart LR
 | Cleanup    | simplify skill による整理と test 検証。テストが落ちたら編集を stash で巻き戻す                          |
 | Verify     | 決定論チェック (diff スコープ + T-NNN 照合) と並行して conformance/structure review                     |
 | Ship       | 残余 commit + draft PR。PR 本文の fact 節はデータから決定論レンダリングする                             |
-
-正しさの確認は plan 自身のアンカー (Preconditions、files スコープ、T-NNN 言明、conformance) との比較であり、範囲を定めない欠陥探索ではない。欠陥探索は draft PR への `/audit` が担う。
 
 ### 停止条件
 
@@ -86,6 +86,8 @@ build が入れ子で呼ぶのは code のみ。他は単体起動する。
 
 ## Command → 実装マッピング
 
+skill は SKILL.md の手順を会話の文脈で実行し、workflow はスクリプトが進行を強制する。fan-out、ループ、ゲートを持つ処理は workflow に置き、LLM の裁量で飛ばせない形にする ([WORKFLOWS](../rules/conventions/WORKFLOWS.md))。
+
 | コマンド  | 実装                    | 形態                                    |
 | --------- | ----------------------- | --------------------------------------- |
 | `/think`  | `skills/think/SKILL.md` | skill (critic-design を起動)            |
@@ -94,8 +96,6 @@ build が入れ子で呼ぶのは code のみ。他は単体起動する。
 | `/code`   | `workflows/code.js`     | workflow (build から入れ子でも呼ばれる) |
 | `/audit`  | `workflows/audit.js`    | workflow                                |
 | `/polish` | `workflows/polish.js`   | workflow                                |
-
-skill は SKILL.md の手順を会話の文脈で実行し、workflow はスクリプトが進行を強制する。fan-out、ループ、ゲートを持つ処理は workflow に置き、LLM の裁量で飛ばせない形にする ([WORKFLOWS](../rules/conventions/WORKFLOWS.md))。
 
 ## 関連
 

--- a/.ja/docs/SECURITY_MODEL.md
+++ b/.ja/docs/SECURITY_MODEL.md
@@ -12,13 +12,13 @@ LLM はテキスト生成器であり、tool_use は出力フォーマットの 
 
 shields (コマンドガード、ファイル ACL、secrets チェック) は同ファミリーのバイナリだが `settings.json` へ配線しておらず、防御には数えない ([HOOKS](./HOOKS.md)の休止中を参照)。
 
+重要: L1 と L2 は人間の介入ポイントの調整 (UX)。L3 が実セキュリティ境界。
+
 | レイヤー            | 実装                                            | 何を止めるか                       | Bash 経由でバイパス可能か |
 | ------------------- | ----------------------------------------------- | ---------------------------------- | ------------------------- |
 | L1: Deny Rules      | `settings.json` の `permissions.deny` (43 件)   | 個別 tool_use ブロック             | 可                        |
 | L2: PreToolUse Hook | `hooks/security/` 3 本 + `hooks/pre-bash/` 3 本 | Bash 内の危険パターン              | 部分的                    |
 | L3: Process Sandbox | sandbox-runtime (`settings.json` の `sandbox`)  | ファイルシステム書込とネットワーク | 不可                      |
-
-重要: L1 と L2 は人間の介入ポイントの調整 (UX)。L3 が実セキュリティ境界。
 
 ### L3 の現在の設定
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -28,6 +28,8 @@ A fix confined to 1-3 files skips this column and completes directly via `/fix <
 
 Launched via `Workflow({name: "build", args: {issue, repo, base?}})`. Taking a plan-backed issue as input, it runs 7 stages as a deterministic script. The division of labor is "extraction and implementation go to the LLM, verification and progression stay in the script": every LLM output passes a script-side cross-check.
 
+Correctness checking is a comparison against the plan's own anchors (Preconditions, files scope, T-NNN statements, conformance), not an open-ended defect hunt. Defect hunting belongs to `/audit` on the draft PR.
+
 | Stage      | What it does                                                                                                         |
 | ---------- | -------------------------------------------------------------------------------------------------------------------- |
 | Load       | Fetch the issue body verbatim, collect `## Plan` U-NNN / T-NNN ids deterministically, cross-check the LLM extraction |
@@ -37,8 +39,6 @@ Launched via `Workflow({name: "build", args: {issue, repo, base?}})`. Taking a p
 | Cleanup    | A simplify-skill pass with test validation. Failing tests roll the edits back via stash                              |
 | Verify     | Deterministic checks (diff scope + T-NNN matching) alongside conformance / structure reviews                         |
 | Ship       | Remainder commit + draft PR. The PR body's fact sections are rendered deterministically from data                    |
-
-Correctness checking is a comparison against the plan's own anchors (Preconditions, files scope, T-NNN statements, conformance), not an open-ended defect hunt. Defect hunting belongs to `/audit` on the draft PR.
 
 ### Stop Conditions
 
@@ -86,6 +86,8 @@ build nests only code. The others launch standalone.
 
 ## Command → Implementation Mapping
 
+A skill executes its SKILL.md procedure in the conversation context; a workflow's script enforces progression. Processing that carries fan-out, loops, or gates goes into a workflow, in a shape the LLM cannot skip at its discretion ([WORKFLOWS](../rules/conventions/WORKFLOWS.md)).
+
 | Command   | Implementation          | Form                                   |
 | --------- | ----------------------- | -------------------------------------- |
 | `/think`  | `skills/think/SKILL.md` | Skill (launches critic-design)         |
@@ -94,8 +96,6 @@ build nests only code. The others launch standalone.
 | `/code`   | `workflows/code.js`     | Workflow (also nested from build)      |
 | `/audit`  | `workflows/audit.js`    | Workflow                               |
 | `/polish` | `workflows/polish.js`   | Workflow                               |
-
-A skill executes its SKILL.md procedure in the conversation context; a workflow's script enforces progression. Processing that carries fan-out, loops, or gates goes into a workflow, in a shape the LLM cannot skip at its discretion ([WORKFLOWS](../rules/conventions/WORKFLOWS.md)).
 
 ## Related
 

--- a/docs/SECURITY_MODEL.md
+++ b/docs/SECURITY_MODEL.md
@@ -12,13 +12,13 @@ ref: <https://zenn.dev/commander/articles/72a907ce68a8c1>
 
 shields (command guard, file ACL, secrets check) belongs to the same binary family but is not wired into `settings.json`, so it does not count as a layer (see Dormant in [HOOKS](./HOOKS.md)).
 
+Important: L1 and L2 tune human intervention points (UX). L3 is the actual security boundary.
+
 | Layer               | Implementation                                        | What It Stops                  | Bypass via Bash |
 | ------------------- | ----------------------------------------------------- | ------------------------------ | --------------- |
 | L1: Deny Rules      | `settings.json` `permissions.deny` (43 rules)         | Per tool_use block             | Yes             |
 | L2: PreToolUse Hook | 3 hooks in `hooks/security/` + 3 in `hooks/pre-bash/` | Dangerous patterns inside Bash | Partial         |
 | L3: Process Sandbox | sandbox-runtime (`settings.json` `sandbox`)           | Filesystem writes and network  | No              |
-
-Important: L1 and L2 tune human intervention points (UX). L3 is the actual security boundary.
 
 ### Current L3 Configuration
 

--- a/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md
+++ b/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md
@@ -124,6 +124,8 @@ Phase 2 PR で JSON schema を `serde` 派生型として実装し、本 ADR の
 
 複数分類が当てはまる場合の優先順位。scout の実エラーソース (clap parse/URL invalid/404/rate limit/timeout/JSON parse/network IO) から 5 段に絞る。
 
+ルールの読み方: 上から順に評価。マッチした時点で確定。例: GitHub API から 404 と rate limit 余地のあるレスポンスが同時にあった場合、優先 3 で 66 NOT_FOUND を採用 (rate limit より先に 404 評価)。
+
 | 優先 | ルール                                            | 分類                               |
 | ---- | ------------------------------------------------- | ---------------------------------- |
 | 1    | env var missing / 設定起因 / 引数誤り             | 64 USAGE_ERROR                     |
@@ -132,8 +134,6 @@ Phase 2 PR で JSON schema を `serde` 派生型として実装し、本 ADR の
 | 4    | retry で回復見込みあり (rate limit, 5xx, timeout) | 75 TEMP_FAILURE または 124 TIMEOUT |
 | 5    | アプリ内部不具合と判断できる                      | 70 INTERNAL                        |
 | 退避 | 上記いずれにも分類できない                        | 104 UNKNOWN                        |
-
-ルールの読み方: 上から順に評価。マッチした時点で確定。例: GitHub API から 404 と rate limit 余地のあるレスポンスが同時にあった場合、優先 3 で 66 NOT_FOUND を採用 (rate limit より先に 404 評価)。
 
 `UNKNOWN` が増える場合は分類設計の signal。`anyhow::Error` の握り潰しを検知する目的で意図的に独立。
 

--- a/docs/decisions/0069-adopt-yomu-indirect-prompt-injection-defense.md
+++ b/docs/decisions/0069-adopt-yomu-indirect-prompt-injection-defense.md
@@ -49,12 +49,12 @@ chunks テーブル schema version 9 で 2 column 追加 (additive ALTER ADD COL
 
 JSON 出力で 2 field 追加 (additive optional):
 
+silent-default-false の罠 (空配列 `[]` が「検査済みクリーン」と誤読される) を構造的に排除する。`injection_flags` の field 不在 = matcher 未走行、空 Vec = matcher 走行 + ヒットなし、Some Vec = matcher 走行 + ヒット。`injection_check` sentinel は response 単位で matcher 状態を 1 箇所に集約し、consumer が「matcher 未走行の chunk を LLM 投入してはならない」契約を実装できる。
+
 | Field             | 位置               | 型                  | serde 属性                                           |
 | ----------------- | ------------------ | ------------------- | ---------------------------------------------------- |
 | `injection_flags` | per-chunk          | `Option<Vec<&str>>` | `skip_serializing_if = "Option::is_none"`、`default` |
 | `injection_check` | response top-level | enum sentinel       | 必須。3 値: `ran`、`skipped`、`unavailable`          |
-
-silent-default-false の罠 (空配列 `[]` が「検査済みクリーン」と誤読される) を構造的に排除する。`injection_flags` の field 不在 = matcher 未走行、空 Vec = matcher 走行 + ヒットなし、Some Vec = matcher 走行 + ヒット。`injection_check` sentinel は response 単位で matcher 状態を 1 箇所に集約し、consumer が「matcher 未走行の chunk を LLM 投入してはならない」契約を実装できる。
 
 ### Migration
 

--- a/tests/table-paragraph.test.js
+++ b/tests/table-paragraph.test.js
@@ -1,6 +1,7 @@
 // MARKDOWN.md § Do not puts a table's explanation before the table, so the reader holds the rule
-// before the rows it governs. docs/** (48) still carries paragraphs below its tables and stays out
-// of this scan until it is cleaned. workflows/ and commands/ hold no markdown.
+// before the rows it governs. docs/** stays out: its paragraphs below a table read that table's
+// result back, or carry the section around it, and hoisting either one degrades the page (#450).
+// workflows/ and commands/ hold no markdown.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile, readdir } from "node:fs/promises";
@@ -34,8 +35,13 @@ const DERIVED_CONCLUSIONS = new Map([
 
 // An ordered list is not a paragraph, and reading `1. foo` as one fails a file that carries steps.
 const CONTINUES_A_BLOCK = /^(?:[|#>*-]|\d+[.)]\s)/;
+const OPENS_A_BLOCK = /^(?:[|*-]|\d+[.)]\s|```)/;
 
 const keyFor = (path, text) => `${path} :: ${text.split(/(?<=[。.])\s*/)[0]}`;
+const nextNonEmpty = (lines, i) => {
+  for (let j = i + 1; j < lines.length; j++) if (lines[j].trim()) return lines[j].trim();
+  return "";
+};
 
 const markdownUnder = async (dir) => {
   let entries;
@@ -68,7 +74,11 @@ const paragraphsAfterTables = (source) => {
       continue;
     }
     if (inFence || !line) continue;
-    if (inTable && !CONTINUES_A_BLOCK.test(line)) out.push({ line: i + 1, text: line });
+    // A paragraph the next block opens under introduces that block, not the table above it.
+    // The lookahead sits last so it runs only for a line that is otherwise a hit.
+    if (inTable && !CONTINUES_A_BLOCK.test(line) && !OPENS_A_BLOCK.test(nextNonEmpty(lines, i))) {
+      out.push({ line: i + 1, text: line });
+    }
     inTable = line.startsWith("|");
   }
   return out;
@@ -115,4 +125,23 @@ test("every DERIVED_CONCLUSIONS entry still names a paragraph that exists", asyn
     [],
     `DERIVED_CONCLUSIONS holds entries that no longer occur:\n${stale.join("\n")}`,
   );
+});
+
+// Two of these shapes occur nowhere in the tree, so a scan of it passes however they are handled.
+test("the classifier separates a trailing explanation from the shapes that are not one", () => {
+  const table = "| a | b |\n| - | - |\n| 1 | 2 |\n";
+  const cases = [
+    ["a trailing paragraph", `${table}\nExplains the rows above.\n`, ["Explains the rows above."]],
+    ["an ordered list", `${table}\n1. A step, not a paragraph.\n`, []],
+    ["a lead-in to a list", `${table}\nThe options are:\n\n- one\n`, []],
+    ["a lead-in to a table", `${table}\nThe next table:\n\n${table}`, []],
+    ["a fenced block", `${table}\n\`\`\`\nnot prose\n\`\`\`\n`, []],
+  ];
+  for (const [name, source, expected] of cases) {
+    assert.deepEqual(
+      paragraphsAfterTables(source).map((h) => h.text),
+      expected,
+      name,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

`docs/**` の「表の後の段落」を 1 件ずつ見た。**表の説明だったのは 8 件で、残りは表が導いた結論か MADR の物語だった。** #450 の判断材料として、分けた結果を全て記録する。

`tests/table-paragraph.test.js` の走査範囲は変えていない。`docs` は依然として対象外。

## 分類

| 種別 | 件数 | 扱い |
| --- | --- | --- |
| 表の説明 | 8 | 表の前へ移した |
| 表が導いた結論 / MADR の物語 | 33 | 残した。MARKDOWN.md の該当行が #447 で例外を持っている |
| 次のリストへの導入文 | 7 | 検出器の誤検出。分類器を直した |

判定は「表の上へ移して読めるか」で行った。移すと直前の指示語や接続詞が宙に浮くものは、表が導いた側と判断した。

### 移した 8 件

| ファイル | 段落 |
| --- | --- |
| `docs/COMMANDS.md` (+`.ja`) | `Correctness checking is a comparison against the plan's own anchors...` |
| `docs/COMMANDS.md` (+`.ja`) | `A skill executes its SKILL.md procedure...; a workflow's script enforces progression.` |
| `docs/SECURITY_MODEL.md` (+`.ja`) | `Important: L1 and L2 tune human intervention points (UX). L3 is the actual security boundary.` |
| `docs/decisions/0065-...` | `ルールの読み方: 上から順に評価。マッチした時点で確定。` |
| `docs/decisions/0069-...` | `silent-default-false の罠 ... を構造的に排除する。` |

いずれも表そのものの読み方か、行に対する例外を述べている。

### 残した 33 件の例

```
[2] 0012:53  ## Decision Outcome
    Compound-reviewer layer removed in all tiers.        ← 選択肢の表が導いた結論

[19] 0055:19 ## Context and Problem Statement
    それぞれ役割を示す prefix だが alphabetical に散るため...  ← 「それぞれ」が表の行を指す
```

`## Context and Problem Statement` の 16 件は、MADR の物語が表を挟んで進む形になる。表を先に説明する規則の対象ではない。

## HOOKS.md の 6 件は移してから戻した

一度移したところ、節の見え方が悪化した。

```
## Execution Layers

The Rust binaries are also distributed as sentinels plugins, but registration goes through ...

A hook is a shell script when its work is a few checks and a fork, and Python when ...
A test is written in the language of the hook it covers. ...
On the Python side, one method stops at its first failure and skips the assertions after it. ...

| Layer         | Implementation                 | Registration                     |
```

節の冒頭 1 文は registration の話で、表もそれを受ける。あいだの 3 段落は shell と Python の使い分けとテストの話で、表の説明ではない。前へ出すと表が節末尾まで押し出され、表を導く文から離れる。

この 6 件は「節の本文が表を挟んで続く」形で、#447 で足した「表が導いた結論」とも違う第 3 の形になる。

## 検出器の 3 つ目の欠陥を直した

次のリストや表への導入文を、表の後の段落として数えていた。

```
| ... 表 ... |

wiki-worthyの判定基準:

- 判定 1
- 判定 2
```

`wiki-worthyの判定基準:` は後続のリストを導く文で、表の説明ではない。次の非空行がリスト、表、フェンスのいずれかで始まる段落を除外した。

走査対象の `agents` / `rules` / `skills` に導入文は 1 件も無く、リポジトリを相手にした検査ではこの誤検出を捕まえられない。合成入力で分類器そのものを見るテストを足した。

| 入力 | 期待 |
| --- | --- |
| 表 → 段落 | 検出する |
| 表 → 順序付きリスト | 検出しない |
| 表 → 導入文 → リスト | 検出しない |
| 表 → 導入文 → 表 | 検出しない |
| 表 → フェンス | 検出しない |

## Testing

破壊検査 2 件。どちらも分類器の規則を 1 つずつ外して、合成入力のテストが落ちることを見た。

| 破壊 | 結果 |
| --- | --- |
| 導入文の除外を外す | 落ちた |
| 順序付きリストの除外を外す | 落ちた |

496 テスト緑、rumdl / textlint / oxlint 緑、変更した Markdown は prettier 緑。

## 残っているもの

`docs/**` に 41 件 (DR 35、HOOKS.md 6、`.ja` 側を含む)。走査対象へ広げるには、この 41 件を許容する形を決める必要がある。#450 はそのために開けておく。

Refs #450

https://claude.ai/code/session_01WKMAvw3AWjxKTW29eeJeKq
