### PR TITLE
fix(scribe): triage が候補行を自分で読むようにする

### DIFF
--- a/.ja/skills/scribe/SKILL.md
+++ b/.ja/skills/scribe/SKILL.md
@@ -41,12 +41,13 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 2. スコープの各 PR/issue を `gh pr view <番号> --comments`/`gh issue view <番号> --comments` で本文/コメントまで読む
 3. スコープの各 research ファイルを Read で全文読む。セクション名で絞らない
 4. 読んだ内容を共通項ごとにまとめ、配列へ足す。同じ共通項が配列にあれば根拠だけを足す。設計判断とその経緯は `docs/decisions/` の領分なので対象外
-5. その配列を `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<共通項の JSON 配列>' docs/wiki/_candidates.md` に渡す。script が `_candidates.md` の両方の節から候補行を読んで配列へ混ぜ、閾値 2 件と 1 回あたりのページ上限を当て、`pages` (新規/昇格/更新)、`candidates`、`deferred` (今回は見送り) に分ける。候補行を自分で配列へ入れない。閾値と上限も自分で判定しない
-6. `docs/wiki/_candidates.md` を書き換える形を用意する。`candidates` は「単発」節へ、`deferred` は「昇格待ち」節へ置き、`pages` になった共通項の行は消す。行は `- <内容 1 行> <根拠>` の形にし、根拠は `#番号` と `(research)` をスペース区切りで並べる。既に行があれば根拠だけを足す。書き込みは Phase 6 の worktree 内で行う
+5. `docs/wiki/_candidates.md` を読み、配列の共通項が既存の候補行と同じものを指すなら、その行の本文をそのまま `name` に使う
+6. その配列を `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<共通項の JSON 配列>' docs/wiki/_candidates.md` に渡す。script が `_candidates.md` の両方の節から候補行を読んで配列へ混ぜ、閾値 2 件と 1 回あたりのページ上限を当て、`pages` (新規/昇格/更新)、`candidates`、`deferred` (今回は見送り) に分ける。閾値と上限を自分で判定しない
+7. `docs/wiki/_candidates.md` を書き換える形を用意する。`candidates` は「単発」節へ、`deferred` は「昇格待ち」節へ置き、`pages` になった共通項の行は消す。行は `- <内容 1 行> <根拠>` の形にし、根拠は `#番号` と `(research)` をスペース区切りで並べる。既に行があれば根拠だけを足す。書き込みは Phase 6 の worktree 内で行う
 
 | フィールド | 値                                                                            |
 | ---------- | ------------------------------------------------------------------------------- |
-| `name`     | 共通項の名前。ページ化されると kebab-case のファイル名になる                  |
+| `name`     | 共通項の同一性を決めるキー。候補行から来たものは行の本文がそのまま入る。ページのファイル名は Phase 6 で決める |
 | `evidence` | 根拠の配列。PR/issue 由来は `#番号`、research 由来は `(research)`              |
 | `existing` | 既存ページにあれば `page`、`_candidates.md` にあれば `candidate`、無ければ `none` |
 

--- a/.ja/skills/scribe/SKILL.md
+++ b/.ja/skills/scribe/SKILL.md
@@ -38,12 +38,11 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 ## Phase 3: 抽出
 
 1. `docs/wiki/*.md` を読み、既存ページを把握する。`kind: structure` を持つページは共通項ではないので、名前が一致しても `existing: "none"` のままにする
-2. `docs/wiki/_candidates.md` の候補行を両方の節から全て読み、1 行ごとに `{name, evidence, existing: "candidate"}` として配列へ入れる。上限で持ち越した行が戻る経路はここだけ
-3. スコープの各 PR/issue を `gh pr view <番号> --comments`/`gh issue view <番号> --comments` で本文/コメントまで読む
-4. スコープの各 research ファイルを Read で全文読む。セクション名で絞らない
-5. 読んだ内容を共通項ごとにまとめ、配列へ足す。同じ共通項が配列にあれば根拠だけを足す。設計判断とその経緯は `docs/decisions/` の領分なので対象外
-6. その配列を `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<共通項の JSON 配列>'` に渡す。script が閾値 2 件と 1 回あたりのページ上限を当て、`pages` (新規/昇格/更新)、`candidates`、`deferred` (今回は見送り) に分ける。閾値と上限を自分で判定しない
-7. `docs/wiki/_candidates.md` を書き換える形を用意する。`candidates` は「単発」節へ、`deferred` は「昇格待ち」節へ置き、`pages` になった共通項の行は消す。行は `- <内容 1 行> <根拠>` の形にし、根拠は `#番号` と `(research)` をスペース区切りで並べる。既に行があれば根拠だけを足す。書き込みは Phase 6 の worktree 内で行う
+2. スコープの各 PR/issue を `gh pr view <番号> --comments`/`gh issue view <番号> --comments` で本文/コメントまで読む
+3. スコープの各 research ファイルを Read で全文読む。セクション名で絞らない
+4. 読んだ内容を共通項ごとにまとめ、配列へ足す。同じ共通項が配列にあれば根拠だけを足す。設計判断とその経緯は `docs/decisions/` の領分なので対象外
+5. その配列を `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<共通項の JSON 配列>' docs/wiki/_candidates.md` に渡す。script が `_candidates.md` の両方の節から候補行を読んで配列へ混ぜ、閾値 2 件と 1 回あたりのページ上限を当て、`pages` (新規/昇格/更新)、`candidates`、`deferred` (今回は見送り) に分ける。候補行を自分で配列へ入れない。閾値と上限も自分で判定しない
+6. `docs/wiki/_candidates.md` を書き換える形を用意する。`candidates` は「単発」節へ、`deferred` は「昇格待ち」節へ置き、`pages` になった共通項の行は消す。行は `- <内容 1 行> <根拠>` の形にし、根拠は `#番号` と `(research)` をスペース区切りで並べる。既に行があれば根拠だけを足す。書き込みは Phase 6 の worktree 内で行う
 
 | フィールド | 値                                                                            |
 | ---------- | ------------------------------------------------------------------------------- |

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -38,12 +38,11 @@ The patterns worth picking up are procedures that recur as a routine or a conven
 ## Phase 3: Extraction
 
 1. Read `docs/wiki/*.md` to grasp the existing pages. A page carrying `kind: structure` is not a pattern, so a coinciding name stays `existing: "none"`
-2. Read every candidate line in `docs/wiki/_candidates.md`, both sections, and put each one into the array as `{name, evidence, existing: "candidate"}`. This is the only route by which a line the cap carried over comes back
-3. Read each in-scope PR/issue including comments via `gh pr view <number> --comments`/`gh issue view <number> --comments`
-4. Read each in-scope research file in full with Read. Do not narrow by section name
-5. Add what you read to the array, grouped per pattern. Add only the evidence when the pattern is in the array already. Design decisions and their history belong to `docs/decisions/` and are out of scope
-6. Pass that array to `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<JSON array of patterns>'`. The script applies the two-evidence threshold and the per-run page cap, splitting the input into `pages` (create/promote/update), `candidates`, and `deferred` (left for a later run). Do not judge the threshold or the cap yourself
-7. Prepare how `docs/wiki/_candidates.md` changes. `candidates` go under the 単発 section and `deferred` under the 昇格待ち section, and the line of a pattern that became a page is removed. A line takes the form `- <one-line content> <evidence>`, with `#number` and `(research)` listed space-separated. When the line is already there, add only the evidence. The write happens inside Phase 6's worktree
+2. Read each in-scope PR/issue including comments via `gh pr view <number> --comments`/`gh issue view <number> --comments`
+3. Read each in-scope research file in full with Read. Do not narrow by section name
+4. Add what you read to the array, grouped per pattern. Add only the evidence when the pattern is in the array already. Design decisions and their history belong to `docs/decisions/` and are out of scope
+5. Pass that array to `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<JSON array of patterns>' docs/wiki/_candidates.md`. The script reads the candidate lines from both sections of `_candidates.md` into the array, then applies the two-evidence threshold and the per-run page cap, splitting the result into `pages` (create/promote/update), `candidates`, and `deferred` (left for a later run). Do not put the candidate lines into the array yourself, and do not judge the threshold or the cap either
+6. Prepare how `docs/wiki/_candidates.md` changes. `candidates` go under the 単発 section and `deferred` under the 昇格待ち section, and the line of a pattern that became a page is removed. A line takes the form `- <one-line content> <evidence>`, with `#number` and `(research)` listed space-separated. When the line is already there, add only the evidence. The write happens inside Phase 6's worktree
 
 | Field      | Value                                                                                      |
 | ---------- | ------------------------------------------------------------------------------------------ |

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -41,12 +41,13 @@ The patterns worth picking up are procedures that recur as a routine or a conven
 2. Read each in-scope PR/issue including comments via `gh pr view <number> --comments`/`gh issue view <number> --comments`
 3. Read each in-scope research file in full with Read. Do not narrow by section name
 4. Add what you read to the array, grouped per pattern. Add only the evidence when the pattern is in the array already. Design decisions and their history belong to `docs/decisions/` and are out of scope
-5. Pass that array to `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<JSON array of patterns>' docs/wiki/_candidates.md`. The script reads the candidate lines from both sections of `_candidates.md` into the array, then applies the two-evidence threshold and the per-run page cap, splitting the result into `pages` (create/promote/update), `candidates`, and `deferred` (left for a later run). Do not put the candidate lines into the array yourself, and do not judge the threshold or the cap either
-6. Prepare how `docs/wiki/_candidates.md` changes. `candidates` go under the 単発 section and `deferred` under the 昇格待ち section, and the line of a pattern that became a page is removed. A line takes the form `- <one-line content> <evidence>`, with `#number` and `(research)` listed space-separated. When the line is already there, add only the evidence. The write happens inside Phase 6's worktree
+5. Read `docs/wiki/_candidates.md`. When a pattern in the array points at the same thing as an existing candidate line, use that line's body verbatim as the `name`
+6. Pass that array to `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<JSON array of patterns>' docs/wiki/_candidates.md`. The script reads the candidate lines from both sections of `_candidates.md` into the array, then applies the two-evidence threshold and the per-run page cap, splitting the result into `pages` (create/promote/update), `candidates`, and `deferred` (left for a later run). Do not judge the threshold or the cap yourself
+7. Prepare how `docs/wiki/_candidates.md` changes. `candidates` go under the 単発 section and `deferred` under the 昇格待ち section, and the line of a pattern that became a page is removed. A line takes the form `- <one-line content> <evidence>`, with `#number` and `(research)` listed space-separated. When the line is already there, add only the evidence. The write happens inside Phase 6's worktree
 
 | Field      | Value                                                                                      |
 | ---------- | ------------------------------------------------------------------------------------------ |
-| `name`     | The pattern's name. It becomes the kebab-case file name once the pattern reaches a page    |
+| `name`     | The key deciding whether two patterns are the same. One from a candidate line carries that line's body verbatim |
 | `evidence` | The array of evidence. `#number` from a PR/issue, `(research)` from a research file        |
 | `existing` | `page` when it sits on an existing page, `candidate` when in `_candidates.md`, else `none` |
 

--- a/skills/scribe/scripts/triage.py
+++ b/skills/scribe/scripts/triage.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""Usage: triage.py '<JSON array of patterns>'
+"""Usage: triage.py '<JSON array of patterns>' <candidates-file>
 
-Each element is {name, evidence: [str], existing: "page"|"candidate"|"none"}.
+Each element is {name, evidence: [str], existing: "page"|"candidate"|"none"}. The array carries
+what this run extracted; the candidate store is read here rather than passed in, so a run cannot
+leave the carried-over rows out of the ranking.
 
 stdout: JSON { pages, candidates, deferred }
-exit: 0, or 2 when the argument is missing
+exit: 0, or 2 when an argument is missing
 """
 
 import json
+import re
 import sys
+from pathlib import Path
 from typing import Literal, TypedDict, cast
 
 # A pattern with fewer than two pieces of evidence does not become a page. One piece cannot show
@@ -19,6 +23,12 @@ EVIDENCE_THRESHOLD = 2
 PAGE_CAP = 3
 
 ACTION = {"page": "update", "candidate": "promote", "none": "create"}
+
+# The two headings Phase 3 sorts the store into. A row under either one is a carried-over pattern.
+STORE_SECTIONS = ("## 昇格待ち", "## 単発")
+
+# Evidence as a store line writes it: `#123` from a PR or issue, `(research)` from a research file.
+EVIDENCE = re.compile(r"#\d+|\(research\)")
 
 
 class Pattern(TypedDict, total=False):
@@ -71,12 +81,53 @@ def triage(patterns: list[Pattern]) -> dict[str, list[Triaged]]:
     }
 
 
+def read_store(path: Path) -> list[Pattern]:
+    """The carried-over rows, or an empty list when the store does not exist yet.
+
+    A row's name is its line with the evidence cut off, which is the form Phase 3 writes.
+    """
+    if not path.is_file():
+        return []
+    rows: list[Pattern] = []
+    inside = False
+    for line in path.read_text(encoding="utf-8").split("\n"):
+        if line.startswith("## "):
+            inside = any(line.startswith(s) for s in STORE_SECTIONS)
+            continue
+        if not inside or not line.startswith("- "):
+            continue
+        body = line[2:]
+        evidence = EVIDENCE.findall(body)
+        name = EVIDENCE.sub("", body).strip()
+        if name:
+            rows.append({"name": name, "evidence": evidence, "existing": "candidate"})
+    return rows
+
+
+def merge(store: list[Pattern], fresh: list[Pattern]) -> list[Pattern]:
+    """Store rows first, so a fresh pattern tying on evidence count does not displace one that
+    has already waited a run."""
+    merged: list[Pattern] = []
+    index: dict[str, int] = {}
+    for p in [*store, *fresh]:
+        name = p.get("name", "")
+        at = index.get(name)
+        if at is None:
+            index[name] = len(merged)
+            merged.append({**p, "evidence": list(p.get("evidence") or [])})
+            continue
+        seen = merged[at]["evidence"]
+        seen.extend(e for e in (p.get("evidence") or []) if e not in seen)
+    return merged
+
+
 def main() -> None:
-    if len(sys.argv) < 2:
-        print("usage: triage.py '<JSON array of patterns>'", file=sys.stderr)
+    if len(sys.argv) < 3:
+        print("usage: triage.py '<JSON array of patterns>' <candidates-file>", file=sys.stderr)
         sys.exit(2)
-    patterns = cast(list[Pattern], json.loads(sys.argv[1]))
-    print(json.dumps(triage(patterns), ensure_ascii=False))
+    fresh = cast(list[Pattern], json.loads(sys.argv[1]))
+    rows = merge(read_store(Path(sys.argv[2])), fresh)
+    print(json.dumps(triage(rows), ensure_ascii=False))
     sys.exit(0)
 
 

--- a/skills/scribe/scripts/triage.py
+++ b/skills/scribe/scripts/triage.py
@@ -24,10 +24,8 @@ PAGE_CAP = 3
 
 ACTION = {"page": "update", "candidate": "promote", "none": "create"}
 
-# The two headings Phase 3 sorts the store into. A row under either one is a carried-over pattern.
 STORE_SECTIONS = ("## 昇格待ち", "## 単発")
 
-# Evidence as a store line writes it: `#123` from a PR or issue, `(research)` from a research file.
 EVIDENCE = re.compile(r"#\d+|\(research\)")
 
 
@@ -82,10 +80,7 @@ def triage(patterns: list[Pattern]) -> dict[str, list[Triaged]]:
 
 
 def read_store(path: Path) -> list[Pattern]:
-    """The carried-over rows, or an empty list when the store does not exist yet.
-
-    A row's name is its line with the evidence cut off, which is the form Phase 3 writes.
-    """
+    """Phase 1 creates the store inside Phase 6's worktree, so the first run has none."""
     if not path.is_file():
         return []
     rows: list[Pattern] = []
@@ -105,8 +100,8 @@ def read_store(path: Path) -> list[Pattern]:
 
 
 def merge(store: list[Pattern], fresh: list[Pattern]) -> list[Pattern]:
-    """Store rows first, so a fresh pattern tying on evidence count does not displace one that
-    has already waited a run."""
+    """Fresh first would let a pattern tying on evidence count displace one that already waited
+    a run, since sorted is stable."""
     merged: list[Pattern] = []
     index: dict[str, int] = {}
     for p in [*store, *fresh]:

--- a/skills/scribe/tests/skill_contract_test.py
+++ b/skills/scribe/tests/skill_contract_test.py
@@ -69,9 +69,7 @@ class SkillContract(unittest.TestCase):
         for lang in LANGS:
             doc = skill(lang)
             phase3 = doc[doc.index("## Phase 3") : doc.index("## Phase 4")]
-            self.assertIn(
-                "triage.py '<", phase3, f"{lang}: Phase 3 names the triage call"
-            )
+            self.assertIn("triage.py '<", phase3, f"{lang}: Phase 3 names the triage call")
             call = phase3[phase3.index("triage.py '<") :]
             call = call[: call.index("`")]
             self.assertIn(

--- a/skills/scribe/tests/skill_contract_test.py
+++ b/skills/scribe/tests/skill_contract_test.py
@@ -3,7 +3,9 @@
 Run: python3 skills/scribe/tests/skill_contract_test.py
 """
 
+import json
 import re
+import subprocess
 import sys
 import unittest
 from pathlib import Path
@@ -14,6 +16,8 @@ ROOT = HERE.parents[2]
 sys.path.insert(0, str(HERE.parent / "scripts"))
 
 from triage import triage  # noqa: E402
+
+TRIAGE = HERE.parent / "scripts" / "triage.py"
 
 LANGS = ["ja", "en"]
 
@@ -58,22 +62,41 @@ class SkillContract(unittest.TestCase):
         for line in lines:
             self.assertRegex(line, r"^- \S.*?(?: (?:#\d+|\(research\)))+$", line)
 
-    def test_a_carried_over_candidate_returns_to_the_array_and_promotes(self) -> None:
-        """Nothing else re-reads the store, so a line the cap deferred never reaches a page again
-        unless Phase 3 puts it back. The array step and the run condition both have to say so."""
-        reads_back = {
-            "ja": "`docs/wiki/_candidates.md` の候補行を両方の節から全て読み",
-            "en": "Read every candidate line in `docs/wiki/_candidates.md`, both sections",
-        }
-        runs_anyway = {"ja": "0 件でも", "en": "Even with PRs, issues, and research all empty"}
+    def test_the_call_the_skill_writes_hands_triage_the_store(self) -> None:
+        """A line the cap deferred reaches a page again only if the store is in the ranking.
+        The skill's call and the script's arity are the two halves; either alone reads green
+        while the store sits out, which is what #504 was."""
         for lang in LANGS:
             doc = skill(lang)
             phase3 = doc[doc.index("## Phase 3") : doc.index("## Phase 4")]
-            self.assertIn(reads_back[lang], phase3, f"{lang}: Phase 3 reads the store back")
-            phase2 = doc[doc.index("## Phase 2") : doc.index("## Phase 3")]
-            self.assertIn(runs_anyway[lang], phase2, f"{lang}: Phase 2 runs on the store alone")
+            self.assertIn(
+                "triage.py '<", phase3, f"{lang}: Phase 3 names the triage call"
+            )
+            call = phase3[phase3.index("triage.py '<") :]
+            call = call[: call.index("`")]
+            self.assertIn(
+                "docs/wiki/_candidates.md",
+                call,
+                f"{lang}: the call hands triage the store",
+            )
+        proc = subprocess.run(
+            [sys.executable, str(TRIAGE), json.dumps([])],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 2, "the script refuses the call without the store")
         report = triage([{"name": "carried", "evidence": ["#1", "#2"], "existing": "candidate"}])
         self.assertEqual(report["pages"][0]["action"], "promote")
+
+    def test_phase_2_goes_on_when_only_the_store_holds_anything(self) -> None:
+        """With the scope empty and the store full, stopping at Phase 2 would strand every
+        carried-over row."""
+        runs_anyway = {"ja": "0 件でも", "en": "Even with PRs, issues, and research all empty"}
+        for lang in LANGS:
+            doc = skill(lang)
+            phase2 = doc[doc.index("## Phase 2") : doc.index("## Phase 3")]
+            self.assertIn(runs_anyway[lang], phase2, f"{lang}: Phase 2 runs on the store alone")
 
     def test_the_store_template_carries_both_sections_the_skill_writes_into(self) -> None:
         """Phase 3 sorts candidates and deferred into two named sections. A skeleton missing one

--- a/skills/scribe/tests/triage_test.py
+++ b/skills/scribe/tests/triage_test.py
@@ -6,6 +6,7 @@ Run: python3 skills/scribe/tests/triage_test.py
 import json
 import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Literal, cast
@@ -14,7 +15,7 @@ HERE = Path(__file__).resolve().parent
 SCRIPT = HERE.parent / "scripts" / "triage.py"
 sys.path.insert(0, str(SCRIPT.parent))
 
-from triage import Pattern, triage  # noqa: E402
+from triage import Pattern, Triaged, triage  # noqa: E402
 
 # The same three values triage branches on. A plain str here widens the literal and the helper
 # stops building the shape the function accepts.
@@ -54,16 +55,133 @@ class Triage(unittest.TestCase):
         self.assertEqual(len(report["pages"]), 3)
         self.assertEqual(len(report["candidates"]), 2)
 
-    def test_the_cli_takes_the_array_on_argv_and_returns_the_three_groups(self) -> None:
+    def test_the_cli_takes_the_array_and_the_store_and_returns_the_three_groups(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "_candidates.md"
+            _ = path.write_text("# candidates\n\n## 昇格待ち\n\n## 単発\n", encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), json.dumps([pattern("a", 2)]), str(path)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        self.assertEqual(proc.returncode, 0)
+        report = cast(dict[str, object], json.loads(proc.stdout))
+        self.assertEqual(sorted(report), ["candidates", "deferred", "pages"])
+
+    def test_the_cli_stops_when_the_store_path_is_missing(self) -> None:
+        """An optional path would put the carried-over rows back at the caller's discretion,
+        which is the shape #504 came from."""
         proc = subprocess.run(
             [sys.executable, str(SCRIPT), json.dumps([pattern("a", 2)])],
             capture_output=True,
             text=True,
             check=False,
         )
+        self.assertEqual(proc.returncode, 2)
+        self.assertIn("candidates-file", proc.stderr)
+
+    def test_a_store_that_does_not_exist_yet_reads_as_no_rows(self) -> None:
+        """Phase 1 creates the store inside Phase 6's worktree, so the first run has none."""
+        with tempfile.TemporaryDirectory() as tmp:
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    json.dumps([pattern("a", 2)]),
+                    str(Path(tmp) / "_candidates.md"),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
         self.assertEqual(proc.returncode, 0)
-        report = cast(dict[str, object], json.loads(proc.stdout))
-        self.assertEqual(sorted(report), ["candidates", "deferred", "pages"])
+        report = cast(dict[str, list[Triaged]], json.loads(proc.stdout))
+        self.assertEqual([p["name"] for p in report["pages"]], ["a"])
+
+
+# The store lines the fixtures below stand for. Content stays Japanese because the store this
+# repository keeps is Japanese, and the parse has to survive that.
+STARVED = "hook のコマンド判定は shlex による位置の解析で行う"
+WAITING = "テンプレートは validator が要求するフィールドを載せる"
+ONE_OFF = "user rule の paths frontmatter は originalCwd 相対で評価される"
+SHARED = "linter の false positive は理由コメント付き disable で抑止する"
+
+
+def store(waiting: list[str], one_off: list[str]) -> str:
+    """A store file carrying the two headings the skill writes into."""
+    return "\n".join(["# candidates", "", "## 昇格待ち", "", *waiting, "", "## 単発", "", *one_off])
+
+
+def run_cli(patterns: list[Pattern], text: str) -> dict[str, list[Triaged]]:
+    """Run the CLI with the freshly extracted array and a store written to a temporary file.
+
+    The store path is passed on argv rather than the array being pre-merged here, because the
+    manual merge is exactly what #504 showed no run performs.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "_candidates.md"
+        _ = path.write_text(text, encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), json.dumps(patterns), str(path)],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=False,
+        )
+    assert proc.returncode == 0, proc.stderr
+    return cast(dict[str, list[Triaged]], json.loads(proc.stdout))
+
+
+class StoreMerge(unittest.TestCase):
+    """The script reads the store itself (#504).
+
+    Decision table for where a pattern comes from. The Triage class above already covers the
+    fresh-only row, so the two rows the store introduces are the ones tested here:
+
+    | in the store | in the fresh array | expected                                               |
+    | ------------ | ------------------ | ------------------------------------------------------ |
+    | yes          | no                 | enters triage as a candidate and sorts by its evidence |
+    | no           | yes                | enters triage as before                                |
+    | yes          | yes                | folds into one row whose evidence is the union         |
+
+    Perspectives: Combination (the merge), Boundary (the two-evidence bar and the three-page cap),
+    Hazard (a store row starved by the cap while thinner patterns take the pages).
+    """
+
+    def test_a_store_row_outranks_thinner_fresh_patterns_for_the_page_cap(self) -> None:
+        """#504 itself: a row backed seven times sat in 昇格待ち for five runs while patterns
+        backed four times took every page. The row reaches the cap only when the script reads
+        the store, since nothing else puts it back into the sort."""
+        report = run_cli(
+            [pattern("a", 4), pattern("b", 4), pattern("c", 4)],
+            store([f"- {STARVED} #349 #350 #351 #352 #353 #354 (research)"], []),
+        )
+        self.assertEqual(report["pages"][0]["name"], STARVED)
+        self.assertEqual(report["pages"][0]["count"], 7)
+        self.assertEqual(len(report["pages"]), 3)
+        self.assertEqual(len(report["deferred"]), 1)
+
+    def test_both_headings_are_read_and_the_evidence_is_cut_off_the_name(self) -> None:
+        """A parse taking 昇格待ち alone drops the 単発 row that a second sighting would promote.
+        Evidence left on the name makes the page file name carry issue numbers."""
+        report = run_cli([], store([f"- {WAITING} #330 (research)"], [f"- {ONE_OFF} #59"]))
+        self.assertEqual(
+            [(p["name"], p["count"], p["action"]) for p in report["pages"]],
+            [(WAITING, 2, "promote")],
+        )
+        self.assertEqual(report["pages"][0]["evidence"], ["#330", "(research)"])
+        self.assertEqual([(c["name"], c["count"]) for c in report["candidates"]], [(ONE_OFF, 1)])
+
+    def test_a_name_held_by_both_sides_folds_into_one_row_with_the_evidence_united(self) -> None:
+        """Two rows under one name split the same pattern's evidence, and the store would gain a
+        second line for a page it already has. A repeated piece of evidence is counted once."""
+        fresh: Pattern = {"name": SHARED, "evidence": ["#168", "#390"], "existing": "none"}
+        report = run_cli([fresh], store([f"- {SHARED} #167 #168"], []))
+        rows = report["pages"] + report["candidates"] + report["deferred"]
+        self.assertEqual([r["name"] for r in rows], [SHARED])
+        self.assertEqual(sorted(rows[0]["evidence"]), ["#167", "#168", "#390"])
+        self.assertEqual(rows[0]["count"], 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & Why

`triage.py` が `docs/wiki/_candidates.md` を自分で読むようにする。

Phase 3 が候補行を配列へ入れる手順は LLM の手作業で、機構が強制していなかった。26 行を毎回 JSON へ組む作業なので実際の run では省略され、根拠 7 件の行が 5 run 昇格せず、同じ run で根拠 4 件の行がページになった。2026-07-19 から 12 行が 36 日滞留している。

## Review focus

- `triage.py` の第 2 引数を必須にした判断。任意にすると「skill が渡せと言うが機構が強制しない」という同じ形が一段下で再発する
- `skill_contract_test.py` の書き直し。散文 grep から、呼び出し形と script の arity を対で見る形へ
- `read_store` の name の取り方。行から根拠を落とした残りを name にする。新規抽出の name (kebab-case 化できる短い名前) とは形が違うので、両者の完全一致は起きにくい

## Changes

- `triage.py` に `read_store` と `merge` を足し、CLI の第 2 引数を必須にする。store の行を先に置くので、根拠数が並んだとき 1 run 待った行が新規に負けない
- `SKILL.md` (ja + en) の Phase 3 から候補行を配列へ入れる手順を落とし、呼び出しに store のパスを足す
- `triage_test.py` に #504 の症状を固定するテストと、引数省略時の停止、store 未作成時の扱いを足す
- `skill_contract_test.py` の空振りテストを書き直す

## Scope

- Not included: `PAGE_CAP` の値と昇格待ちプールの存在
- Not included: aging や FIFO 枠。候補行が渡っていないことが原因なので、ソートキーを変えても結果は変わらない
- Not included: `_candidates.md` の行形式。name を持たせる形にすれば新規抽出との照合が効くが、38 行の移行を伴うので別に切る

## Design Decisions

- 第 2 引数を必須にした。既存の `test_the_cli_takes_the_array_on_argv_and_returns_the_three_groups` が引数 1 個で exit 0 を期待していたので書き換えている
- `triage()` の signature は変えず、`main()` で読んでマージする。`from triage import triage` を使う既存テストがそのまま通る
- store の行を fresh より前に置く。`sorted` が安定なので、根拠数が同じなら待った行が先に出る
- 散文 grep のテストを消さずに書き直した。Phase 2 の起動条件は散文にしか存在しないので、そちらは grep のまま別テストに分けている

## How to Test

1. `python3 skills/scribe/tests/triage_test.py` と `python3 skills/scribe/tests/skill_contract_test.py` を実行する
2. 11 tests OK と 15 tests OK になる
3. `triage.py` の `main` を `if len(sys.argv) < 2` と `rows = fresh` に戻す
4. 契約テスト 1 件と triage テスト 4 件が落ちる。修正前のテストは同じ改変で green のままだった

## Related

- Closes #504
