### PR TITLE
chore: MIT ライセンスを追加する

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 thkt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## 背景

GitHub 上でこのリポジトリのライセンス欄が空欄になっている。再利用してよいかを判断するには、リポジトリ全体を読むしかない状態だった。

`gh repo view thkt/dotclaude --json licenseInfo` が `null` を返すことで確認した。

## 変更

MIT License を `LICENSE` として追加する。著作権表示は `Copyright (c) 2026 thkt`。

拡張子を付けずに `LICENSE` としたのは、`.rumdl.toml` と markdownlint の走査対象から外すため。GitHub のライセンス検出はこのファイル名でも動作する。

## 確認

マージ後、リポジトリ画面の右サイドバーに MIT License と表示されること。

https://claude.ai/code/session_012qtZxR28qqYSsWJpAqnbNA