### PR TITLE
build の Revalidate が reference_module.path のディレクトリを plan-drift と誤判定する

### DIFF
--- a/.ja/workflows/build/revalidate.py
+++ b/.ja/workflows/build/revalidate.py
@@ -7,7 +7,7 @@ stdin:  {path, pattern?} の JSON 配列。issue の plan が前提とする既�
         path は process cwd (repo root) からの相対。pattern は任意で、その
         ファイルに含まれるはずの literal (fixed-string、regex ではない) 部分文字列。
 stdout: JSON {results: [{path, pattern, exists, matches}]}、入力順に 1 件ずつ。
-          exists  = path が通常ファイル
+          exists  = path が実在する。pattern 有りなら通常ファイルであること
           matches = pattern 無しなら exists と同じ。pattern 有りなら exists かつ
                     その literal pattern がファイルの bytes に出現する
 完了時は exit 0 (verdict は JSON から読む)。usage / parse error 時は exit 1。
@@ -29,14 +29,16 @@ def verify_one(root: Path, entry: object) -> dict[str, str | bool]:
     path = str(mapping.get("path", ""))
     raw_pattern = mapping.get("pattern", "")
     pattern = "" if raw_pattern is None else str(raw_pattern)
-    exists = (root / path).is_file() if path else False
+    # 一律 is_file() にはしない。reference_module.path はディレクトリを指す (#494)。
+    target = root / path
+    exists = bool(path) and (target.is_file() if pattern else target.exists())
     if not pattern:
         matches = exists
     elif not exists:
         matches = False
     else:
         try:
-            matches = pattern.encode("utf-8") in (root / path).read_bytes()
+            matches = pattern.encode("utf-8") in target.read_bytes()
         except OSError:
             matches = False
     return {"path": path, "pattern": pattern, "exists": exists, "matches": matches}

--- a/.ja/workflows/build/revalidate.py
+++ b/.ja/workflows/build/revalidate.py
@@ -29,7 +29,7 @@ def verify_one(root: Path, entry: object) -> dict[str, str | bool]:
     path = str(mapping.get("path", ""))
     raw_pattern = mapping.get("pattern", "")
     pattern = "" if raw_pattern is None else str(raw_pattern)
-    # 一律 is_file() にはしない。reference_module.path はディレクトリを指す (#494)。
+    # 一律 is_file() にはしない。reference_module.path はディレクトリを指す。
     target = root / path
     exists = bool(path) and (target.is_file() if pattern else target.exists())
     if not pattern:

--- a/workflows/build/revalidate.py
+++ b/workflows/build/revalidate.py
@@ -7,7 +7,7 @@ stdin:  JSON array of {path, pattern?} — existing code the issue's plan presup
         path is relative to the process cwd (the repo root). pattern is an optional
         literal (fixed-string, not regex) substring expected to occur in that file.
 stdout: JSON {results: [{path, pattern, exists, matches}]}, one per input in order.
-          exists  = path is a regular file
+          exists  = the path is present; with a pattern, it is a regular file
           matches = with no pattern, equals exists; otherwise exists AND the literal
                     pattern occurs in the file's bytes
 exit 0 on a completed run (read the verdict from JSON). exit 1 on usage / parse error
@@ -29,14 +29,16 @@ def verify_one(root: Path, entry: object) -> dict[str, str | bool]:
     path = str(mapping.get("path", ""))
     raw_pattern = mapping.get("pattern", "")
     pattern = "" if raw_pattern is None else str(raw_pattern)
-    exists = (root / path).is_file() if path else False
+    # Not is_file() throughout: reference_module.path names a directory (#494).
+    target = root / path
+    exists = bool(path) and (target.is_file() if pattern else target.exists())
     if not pattern:
         matches = exists
     elif not exists:
         matches = False
     else:
         try:
-            matches = pattern.encode("utf-8") in (root / path).read_bytes()
+            matches = pattern.encode("utf-8") in target.read_bytes()
         except OSError:
             matches = False
     return {"path": path, "pattern": pattern, "exists": exists, "matches": matches}

--- a/workflows/build/revalidate.py
+++ b/workflows/build/revalidate.py
@@ -29,7 +29,7 @@ def verify_one(root: Path, entry: object) -> dict[str, str | bool]:
     path = str(mapping.get("path", ""))
     raw_pattern = mapping.get("pattern", "")
     pattern = "" if raw_pattern is None else str(raw_pattern)
-    # Not is_file() throughout: reference_module.path names a directory (#494).
+    # Not is_file() throughout: reference_module.path names a directory.
     target = root / path
     exists = bool(path) and (target.is_file() if pattern else target.exists())
     if not pattern:

--- a/workflows/build/tests/revalidate_test.py
+++ b/workflows/build/tests/revalidate_test.py
@@ -70,7 +70,7 @@ class RunTest(unittest.TestCase):
         self.assertEqual((v[1]["exists"], v[1]["matches"]), (False, False))
 
     def test_pattern_less_directory_exists(self) -> None:
-        # #494: reporting the directory absent stopped build at plan-drift.
+        # Reporting the directory absent stopped build at plan-drift.
         (self.root / "adir").mkdir()
         v = revalidate.run([{"path": "adir"}, {"path": "adir/"}], self.root)
         self.assertEqual((v[0]["exists"], v[0]["matches"]), (True, True))

--- a/workflows/build/tests/revalidate_test.py
+++ b/workflows/build/tests/revalidate_test.py
@@ -69,10 +69,18 @@ class RunTest(unittest.TestCase):
         self.assertEqual((v[0]["exists"], v[0]["matches"]), (True, True))
         self.assertEqual((v[1]["exists"], v[1]["matches"]), (False, False))
 
-    def test_directory_is_not_a_file(self) -> None:
+    def test_pattern_less_directory_exists(self) -> None:
+        # #494: reporting the directory absent stopped build at plan-drift.
         (self.root / "adir").mkdir()
-        v = revalidate.run([{"path": "adir"}], self.root)
-        self.assertEqual((v[0]["exists"], v[0]["matches"]), (False, False))
+        v = revalidate.run([{"path": "adir"}, {"path": "adir/"}], self.root)
+        self.assertEqual((v[0]["exists"], v[0]["matches"]), (True, True))
+        self.assertEqual((v[1]["exists"], v[1]["matches"]), (True, True))
+
+    def test_directory_carrying_a_pattern_does_not_exist(self) -> None:
+        # Not the except OSError path: is_file() settles it before read_bytes() runs.
+        (self.root / "adir").mkdir()
+        v = self.verdicts([{"path": "adir", "pattern": "anything"}])
+        self.assertEqual(v[("adir", "anything")], (False, False))
 
     def test_order_and_count_preserved(self) -> None:
         pre = [


### PR DESCRIPTION
## What & Why

build workflow の Revalidate が、実在するディレクトリを「plan が前提とするコードが無い」と読んで `plan-drift` で停止していた。`reference_module.path` はディレクトリを指すのに、`workflows/build/revalidate.py` の `exists` が `is_file()` でそれを不在と報告していたのが原因。

止まるのは 1 件ではない。#479/#480/#489 はいずれも `reference_module.path` がディレクトリで、build に投入すると同じ位置で止まる。#479 は 2026-08-24 の run で実際に停止した。

## Review focus

- `revalidate.py:36` の `exists` の分岐。pattern の有無で通常ファイルを要求するかが変わる
- `test_directory_is_not_a_file` を削除でなく書き換えにした判断。何を守っていたつもりだったかは commit 本文に書いた
- `build.js` は触っていないこと。`build.behavior.test.js` の `reference_module` 4 件は revalidate の結果を stub して build.js の反応を固定しており、判定の作り方には触れないため無傷で通る

## Design Decisions

`revalidate.py` 側を直し、`build.js` の drift ゲートは触らなかった。当初は build.js の drift ゲートから `reference_module.path` を外す案を検討したが、`git log -S` で前提が崩れた。

`4e48f86a` (2026-07-05) が precondition の `test -f` を置き換えるために `exists` を作った時点で、payload に `reference_module` は無かった。`dad40714` (#287, 2026-07-30) がそれを後から同じ payload へ流し込み、`exists` の意味は見直されなかった。file 限定は意図的な防壁ではなく、precondition 専用だった頃の名残。防壁は、それが塞いでいるフィールドより先に建っていた。

`{path, kind: "dir"}` のような明示マーカーを stdin 契約へ足す案も検討したが、呼び出し側が 1 箇所しかないので採らなかった (YAGNI Boundary)。

## Scope

- Not included: `workflows/build.js` の変更。`reference_module.path` を drift ゲートへ流す経路はそのまま
- Not included: `history/build-runs.jsonl` に残った run `8d9c86ef…` の `plan_quality: true`。この偽陽性を「より良い Plan なら防げた」と記録したままなので、#459 がそれを数える。訂正するか注記するかは別途判断が要る

## How to Test

1. `python3 workflows/build/tests/revalidate_test.py` を実行し、14 tests OK を確認する
2. `exists` を `bool(path) and target.is_file()` へ戻し、同じコマンドで `test_pattern_less_directory_exists` が落ちることを確認する
3. `node --test "workflows/**/tests/*.test.js"` を実行し、`build.behavior.test.js` の `reference_module` 4 件が通ることを確認する

## Related

- Closes #494
- Unblocks #479, #480, #489
