### PR TITLE
fix(assert): 停止した入れ子 audit を劣化として扱う

### DIFF
--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -319,6 +319,7 @@ let audit = null;
 // スコープ外になる。
 let challengeStalled = false;
 let auditDegraded = false;
+let auditReason = "";
 
 // ---- Run recording: 確定した run ごとに 1 行。build.js の recordRun に倣う ----
 // record.py は payload をそのまま複製するので、ここでキーを増やしても向こう側は変えなくてよい。
@@ -614,9 +615,18 @@ try {
   // 「fail-open (challenge が走らず audit.js が全件 confirmed のまま通した run)」を区別する
   // 値。findings が 0 件の早期 return も challenge_ran=false を返すため degraded に含める。
   // reviewer が何も出さず challenge も走らなかった run が issues 0 件のまま Ready に届く穴を塞ぐ。
-  auditDegraded = !!audit && audit.challenge_ran === false;
+  // 停止した audit は challenge_ran を持たず、reject した thunk は parallel() の slot に null を
+  // 残す。等値比較だけでは、どちらも「findings 0 件の健全な audit」と読める。
+  auditReason = !audit
+    ? "nested audit returned nothing"
+    : audit.stopped
+      ? `nested audit stopped (${audit.stopped})`
+      : audit.challenge_ran === false
+        ? "audit challenge failed open"
+        : "";
+  auditDegraded = auditReason !== "";
   const auditFindingsIntro = auditDegraded
-    ? "入れ子の audit workflow の challenge stage が走らなかった (fail-open) ため、以下の findings は未検証として扱う。そのまま issues に含めてよいが、report で表面化する。"
+    ? `入れ子の audit workflow が劣化した (${auditReason}) ため、以下の findings は未検証として扱う。そのまま issues に含めてよいが、report で表面化する。`
     : "audit workflow の統合済み findings (critic 検証済み。そのまま issues に含める) は次のとおり。";
   synth = await agent(
     anchor(
@@ -657,7 +667,7 @@ try {
   } else {
     gate = "Ready (caveat)";
     if (envFail) gateReason.push("env fail (dynamic verification skipped)");
-    if (auditDegraded) gateReason.push("audit challenge failed open");
+    if (auditDegraded) gateReason.push(auditReason);
     if (testsCol !== "pass" && testsCol !== "no-runner" && !envFail)
       gateReason.push(`tests ${testsCol}`);
   }

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -321,6 +321,7 @@ let audit = null;
 // before Synthesize would otherwise reach with these out of scope.
 let challengeStalled = false;
 let auditDegraded = false;
+let auditReason = "";
 
 // ---- Run recording: one jsonl row per settled run, modeled on build.js's recordRun ----
 // record.py copies the payload verbatim, so a key added here needs no change there.
@@ -626,9 +627,18 @@ try {
   // as confirmed)". The zero-findings early return carries challenge_ran=false too and
   // counts as degraded, closing the hole where a run whose reviewers found nothing and
   // whose challenge never ran still reaches Ready with zero issues.
-  auditDegraded = !!audit && audit.challenge_ran === false;
+  // A stopped audit carries no challenge_ran, and a rejected thunk leaves null in parallel()'s
+  // slot, so an equality check alone reads both as a healthy zero-findings audit.
+  auditReason = !audit
+    ? "nested audit returned nothing"
+    : audit.stopped
+      ? `nested audit stopped (${audit.stopped})`
+      : audit.challenge_ran === false
+        ? "audit challenge failed open"
+        : "";
+  auditDegraded = auditReason !== "";
   const auditFindingsIntro = auditDegraded
-    ? "The nested audit workflow's challenge stage did not run (fail-open), so treat the following findings as unverified; include them in issues as-is but flag this in the report."
+    ? `The nested audit workflow degraded (${auditReason}), so treat the following findings as unverified; include them in issues as-is but flag this in the report.`
     : "The integrated findings from the audit workflow (critic-verified; include them in issues as-is) are as follows.";
   synth = await agent(
     anchor(
@@ -669,7 +679,7 @@ try {
   } else {
     gate = "Ready (caveat)";
     if (envFail) gateReason.push("env fail (dynamic verification skipped)");
-    if (auditDegraded) gateReason.push("audit challenge failed open");
+    if (auditDegraded) gateReason.push(auditReason);
     if (testsCol !== "pass" && testsCol !== "no-runner" && !envFail)
       gateReason.push(`tests ${testsCol}`);
   }

--- a/workflows/assert/tests/assert.degradation.test.js
+++ b/workflows/assert/tests/assert.degradation.test.js
@@ -113,6 +113,11 @@ const makeAuditWorkflowStub = (challengeRan) => (name) =>
       }
     : undefined;
 
+// A nested audit that ran normally. A run with no workflow stub leaves audit null, which is a
+// degradation, so every test asserting Ready has to stand one up.
+const healthyAudit = (name) =>
+  name === "audit" ? { findings: [], challenge_ran: true, verify_ran: true } : undefined;
+
 // The synthesize agent is called exactly once per run.
 const synthesizePromptOf = (calls) => {
   const call = calls.agent.find((c) => c.opts && c.opts.label === "synthesize");
@@ -321,7 +326,7 @@ test("T-003 a Ready run whose build was skipped does not report build as passing
   const skippedBoot = { ...bootOk, build: "skipped" };
   const { result } = await runWorkflow(assertJs, {
     args: {},
-    stubs: { agent: makeGateReasonAgent({ boot: skippedBoot }) },
+    stubs: { agent: makeGateReasonAgent({ boot: skippedBoot }), workflow: healthyAudit },
   });
   assert.equal(result.gate, "Ready", "no build concept and passing tests still reach Ready");
   assert.equal(result.build, "skipped", "the build column reports what bootstrap returned");
@@ -423,7 +428,8 @@ test("T-012 a run that reaches a gate writes one row carrying that gate and the 
 test("T-013 a recorder returning nothing leaves the gate unchanged and names the unwritten row in log()", async () => {
   const { result, logs } = await runWorkflow(assertJs, {
     args: {},
-    stubs: { agent: makeAgent({ ran: true, tests: [] }) }, // the "record" label falls through to undefined
+    // the "record" label falls through to undefined
+    stubs: { agent: makeAgent({ ran: true, tests: [] }), workflow: healthyAudit },
   });
   assert.equal(
     result.gate,
@@ -498,6 +504,7 @@ test("T-016 a Ready-gated run appends exactly one record row", async () => {
           return { path: "/home/u/.claude/history/assert-runs.jsonl" };
         return makeAgent({ ran: true, tests: [] })(prompt, opts);
       },
+      workflow: healthyAudit,
     },
   });
   assert.equal(result.gate, "Ready", "no issues and passing evidence gate Ready");
@@ -518,6 +525,7 @@ test("T-017 a recorder that throws leaves the gate unchanged and names the unwri
         if (opts && opts.label === "record") throw new Error("recorder exploded");
         return makeAgent({ ran: true, tests: [] })(prompt, opts);
       },
+      workflow: healthyAudit,
     },
   });
   assert.equal(
@@ -530,3 +538,41 @@ test("T-017 a recorder that throws leaves the gate unchanged and names the unwri
     "the unwritten row reaches log() naming the file it is missing from",
   );
 });
+
+// A stopped nested audit spawned no reviewer at all, yet challenge_ran is absent rather than
+// false, so an equality check alone read it as a healthy audit that found nothing (#461).
+const stoppedAudit = (name) =>
+  name === "audit" ? { stopped: "no-repo", why: "pass args.repo" } : undefined;
+// parallel() leaves null in a rejected thunk's slot, which is the same shape one step further.
+const deadAudit = (name) => (name === "audit" ? null : undefined);
+
+for (const [label, workflowStub] of [
+  ["stops", stoppedAudit],
+  ["returns nothing", deadAudit],
+]) {
+  test(`T-018 a run whose nested audit ${label} does not call its findings critic-verified`, async () => {
+    const { calls } = await runWorkflow(assertJs, {
+      args: {},
+      stubs: { agent: makeAgent({ ran: true, tests: [] }), workflow: workflowStub },
+    });
+    const prompt = synthesizePromptOf(calls);
+    assert.ok(prompt.length > 0, "the synthesize agent ran");
+    assert.ok(
+      !/critic-verified/i.test(prompt),
+      `an audit that ${label} is not called critic-verified`,
+    );
+  });
+
+  test(`T-019 the gate does not reach Ready when the nested audit ${label}`, async () => {
+    const { result } = await runWorkflow(assertJs, {
+      args: {},
+      stubs: { agent: makeAgent({ ran: true, tests: [] }), workflow: workflowStub },
+    });
+    assert.notEqual(result.gate, "Ready", `an audit that ${label} keeps the run off Ready`);
+    assert.match(
+      JSON.stringify(result.gate_reason),
+      /nested audit (stopped|returned nothing)/,
+      "gate_reason names what the audit failed to do, not the challenge stage it never reached",
+    );
+  });
+}


### PR DESCRIPTION
## Summary

`workflows/assert.js` の `auditDegraded` が、入れ子 audit の停止と不在を劣化と見なしていなかった。静的検査が 1 件も走っていない run が Ready に到達しうる。

```js
-  auditDegraded = !!audit && audit.challenge_ran === false;
+  auditReason = !audit
+    ? "nested audit returned nothing"
+    : audit.stopped
+      ? `nested audit stopped (${audit.stopped})`
+      : audit.challenge_ran === false
+        ? "audit challenge failed open"
+        : "";
+  auditDegraded = auditReason !== "";
```

劣化の理由を 1 箇所で決め、真偽値はそこから導く。同じ 3 条件を 2 箇所に書くと、片方だけ動く。

## 何が読み違えられていたか

| audit の返り値 | `challenge_ran` | 変更前の判定 | 実際に失われたもの |
| --- | --- | --- | --- |
| `{stopped: "..."}` | 無い (`undefined === false` は false) | 健全 | reviewer が 1 体も走っていない |
| `null` (thunk が reject) | 読めない (`!!audit` が false) | 健全 | 同上 |
| `{challenge_ran: false}` | false | 劣化 | reviewer は走り、findings が未検証 |

`auditFindings` は `assert.js:596` の `((audit && audit.findings) || [])` で `[]` に落ちるので、上 2 行は「reviewer が走って何も見つけなかった run」と区別が付かなかった。`audit.stopped` を読む箇所は `assert.js` に 1 つも無かった。

`audit.js` は今のところ `stopped` を返す経路を持たない (`grep -c "stopped:"` が 0) ので、この穴を踏んだ run は記録されていない。**#458 が audit に `no-repo` 停止を入れると発火する。**

## 文言を 2 箇所で直した

劣化の中身が 3 通りで違うのに、`gate_reason` と Synthesize の prompt がどちらも「challenge stage did not run (fail-open)」の 1 文言だった。停止した run では reviewer が 1 体も走っておらず、challenge に到達すらしていない。

```js
-    if (auditDegraded) gateReason.push("audit challenge failed open");
+    if (auditDegraded) gateReason.push(auditReason);

-    ? "The nested audit workflow's challenge stage did not run (fail-open), so treat ..."
+    ? `The nested audit workflow degraded (${auditReason}), so treat ...`
```

WORKFLOWS.md § Degradation recording が「A failure is swallowed and fail-open advances the next phase → What could not be verified, that it is unverified」を求めている。

## 既存テスト 4 本が誤った契約を encode していた

T-003 / T-013 / T-016 / T-017 は `workflow` を stub せず、`audit` が `null` のまま Ready を assert していた。新しい判定ではそれが劣化に当たるので落ちる。

これはテスト側の欠陥だった。`null` な audit を健全と見なすのが、この PR が塞いでいる穴そのものになる。健全な audit を返す `healthyAudit` stub を張って直した。

## Testing

新規 4 本 (T-018 / T-019 を stopped と null の 2 通りで)。

破壊検査 3 件。

| 破壊 | 結果 |
| --- | --- |
| `stopped` の判定を外す | 2 本落ちた |
| `null` の判定を外す | 11 本落ちた |
| 理由を元の 1 文言に戻す | 2 本落ちた |
| 健全な audit にも理由を返させる | 6 本落ちた |

500 テスト緑、oxlint / oxfmt 緑。

## Related

- #458 の先行条件の 1 つ。もう 1 つは #462
- 2 体の `critic-design` が #458 の設計批評で独立にこの穴を指摘した

Closes #461

https://claude.ai/code/session_01WKMAvw3AWjxKTW29eeJeKq
