### PR TITLE
[scribe] external-origin-labeling と policy-value-capture-test を追加

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -11,17 +11,14 @@
 - ローカルで通り CI や別の起動元で落ちる差は、環境が供給するものの違いから出る #354 #358 #381
 - 条件付き rules の paths が発火しないまま実装が先行し、規約と実態が乖離する #237 #240
 - plugin 配布は fix PR 後に marketplace.json の version bump を別 PR で行い、桁は fix=patch/呼び出し契約変更=minor #200 #203 #207
-- linter の false positive は緩和でなく理由コメント付き disable で抑止する #167 #168 #171 #176 #390
 - 成果物が gitignore 配下 (output-styles/、.claude/workspace/) の作業は PR にせず手動 close する #33 #37 #38 #42
 - 根本原因が Claude Code runtime 側のバグは repo 側 wontfix + upstream 起票 + guard 文言で close する #132 #133 #177
 - 横展開の要否は ugrep 全ツリー確認で確定してから scope を固定する #49 #50 #53 #57
 - reviewer 系の新設・再構築は Recall、FP baseline を計測して close する #24 #28 #43
-- 外部発想の issue には source:<origin> ラベルを付ける #30 #31 #32 #33 #39 #40 #41
 - 軽量バックログ複数件は 1 PR に束ねて複数 Closes する #44 #45
 - script/agent 出力は JSON stdout、error stderr、banner なしの機械可読形式にする #13 #54
 - audit report 命名は `<YYYY-MM-DD>-<HHMMSS>-<slug>.md`、slug は skill 名一致 #47 #51 #52 #53
 - 翻訳は情報系 prose のみ、file:line、severity、Closes 等の構造化フィールドは verbatim #175 #176
-- policy 値 (effort/model) は per-file 定数でなく behavioral capture テストで固定する #191 #192 #199 #223 #224
 - hook payload の形状は smoke test で実測確定し fixture 化してから gate を作る #150 #154
 - 挙動が実 run で観測できるまで PR は draft に据え置く #143 #159 #162 #163 #226
 - 計画/umbrella issue は実装 issue へ切り直して superseded close する #37 #42 #46 #136
@@ -49,3 +46,6 @@
 - 契約の正準が実行側 script にあるとき、参照文書の「この要素は落とす」は必須フィールドの省略として実装され build を止める #468
 
 ## 棄却
+
+- linter の false positive は緩和でなく理由コメント付き disable で抑止する #167 #168 #171 #176 #390
+  根拠の #390 #167 #176 はいずれも linter の false positive への対処を述べておらず、規約の内容を確定できない

--- a/docs/wiki/external-origin-labeling.md
+++ b/docs/wiki/external-origin-labeling.md
@@ -1,0 +1,34 @@
+---
+globs: []
+---
+
+# 外部発想の issue に origin を残す
+
+## 内容
+
+他所で見た仕組みを自分のリポジトリへ持ち込むとき、その issue に `source:<origin>` ラベルを付ける。origin は発想元を指す短い識別子で、リポジトリ名かサービス名を kebab-case で書く。後から「この仕組みはどこから来たのか」を issue 一覧の絞り込みだけで辿れる状態にする。
+
+## 定型手順
+
+1. 外部の記事、リポジトリ、発表から発想した issue を起票する
+2. `source:<origin>` ラベルが無ければ `gh label create` で作る。説明文に発想元を書く
+3. issue にそのラベルを付ける
+4. 色は既存の `source:*` と揃える。1 prefix 1 色の規律に従う
+
+## 参照コード
+
+- `skills/issue/SKILL.md` の `Publishing constraints`（ラベル付与の手順。source 系は「Other labels follow the repository's conventions」に当たる）
+
+## 由来
+
+- `docs/decisions/0059-adopt-tier-3-lite-github-label-strategy.md`（prefix + `:` + kebab-case という命名規約と 1 prefix 1 色を決めた DR）
+
+## 根拠
+
+- #30 ADR 採用基準の 3 条件を追加。`source:mattpocock-skills`
+- #31 TDD ワークフローに horizontal slices 禁止を明文化。`source:mattpocock-skills`
+- #32 issue テンプレートに Testing Decisions セクションを追加。`source:mattpocock-skills`
+- #33 caveman 圧縮モードを追加。`source:mattpocock-skills`
+- #39 Scout 風の docs index 強制読み込みを research skill へ組み込む。`source:gmo-orchestrator-blog`
+- #40 大型 docs の自動分割を実装。`source:gmo-orchestrator-blog`
+- #41 トークン消費 before/after の測定 harness を整備。`source:gmo-orchestrator-blog`

--- a/docs/wiki/policy-value-capture-test.md
+++ b/docs/wiki/policy-value-capture-test.md
@@ -1,0 +1,29 @@
+---
+globs: ["**/workflows/**/*.js"]
+---
+
+# policy 値を behavioral capture テストで固定する
+
+## 内容
+
+agent へ渡す effort と model は、ファイルごとの定数を読むテストでなく、実際に走らせて渡った値を捉えるテストで固定する。定数を読むテストは、定数が残ったまま呼び出し側が値を渡さなくなっても緑のままになる。
+
+## 定型手順
+
+1. workflow を実行し、agent 呼び出しへ渡った effort と model を捉える
+2. 期待値をテスト側へ書き写さず、渡った値そのものを検査する
+3. 呼び出し側から値を落として、テストが落ちることを確認する
+
+## 参照コード
+
+- `workflows/code/tests/code.model.test.js`（`input.model` が Red / Green の実装 agent だけへ届き、その agent が effort high で走ることを捉える）
+- `workflows/audit/tests/audit.effort.test.js`（audit の各段へ渡る effort を捉える）
+- `workflows/polish/tests/polish.effort.test.js`（polish の各段へ渡る effort を捉える）
+
+## 根拠
+
+- #191 workflows の effort policy を per-stage へ一本化し、xhigh を verify / judge 段のみに絞る起票
+- #192 その実装。xhigh を critic-* 系のみに限定した
+- #199 build の sibling を dev-tree 優先へ反転し、stale plugin の shadow を防いだ
+- #223 code workflow の実装 agent へ no-advisor constraint を追加した
+- #224 audit の critic 層を opus から sonnet へ切り替える trial


### PR DESCRIPTION
## 追加したページ

- `external-origin-labeling.md` 外部発想の issue に origin を残す (根拠 7 件、昇格待ちから)
- `policy-value-capture-test.md` policy 値を behavioral capture テストで固定する (根拠 5 件、昇格待ちから)

## 候補の追記

無し。今回は新規抽出をしていない。

## 参照コード / 由来の修理

無し。全 15 ページの参照コードを掃き、壊れ 0 件。由来リンクを持つ 2 ページ (`ja-mirror-drift.md`, `workflow-structure.md`) の DR 4 件はすべて accepted。

## 読んだ範囲

cursor は 2026-08-20T15:12:37Z (#393)。この差分にある merged PR 60 件、closed issue 61 件、research 4 件は今回読んでいない。125 件を 1 コンテキストで読むと context を使い切るため、新規抽出をスキップして昇格待ちの消化だけを行った。cursor は進めていないので、次の run が同じ 125 件を対象にする。

## 検証で落としたもの

| 共通項 | 理由 |
| ------ | ---- |
| linter の false positive は緩和でなく理由コメント付き disable で抑止する | 根拠の #390 #167 #176 を読んだが、いずれも linter の false positive への対処を述べていない。#176 は逆に oxlint のルールを追加した記録。規約の内容を確定できない |

この行は #474 で足した「棄却」節へ理由付きで移した。`triage.py` の `read_store` は昇格待ちと単発しか読まないので、次の run の順位付けには戻らない。

## 残し

昇格待ち 20 行。根拠の多い順に次の run へ回る。次に上がるのは根拠 5 件の 1 行と根拠 4 件の 2 行。

`PAGE_CAP = 3` に対して今回ページ化したのは 2 枚。Phase 4 で 1 件落ちた分は繰り上がらない。
