### PR TITLE
workflow-structure の停止形と入れ子の記述を実装に合わせる

### DIFF
--- a/docs/wiki/workflow-structure.md
+++ b/docs/wiki/workflow-structure.md
@@ -11,7 +11,8 @@ workflow は `adrift` `assert` `audit` `build` `code` `polish` `shake` の 7 本
 
 ## 境界
 
-- 7 本は独立して起動する。入れ子は 2 経路だけで、`assert.js` が `workflow("audit")` を呼び、`build.js` が `workflow("code")` を呼ぶ
+- 7 本は独立して起動する。入れ子は 2 経路だけで、`assert.js` が audit を、`build.js` が code を呼ぶ
+- 入れ子の呼び方は 2 経路で揃っていない。`build.js` は `sibling` を通し、bare 名が解決できなければ `build:` 名前空間へ落とす。`assert.js` は `workflow("audit")` を直に呼ぶ
 - script が持つのは制御フローと判定だけで、git 操作もファイル読み書きも agent に渡す
 - `workflows/_lib/run-workflow.js` はテスト用の実行器で、本番サンドボックスの供給を写している。両者の食い違いの扱いは `harness-production-divergence.md` が持つ
 
@@ -20,22 +21,24 @@ workflow は `adrift` `assert` `audit` `build` `code` `polish` `shake` の 7 本
 | 対象 | 契約 |
 | --- | --- |
 | `args.repo` | 7 本すべてで必須。省略した起動は本体に入る前に `stopped: "no-repo"` で止まる |
-| 起動前の停止 | `{ stopped: "<理由>" }` を返す形に揃える。`build` だけ `no-repo` と `no-plan` の 2 つを持つ |
+| 起動前の停止 | `{ stopped: "<理由>", why }` を返す。`why` には呼び出し側が次に取る操作を書く。理由の語彙は workflow ごとに持つ |
 | `meta` と実行の形 | ファイル先頭の `export const meta`。本体は注入されたグローバルを引数に取る関数本体として走り、トップレベルの `return` が返り値になる |
-| 入れ子の引数 | 親が `repo` を明示的に渡す。`assert` は `skipPreflight: true` も添えて二重実行を防ぐ |
+| 入れ子の引数 | 親が `repo` を明示的に渡す。`assert` は `skipPreflight: true` を、`build` は `model` と `commit` を添える |
 
 ## 要求
 
 | 対象 | 上限 | 超えたときの挙動 |
 | --- | --- | --- |
 | `build` の unit | files 3 / tests 4 (seam unit を除く) | 分割をやり直させる |
-| `shake` の修正 | 再試行 3 回 | 打ち切って confirmed-flaky のまま返す |
+| `shake` の修正 | 再試行 3 回 | `blocker` として返す。テストを弱めない |
 
 ## 参照コード
 
 - `workflows/build.js` の `UNIT_CAPS`
 - `workflows/shake.js` の `MAX_FIX_ATTEMPTS`
 - `workflows/build.js` の `stop`
+- `workflows/build.js` の `sibling` (入れ子の名前解決を plugin 名前空間へ落とす)
+- `workflows/build.js` の `PLAN_QUALITY` (停止理由ごとに、計画の質の問題かを持つ)
 - `workflows/_lib/run-workflow.js` の `checkWorkflowSyntax`
 
 ## 由来


### PR DESCRIPTION
## What & Why

`/think` を issue #479 に回し、`find_wiki_rule.py` が返した `workflow-structure.md` を実装と突き合わせたところ、契約表の 2 行が事実と違っていた。停止の返り値と入れ子の呼び方で、どちらも計画がそのまま写すと誤った実装を導く。

| ページの記述 | 実装 |
| --- | --- |
| `{ stopped: "<理由>" }` を返す | 7 本すべてが `{ stopped, why }` を返す。`why` は呼び出し側が次に取る操作 |
| `build` だけ停止理由を 2 個持つ | `build` は 14 個。`adrift` と `assert` も 3 個ずつ持つ |
| (記述なし) | 入れ子の呼び方が揃っていない。`build.js` は `sibling` 経由で `build:` 名前空間へ落とすが、`assert.js` は直に呼ぶ |
| `shake` の打ち切りは confirmed-flaky のまま返す | `blocker` を立てて返す |

## Review focus

- 契約表の「起動前の停止」の行。`why` を落とした計画が停止を書くと、呼び出し側が次に何をすればよいか分からない返り値になる
- 境界に足した入れ子の非対称。`assert.js` が `sibling` を通さないのは plugin 導入時に効き方が変わる差で、ページに書くべきか実装を揃えるべきかは別の判断

## Scope

- Not included: `assert.js` の呼び出しを `sibling` に揃えること。現状を記述するに留め、実装の是正は別 issue にする

## Design Decisions

- 停止理由の個数をページに書かず「理由の語彙は workflow ごとに持つ」とした。個数は増減するのに `/scribe` の参照コード掃きが検出できない
- `PLAN_QUALITY` と `sibling` を参照コードに足した。参照コード掃きがシンボルの grep を毎回するので、この 2 つが消えたり改名されたら検出される

## How to Test

1. `python3 skills/scribe/tests/skill_contract_test.py` を実行し、13 件が通る
2. `grep -A2 'stopped: "' workflows/*.js` を実行し、どの停止も `why` を伴うことを確認する
3. `grep -n 'stop("' workflows/build.js | wc -l` が 14 を返す
