### PR TITLE
chore(docs): 表の説明を表の前へ移し、走査を docs へ広げる

### DIFF
--- a/.ja/docs/HOOKS.md
+++ b/.ja/docs/HOOKS.md
@@ -11,6 +11,8 @@ Rust バイナリは sentinels プラグインとしても配布するが、登�
 | スクリプト hooks | `~/.claude/hooks/**/*.{sh,py}` | `settings.json`                  |
 | Rust バイナリ    | `brew install thkt/tap/{tool}` | `settings.json` (コマンド直登録) |
 
+### 言語
+
 hook をシェルスクリプトで書くのは、仕事が数個の判定と 1 回の fork で済むとき。構造が要るほど処理が長いか、テストと共有するときは Python で書く。`mirror_prose_guard.py` が後者で、規則そのものは `_lib/mirror_prose.py` にあり、リポジトリ一括検査のテストも同じモジュールを読む。
 
 テストは hook 本体と同じ言語で書く。シェルに残すのは、スタブとしてシェルスクリプトを PATH へ置くものだけで、`amphetamine_agent_session` の osascript と `rust-edit` の cargo がこれにあたる。
@@ -21,6 +23,12 @@ Python 側では、1 つのメソッドが最初の失敗で止まると残り�
 
 ディレクトリがイベントを答えるので、ファイル名は対象と操作を答える。形は `<対象>_<操作>` で、対象はこの hook が見るもの、操作はそれに対して何をするか。読み手は先頭の語で対象を絞り込める。
 
+Python はアンダースコアで区切る。shell はハイフンで区切る。`_lib/` のモジュールは import されるので、語の区切りにアンダースコアが要る。hook 本体どうしは import しないため、技術的な縛りが無い。それでも揃えるのは、テスト名が `<hook 名>_test.py` で一致し、hook からテストを変換なしで引けるため。
+
+操作を表す語は、名詞としても読める語 (guard/gate/fix/index/alert/rewrite) を選ぶ。`notify` のような動詞専用の語は名前として据わりが悪い。既に英語として読める動詞句 (`rm_to_trash`, `body_proofread`) はそのまま置く。
+
+例外は 2 つ。外部アプリを丸ごと扱うものは `<アプリ名>_<管理対象>` とし、`amphetamine_agent_session` は「エージェントのターン中だけ」という限定を名前に残す。1 語で足りるものは 1 語で置く (`statusline`)。複数の hook をまとめて見るテストは、その群を表す名前を持つ (`rust-edit.test.sh` は pre/post の 2 本と `_lib/rust_target.py` を見る)。
+
 | 種別            | 形                  | 例                          |
 | --------------- | ------------------- | --------------------------- |
 | Python hook     | `<対象>_<操作>.py`  | `git_sandbox_guard.py`      |
@@ -28,12 +36,6 @@ Python 側では、1 つのメソッドが最初の失敗で止まると残り�
 | _lib モジュール | `<名詞>.py`         | `command_scan.py`           |
 | Python テスト   | `<hook 名>_test.py` | `git_sandbox_guard_test.py` |
 | shell テスト    | `<hook 名>.test.sh` | `failure-alert.test.sh`     |
-
-Python はアンダースコアで区切る。shell はハイフンで区切る。`_lib/` のモジュールは import されるので、語の区切りにアンダースコアが要る。hook 本体どうしは import しないため、技術的な縛りが無い。それでも揃えるのは、テスト名が `<hook 名>_test.py` で一致し、hook からテストを変換なしで引けるため。
-
-操作を表す語は、名詞としても読める語 (guard/gate/fix/index/alert/rewrite) を選ぶ。`notify` のような動詞専用の語は名前として据わりが悪い。既に英語として読める動詞句 (`rm_to_trash`, `body_proofread`) はそのまま置く。
-
-例外は 2 つ。外部アプリを丸ごと扱うものは `<アプリ名>_<管理対象>` とし、`amphetamine_agent_session` は「エージェントのターン中だけ」という限定を名前に残す。1 語で足りるものは 1 語で置く (`statusline`)。複数の hook をまとめて見るテストは、その群を表す名前を持つ (`rust-edit.test.sh` は pre/post の 2 本と `_lib/rust_target.py` を見る)。
 
 ## 実行の絞り込み
 
@@ -201,12 +203,12 @@ shields (コマンドガード、ファイル ACL、secrets チェック) と re
 
 このモードが名指すのは、スクリプト自身がエラーにどう反応するかであって、ツール呼び出しが生き延びるかどうかではない。呼び出しを止められるのは PreToolUse の hook だけで、止め方は決定を出力することであり、非 0 で終わることではない。hook がエラーで終わっても Claude Code は動き続ける。
 
+fail-closed の hook が特定の失敗を 1 つだけ無視するのは格下げではない。`textlint_fix.py` は自身の欠陥では止まるが textlint の終了コードは無視する。この hook が走る時点で編集はすでに適用されているからである。
+
 | モード      | スクリプトの振る舞い                   | シェルでの書き方    | Python での書き方        | 使う場面          |
 | ----------- | -------------------------------------- | ------------------- | ------------------------ | ----------------- |
 | fail-open   | エラーを踏み越えて 0 で終わる          | `set +e`            | 例外を握って return する | 観測と通知の hook |
 | fail-closed | 自身の欠陥を含め、最初のエラーで止まる | `set -euo pipefail` | 例外を伝播させる         | 安全と規約の hook |
-
-fail-closed の hook が特定の失敗を 1 つだけ無視するのは格下げではない。`textlint_fix.py` は自身の欠陥では止まるが textlint の終了コードは無視する。この hook が走る時点で編集はすでに適用されているからである。
 
 ### 4. 組み合わせられる
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -11,6 +11,8 @@ The Rust binaries are also distributed as sentinels plugins, but registration go
 | Script hooks  | `~/.claude/hooks/**/*.{sh,py}` | `settings.json`                  |
 | Rust binaries | `brew install thkt/tap/{tool}` | `settings.json` (direct command) |
 
+### Language
+
 A hook is a shell script when its work is a few checks and a fork, and Python when the logic
 is long enough to want structure or is shared with a test. `mirror_prose_guard.py` is the second
 kind: its rule lives in `_lib/mirror_prose.py` and the repository-wide sweep test imports the same
@@ -32,14 +34,6 @@ The directory answers which event, so the filename answers the target and the op
 shape is `<target>_<operation>`: the target is what this hook looks at, the operation is what it
 does to it. A reader narrows by the leading word.
 
-| Kind        | Shape                 | Example                     |
-| ----------- | --------------------- | --------------------------- |
-| Python hook | `<target>_<op>.py`    | `git_sandbox_guard.py`      |
-| shell hook  | `<target>-<op>.sh`    | `failure-alert.sh`          |
-| _lib module | `<noun>.py`           | `command_scan.py`           |
-| Python test | `<hook name>_test.py` | `git_sandbox_guard_test.py` |
-| shell test  | `<hook name>.test.sh` | `failure-alert.test.sh`     |
-
 Python separates with underscores, shell with hyphens. A module under `_lib/` is imported, so underscores are required between its
 words, and the hooks themselves import none of each other, so nothing technical binds them.
 They match anyway because it makes the test name land on `<hook name>_test.py`, reachable from
@@ -53,6 +47,14 @@ Two exceptions. Something wrapping an external app whole takes `<app>_<what it m
 `amphetamine_agent_session` keeps "only during an agent's turn" in the name. Something a single
 word covers stays one word (`statusline`). A test covering several hooks at once carries a name
 for that group (`rust-edit.test.sh` covers the pre/post pair plus `_lib/rust_target.py`).
+
+| Kind        | Shape                 | Example                     |
+| ----------- | --------------------- | --------------------------- |
+| Python hook | `<target>_<op>.py`    | `git_sandbox_guard.py`      |
+| shell hook  | `<target>-<op>.sh`    | `failure-alert.sh`          |
+| _lib module | `<noun>.py`           | `command_scan.py`           |
+| Python test | `<hook name>_test.py` | `git_sandbox_guard_test.py` |
+| shell test  | `<hook name>.test.sh` | `failure-alert.test.sh`     |
 
 ## Narrowing the work
 
@@ -235,12 +237,12 @@ once per window", is the exception and says so where it is written.
 
 The mode names how the script itself reacts to an error, not whether the tool call survives. Only a PreToolUse hook can stop a call, and it does so by printing a decision rather than by exiting non-zero. Claude Code keeps running when a hook exits with an error.
 
+A fail-closed hook can still ignore one specific failure, which is not a downgrade: `textlint_fix.py` stops on its own defects and ignores textlint's exit code, because the edit has already landed by the time it runs.
+
 | Mode        | The script                                          | In shell            | In Python                  | Used by                            |
 | ----------- | --------------------------------------------------- | ------------------- | -------------------------- | ---------------------------------- |
 | fail-open   | Runs past an error and exits 0                      | `set +e`            | Catches and returns        | Observation and notification hooks |
 | fail-closed | Stops at the first error, including its own defects | `set -euo pipefail` | Lets the exception through | Security and convention hooks      |
-
-A fail-closed hook can still ignore one specific failure, which is not a downgrade: `textlint_fix.py` stops on its own defects and ignores textlint's exit code, because the edit has already landed by the time it runs.
 
 ### 4. Composable
 

--- a/docs/decisions/0029-integrate-e2e-test-generation-into-spec-driven-workflow.md
+++ b/docs/decisions/0029-integrate-e2e-test-generation-into-spec-driven-workflow.md
@@ -57,6 +57,8 @@ Spec駆動のE2Eテスト生成を /codeと /featureに統合する。専用agen
 
 ## 変更対象
 
+変更なし: generator-test, evaluator-test, generating-tdd-tests
+
 | ファイル                                                     | 変更内容                                                       |
 | ------------------------------------------------------------ | -------------------------------------------------------------- |
 | `templates/spec/template.md`                                 | Test Scenarios に `Type: e2e` 行追加                           |
@@ -65,8 +67,6 @@ Spec駆動のE2Eテスト生成を /codeと /featureに統合する。専用agen
 | `skills/feature/SKILL.md`                                    | Phase 4.5 拡張（スクショ後に E2E 生成）                        |
 | `skills/orchestrating-workflows/references/code-workflow.md` | E2E phase 追記                                                 |
 | `skills/e2e/SKILL.md`                                        | 廃止                                                           |
-
-変更なし: generator-test, evaluator-test, generating-tdd-tests
 
 ## 起動条件
 

--- a/docs/decisions/0030-build-session-monitor-tui-mado.md
+++ b/docs/decisions/0030-build-session-monitor-tui-mado.md
@@ -62,13 +62,13 @@ ratatuiベースのRust TUIバイナリ `mado` を新規構築する。Ghostty s
 
 ### データソース: JSONL のみ
 
+実証: gatesプロジェクトのJSONLでhook_progress 3,973件、stop_hook_summary 198件を確認。preventedContinuationフィールドでpass/block判定可能。
+
 | 検討した方式   | 判定 | 理由                                                                       |
 | -------------- | ---- | -------------------------------------------------------------------------- |
 | JSONL のみ     | 採用 | hook_progress, stop_hook_summary が JSONL に記録済み。追加データソース不要 |
 | Event ファイル | 却下 | gates/shields 側の改修が必要。疎結合だが YAGNI                             |
 | 共有 SQLite    | 却下 | recall との結合度が上がる。責務が異なる                                    |
-
-実証: gatesプロジェクトのJSONLでhook_progress 3,973件、stop_hook_summary 198件を確認。preventedContinuationフィールドでpass/block判定可能。
 
 ### Terminal Jump: AppleScript + cwd マッチ
 

--- a/docs/decisions/0060-adopt-agent-friendly-cli-design-principles.md
+++ b/docs/decisions/0060-adopt-agent-friendly-cli-design-principles.md
@@ -84,6 +84,8 @@ Chosen option: Option B (3 軸 + 補強 + 将来課題の段階導入)。エー�
 
 2023 年改訂の製品品質モデルは旧 Usability を Interaction capability に再定義し、副特性を拡張した。本 ADR の 3 軸はエージェントを利用者と置いたときの Interaction capability の実装形に相当し、レビュー時の観点語彙として以下の対応を使う。
 
+Appropriateness recognizability / User engagement / Inclusivity は人間 UI 前提の副特性であり、エージェント利用者では判定対象にしない。
+
 | 25010:2023 副特性                | 本 ADR での対応                                                              |
 | -------------------------------- | ---------------------------------------------------------------------------- |
 | Self-descriptiveness (2023 新設) | 自己発見軸 (Noun-Verb, `conflicts_with`) + 将来課題の describe コマンド      |
@@ -91,8 +93,6 @@ Chosen option: Option B (3 軸 + 補強 + 将来課題の段階導入)。エー�
 | Learnability                     | Noun-Verb 命名のツール間一貫性                                               |
 | Operability                      | 機械可読軸 (`--json`, stdout/stderr 分離) + stdin 統一 + BrokenPipe handling |
 | User assistance                  | エラー JSON の `next_step` (将来課題の必須化対象)                            |
-
-Appropriateness recognizability / User engagement / Inclusivity は人間 UI 前提の副特性であり、エージェント利用者では判定対象にしない。
 
 ### Reassessment Triggers
 

--- a/docs/decisions/0061-adopt-meta-edit-declaration-pattern-as-a-new-sentinel.md
+++ b/docs/decisions/0061-adopt-meta-edit-declaration-pattern-as-a-new-sentinel.md
@@ -118,14 +118,14 @@ A weekly read of per-project `.declarator/state/edits.jsonl` (aggregated across 
 
 ### Related Issues (to be filed after acceptance)
 
+Starting kinds for the Phase 1 MVP (subject to revision in the Phase 1 Issue based on baseline observation): `edit_refactor_only`, `edit_boundary_condition`, `edit_docs_only`. Rationale: the first covers the largest share of "minor change" self-classifications that decay catches, the second is the smallest concrete bug class with a sharp test obligation, the third unblocks the docs-batch workflow that meta-edit observed as the highest bypass-pressure surface.
+
 | Repo                            | Scope                                                                     | Phase                                           |
 | ------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
 | `~/GitHub/cli/declarator` (new) | MCP server + PreToolUse hook + edit log MVP (3 starting kinds, see below) | 1                                               |
 | `~/GitHub/plugins/sentinels`    | Register declarator plugin into the marketplace once Phase 1 ships        | 1                                               |
 | `~/GitHub/cli/gates`            | Kind-bound test selection (G2)                                            | 2 (deferred until Phase 1 reassessment trigger) |
 | `~/GitHub/cli/chronicler`       | Kind metadata in edit detection (G3)                                      | 2 (deferred until Phase 1 reassessment trigger) |
-
-Starting kinds for the Phase 1 MVP (subject to revision in the Phase 1 Issue based on baseline observation): `edit_refactor_only`, `edit_boundary_condition`, `edit_docs_only`. Rationale: the first covers the largest share of "minor change" self-classifications that decay catches, the second is the smallest concrete bug class with a sharp test obligation, the third unblocks the docs-batch workflow that meta-edit observed as the highest bypass-pressure surface.
 
 ### Spike Reference
 

--- a/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md
+++ b/docs/decisions/0065-scout-json-output-schema-and-sysexits-exit-code-policy.md
@@ -106,6 +106,8 @@ Phase 2 PR で JSON schema を `serde` 派生型として実装し、本 ADR の
 | 124      | GNU coreutils `timeout` 慣例           | `--preserve-status` 非指定時 |
 | 80-104   | PJ 拡張枠 (kodak_diary 記事方針を採用) | 細分類が必要なときのみ採番   |
 
+`error.retryable` は `code == "TEMP_FAILURE"` か `code == "TIMEOUT"` の時のみ `true`、他は `false`。`TIMEOUT` と `TEMP_FAILURE` を分けるのは、retry sleep duration が違うため (timeout は backoff を長めに、rate limit は短め)。
+
 | Exit | Const / 出典       | JSON `error.code` | scout での発生条件                                                                     |
 | ---- | ------------------ | ----------------- | -------------------------------------------------------------------------------------- |
 | 0    | EX_OK              | (none)            | Ok 経路                                                                                |
@@ -118,13 +120,13 @@ Phase 2 PR で JSON schema を `serde` 派生型として実装し、本 ADR の
 | 104  | PJ 拡張            | `UNKNOWN`         | 上記いずれにも分類できない (退避先、増えたら設計見直し signal)                         |
 | 124  | GNU `timeout` 慣例 | `TIMEOUT`         | fetch / research の全体 timeout, API timeout (retry policy が `TEMP_FAILURE` と異なる) |
 
-`error.retryable` は `code == "TEMP_FAILURE"` か `code == "TIMEOUT"` の時のみ `true`、他は `false`。`TIMEOUT` と `TEMP_FAILURE` を分けるのは、retry sleep duration が違うため (timeout は backoff を長めに、rate limit は短め)。
-
 ### Classification Priority
 
 複数分類が当てはまる場合の優先順位。scout の実エラーソース (clap parse/URL invalid/404/rate limit/timeout/JSON parse/network IO) から 5 段に絞る。
 
 ルールの読み方: 上から順に評価。マッチした時点で確定。例: GitHub API から 404 と rate limit 余地のあるレスポンスが同時にあった場合、優先 3 で 66 NOT_FOUND を採用 (rate limit より先に 404 評価)。
+
+`UNKNOWN` が増える場合は分類設計の signal。`anyhow::Error` の握り潰しを検知する目的で意図的に独立。
 
 | 優先 | ルール                                            | 分類                               |
 | ---- | ------------------------------------------------- | ---------------------------------- |
@@ -135,16 +137,14 @@ Phase 2 PR で JSON schema を `serde` 派生型として実装し、本 ADR の
 | 5    | アプリ内部不具合と判断できる                      | 70 INTERNAL                        |
 | 退避 | 上記いずれにも分類できない                        | 104 UNKNOWN                        |
 
-`UNKNOWN` が増える場合は分類設計の signal。`anyhow::Error` の握り潰しを検知する目的で意図的に独立。
-
 ### Migration Strategy
+
+Phase 2 で JSON `error.code` を導入した時点で、内部の `ScoutError::user_error`/`internal`/`transient` から sysexits 6 種への分類関数を確定させる。Phase 3 では分類関数の出力を `ExitCode` に流すだけで完結する。
 
 | Phase | 対象                                         | 互換性                     | リリース            |
 | ----- | -------------------------------------------- | -------------------------- | ------------------- |
 | 2     | `--json` global flag + JSON schema 出力      | 非破壊 (Markdown 経路維持) | 0.8.x で minor bump |
 | 3     | exit code を 0/1/2 → 0/64/65/66/74/75 に拡張 | 破壊的 (既存 script 影響)  | 1.0.0 で major bump |
-
-Phase 2 で JSON `error.code` を導入した時点で、内部の `ScoutError::user_error`/`internal`/`transient` から sysexits 6 種への分類関数を確定させる。Phase 3 では分類関数の出力を `ExitCode` に流すだけで完結する。
 
 ### Trade-offs
 

--- a/docs/decisions/0066-cli-exit-code-policy-grouped-by-error-topology.md
+++ b/docs/decisions/0066-cli-exit-code-policy-grouped-by-error-topology.md
@@ -80,6 +80,8 @@ Chosen option: Option B。Option A は未使用 code が増えて読み手のノ
 
 retryable 軸が中心。ADR-0065 の 9 種をそのまま採用。`TIMEOUT` (124) と `TEMP_FAILURE` (75) の分離が effective。
 
+70 INTERNAL は使用頻度低いが許容 (assert violation 等)。
+
 | Exit | Const         | JSON `error.code` | 主な発生条件                |
 | ---- | ------------- | ----------------- | --------------------------- |
 | 0    | EX_OK         | (none)            | Ok                          |
@@ -91,11 +93,11 @@ retryable 軸が中心。ADR-0065 の 9 種をそのまま採用。`TIMEOUT` (12
 | 124  | GNU `timeout` | `TIMEOUT`         | API timeout                 |
 | 104  | PJ 拡張       | `UNKNOWN`         | 分類不能 (退避)             |
 
-70 INTERNAL は使用頻度低いが許容 (assert violation 等)。
-
 ### Group 2: ローカル semantic 検索
 
 `amici::cli::exit_code::codes` を基盤として、INTERNAL/UNKNOWN 分離を追加。Timeout は通常発生しない (ローカル処理) ので 124 は採用しない。
+
+`amici::cli::exit_code` に `INTERNAL` と `UNKNOWN` を追加することで、グループ 2 全体が共通基盤を共有できる。
 
 | Exit | Const        | JSON `error.code` | 主な発生条件                               |
 | ---- | ------------ | ----------------- | ------------------------------------------ |
@@ -108,11 +110,11 @@ retryable 軸が中心。ADR-0065 の 9 種をそのまま採用。`TIMEOUT` (12
 | 75   | EX_TEMPFAIL  | `TEMP_FAILURE`    | model download retry 可能な失敗            |
 | 104  | PJ 拡張      | `UNKNOWN`         | 分類不能 (退避)                            |
 
-`amici::cli::exit_code` に `INTERNAL` と `UNKNOWN` を追加することで、グループ 2 全体が共通基盤を共有できる。
-
 ### Group 3: Hook tool (fail-closed/open)
 
 Hook は exit code で挙動を分岐する (0 = allow, 非0 = block)。1 と 2 を意図的に分けて、advisory と blocking を区別する。
+
+Hook tool は外形契約 (0/1/2) が支配的なので、内部詳細は JSON stderr で出す。sysexits.h の細分類はオプション。
 
 | Exit | 出典        | 意味                  | Hook 挙動                   |
 | ---- | ----------- | --------------------- | --------------------------- |
@@ -121,8 +123,6 @@ Hook は exit code で挙動を分岐する (0 = allow, 非0 = block)。1 と 2 
 | 2    | 慣例        | blocking 失敗         | block (PreToolUse 系で使用) |
 | 64   | EX_USAGE    | Hook 入力 JSON 不正   | block (Hook 入力契約違反)   |
 | 70   | EX_SOFTWARE | Hook 自身の内部不具合 | block (fail-closed)         |
-
-Hook tool は外形契約 (0/1/2) が支配的なので、内部詳細は JSON stderr で出す。sysexits.h の細分類はオプション。
 
 ### Cross-Group Rules
 

--- a/docs/decisions/0097-ask-instead-of-extract-when-returning-corrections-to-rules.md
+++ b/docs/decisions/0097-ask-instead-of-extract-when-returning-corrections-to-rules.md
@@ -98,6 +98,8 @@ Stop hook が debounce つきで問いを出し、答えを受けて規則ファ
 
 Confirmation の「`claude` を呼ぶ行を持たない」条項が、守るべきものを守らなくなった。この条項が禁じたのは LLM に抽出させて自動で書くことだが、2026-08-14 の変更で `## ask` が追記を subagent へ委ねた時点で、LLM が抽出して LLM が書く形になっている。条項が縛っていたのは、その LLM がどのプロセスで走るかだけだった。
 
+#### 却下理由の再評価
+
 却下した「LLM に抽出させ、結果を自動で書く」の理由 3 つを、分離した `claude -p` へ当てはめ直した。
 
 | 却下理由                                  | 分離した `claude -p` で成立するか                                                            |
@@ -105,6 +107,8 @@ Confirmation の「`claude` を呼ぶ行を持たない」条項が、守るべ�
 | 毎ターン 17 秒から 83 秒のブロック        | しない。`start_new_session` で切り離すので hook は数ミリ秒で返り、10 秒の timeout に届かない |
 | 25 秒 timeout で placeholder へ退避       | しない。timeout が掛からず、退避先の placeholder も持たない                                  |
 | 空 placeholder 492 個。抽出の質を測れない | する。しかも会話に 1 行も出なくなるので、旧実装より気付きにくい                              |
+
+#### 分離の実装と計測
 
 3 つ目だけが残り、気付く経路を別に用意する。子の stdout と stderr を `~/.cache/claude-reflection_ask/runs/<session>/log.txt` へ落とし、wrapper が終了コードを追記する。次のセッションの hook がその行を読み、`exit=0` でない run があれば `systemMessage` で 1 行だけ端末へ出す。報告した log は改名するので、同じ失敗は 1 度しか出ない。`additionalContext` でなく `systemMessage` を使うのは、対処できるのが端末を読む人間だからで、モデルの context は分離が空けたかった場所そのものだから。
 

--- a/tests/table-paragraph.test.js
+++ b/tests/table-paragraph.test.js
@@ -1,7 +1,5 @@
 // MARKDOWN.md § Do not puts a table's explanation before the table, so the reader holds the rule
-// before the rows it governs. docs/** stays out: its paragraphs below a table read that table's
-// result back, or carry the section around it, and hoisting either one degrades the page (#450).
-// workflows/ and commands/ hold no markdown.
+// before the rows it governs. workflows/ and commands/ hold no markdown.
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { readFile, readdir } from "node:fs/promises";
@@ -9,7 +7,11 @@ import { dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..");
-const SCANNED = ["agents", "rules", "skills"];
+const SCANNED = ["agents", "rules", "skills", "docs"];
+// The same row lets a conclusion the table derives stay below it, and a DR's narrative reaches
+// that shape 24 times. Listing each would make an allowlist nobody prunes, so the directory stays
+// out and this line carries the judgement (#450).
+const SKIPPED = new Set(["docs/decisions"]);
 
 // MARKDOWN.md's row exempts a conclusion the table derives, and no regex separates one from an
 // explanation. Each key carries the opening sentence, so rewriting the conclusion asks for the
@@ -53,8 +55,9 @@ const markdownUnder = async (dir) => {
   const out = [];
   for (const e of entries) {
     const path = join(dir, e.name);
-    if (e.isDirectory()) out.push(...(await markdownUnder(path)));
-    else if (e.name.endsWith(".md")) out.push(path);
+    if (e.isDirectory()) {
+      if (!SKIPPED.has(relative(root, path))) out.push(...(await markdownUnder(path)));
+    } else if (e.name.endsWith(".md")) out.push(path);
   }
   return out;
 };


### PR DESCRIPTION
## Summary

`docs/**` の 34 件を 1 件ずつ見て、規則に照らして直すべき 10 件を直した。`docs` 直下が 0 件になったので走査へ入れる。規則そのものは変えていない。

| 判定 | 件数 | 扱い |
| --- | --- | --- |
| 表が導いた結論 | 24 | 残した。規則が「表の下に残す」と定めている |
| 表が節頭にある | 4 | 表の前へ移した |
| 行への例外を述べる | 6 | 表の前へ移した |

## 規則が既に答えを持っていた

`MARKDOWN.md` の該当行はこう定める。

> 説明 (ルール、コンテキスト、例外) はテーブル前に置く。表が導いた結論は表の下に残す

34 件のうち 30 件は表に導入文があり、続く段落はその表から導いた結論だった。文書側は既に規則に沿っている。

```
docs/decisions/0055:19

ADR-0052/0053/0054 で user-invocable: false の skill を 3 prefix に分けた:   ← 導入文
| prefix | 対象 | 件数 |
それぞれ役割を示す prefix だが alphabetical に散るため...                      ← 「それぞれ」が行を指す
```

この段落を表の上へ移すと「それぞれ」の指す先が消える。

## 移した 10 件

### 表が節頭にある 4 件

`0029`、`0030`、`0061`、`0065` の Migration Strategy。表が節の先頭にあるので、段落を上へ移すとその段落が節の導入文になる。

### 行への例外を述べる 6 件

`0060` の ISO 副特性の除外、`0065` の retryable 条件と UNKNOWN の扱い、`0066` の 3 グループ。いずれも表の行に対する条件で、規則が「例外はテーブル前」と定めているものに当たる。

```
### Group 1: 外部 API fetch

retryable 軸が中心。ADR-0065 の 9 種をそのまま採用。

70 INTERNAL は使用頻度低いが許容 (assert violation 等)。   ← 移した

| Exit | Const | JSON error.code | 主な発生条件 |
```

## 見出しで分けた 2 箇所

段落を動かすと表が導入文から離れる節が 2 つあった。どちらも節が 2 つの話題を持っていたので、後半に見出しを与えた。

### `docs/HOOKS.md` の `## Execution Layers`

冒頭 1 文と表は層と登録の話で、続く 3 段落は言語の選び方とテストの話だった。`### Language` を足して分けた。

### `docs/decisions/0097` の `### Trigger fired: 2026-08-18`

表の導入文が 9 段落離れていた。`#### 却下理由の再評価` と `#### 分離の実装と計測` を足し、元の散文の順序を保ったまま表を導入文の隣に戻した。

## 走査を docs へ広げた

`docs` 直下が 0 件になったので `SCANNED` に足した。`docs/decisions` は外す。残る 24 件は規則が許す形で、1 件ずつ allowlist に並べると誰も刈らない一覧になる。理由は検査のコメントに書いた。

## Testing

破壊検査: `docs/HOOKS.md` の fail-mode の段落を表の後ろへ戻すと落ちる。

496 テスト緑、rumdl / textlint / oxlint 緑、変更した Markdown は prettier 緑。

## やってみて分かったこと

最初は 34 件を機械的に表の上へ移した。`0008` では `：` で終わる導入文と表のあいだに別の段落が入り、`0050` では表が 2 つ隣接した。移動が使えるのは表に導入文が無いときに限る。

Closes #450

https://claude.ai/code/session_01WKMAvw3AWjxKTW29eeJeKq
