### PR TITLE
chore(workflows): code の単体呼び出しが何に責任を持つかを code.js に書く

### DIFF
--- a/.ja/workflows/code.js
+++ b/.ja/workflows/code.js
@@ -23,6 +23,8 @@ const parseArgs = () => {
   return {};
 };
 
+// 見るのは units の有無だけ。plan の構造検証と preconditions の再検証は build の Load と
+// Revalidate が持ち、単体で呼ぶ側がそれを済ませてから渡す (#185)。
 const input = parseArgs();
 const plan = input.plan;
 

--- a/workflows/code.js
+++ b/workflows/code.js
@@ -22,6 +22,9 @@ const parseArgs = () => {
   }
   return {};
 };
+// Only the presence of units is checked here. Validating the plan's structure and re-verifying
+// its preconditions belong to build's Load and Revalidate, and a standalone caller does both
+// before handing the plan over (#185).
 const input = parseArgs();
 const plan = input.plan;
 if (!plan || !Array.isArray(plan.units) || !plan.units.length) {


### PR DESCRIPTION
## Summary

`code.js` の単体呼び出しが何に責任を持つかを、コードに書いた。両言語で 1 コメント。

```js
// Only the presence of units is checked here. Validating the plan's structure and re-verifying
// its preconditions belong to build's Load and Revalidate, and a standalone caller does both
// before handing the plan over (#185).
```

## なぜ要るのか

`code.js:27` は `!plan || !Array.isArray(plan.units) || !plan.units.length` しか見ない。`test_command` の欠落も、per-unit フィールドの欠落も、id の重複も、`preconditions` の陳腐化も検査しない。

これは欠陥ではなく設計判断で、#185 のクローズコメントに記録されている。

> 実装済みのためクローズ。malformed plan の最終 validate は build の Load validate が担う。

問題はその契約の置き場所になる。closed issue のコメントにしか無く、`code.js` を読んでも分からない。`build.js:761` の `stripPreconditions` のコメントは入れ子経路を説明するが、単体経路の呼び出し元が何をしてから渡すのかは述べない。

```js
// preconditions / backlog_candidates are consumed on the build side, so code
// receives only the PLAN_SCHEMA equivalent.
```

## この変更の位置づけ

`/challenge` で 3 つの候補を判定した結果、これだけが「欠陥ではないが記録が足りない」に当たった。他の 2 件は issue にした。

| # | 判断 | 結果 |
| --- | --- | --- |
| polish の Review 段が死んだ agent を CLI 不在と同じ値で片付ける | 欠陥 | #457 |
| workflow 7 本のうち build だけが repo を必須にしている | 欠陥 | #458 |
| build → code で preconditions を捨てる | #185 の設計判断と一貫 | この PR (コメントのみ) |

## Testing

496 テスト緑、oxlint / oxfmt 緑。挙動は変えていない。

https://claude.ai/code/session_01WKMAvw3AWjxKTW29eeJeKq
