### PR TITLE
[Feature] scribe が 1 起動でコミットを重ねて在庫を尽くす

### DIFF
--- a/.ja/skills/scribe/SKILL.md
+++ b/.ja/skills/scribe/SKILL.md
@@ -11,14 +11,14 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 
 ## 不変条件
 
-| 条件          | 内容                                                                                                               |
-| ------------- | ------------------------------------------------------------------------------------------------------------------ |
-| PR 経由       | デフォルトブランチへ直接コミット / プッシュしない                                                                  |
-| 進捗の記録    | cursor は最後にマージされた scribe PR の mergedAt。research ファイルはその mergedAt と mtime を比べる              |
-| 閾値の所在    | ページにするか候補に置くかの判定は `scripts/triage.py` が持ち、この skill は判定しない                             |
-| 事実のみ      | PR / issue と research ファイルに書かれた事実、および現在のコードで確認できた事実のみ書く。推測で埋めない          |
-| research は引かない | `.claude/workspace/research/` のファイルパスを `docs/wiki/` 配下に書かない。workspace は追跡外で、wiki を読む人が辿れない |
-| worktree 隔離 | 編集 / commit は隔離 worktree 内で行い、ユーザーの作業ツリーを動かさない。worktree を作るのは Phase 6 なので、書き込む Phase は Phase 6 だけ |
+| 条件                | 内容                                                                                                                                         |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| PR 経由             | デフォルトブランチへ直接コミット / プッシュしない                                                                                            |
+| 進捗の記録          | cursor は最後にマージされた scribe PR の mergedAt。research ファイルはその mergedAt と mtime を比べる                                        |
+| 閾値の所在          | ページにするか候補に置くかの判定は `scripts/triage.py` が持ち、この skill は判定しない                                                       |
+| 事実のみ            | PR / issue と research ファイルに書かれた事実、および現在のコードで確認できた事実のみ書く。推測で埋めない                                    |
+| research は引かない | `.claude/workspace/research/` のファイルパスを `docs/wiki/` 配下に書かない。workspace は追跡外で、wiki を読む人が辿れない                    |
+| worktree 隔離       | 編集 / commit は隔離 worktree 内で行い、ユーザーの作業ツリーを動かさない。worktree を作るのは Phase 6 なので、書き込む Phase は Phase 6 だけ |
 
 ## Phase 1: 前提確認とオンボーディング
 
@@ -45,11 +45,11 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 6. その配列を `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<共通項の JSON 配列>' docs/wiki/_candidates.md` に渡す。script が `_candidates.md` の両方の節から候補行を読んで配列へ混ぜ、閾値 2 件と 1 回あたりのページ上限を当て、`pages` (新規/昇格/更新)、`candidates`、`deferred` (今回は見送り) に分ける。閾値と上限を自分で判定しない
 7. `docs/wiki/_candidates.md` を書き換える形を用意する。`candidates` は「単発」節へ、`deferred` は「昇格待ち」節へ置き、`pages` になった共通項の行は消す。行は `- <内容 1 行> <根拠>` の形にし、根拠は `#番号` と `(research)` をスペース区切りで並べる。既に行があれば根拠だけを足す。書き込みは Phase 6 の worktree 内で行う
 
-| フィールド | 値                                                                            |
-| ---------- | ------------------------------------------------------------------------------- |
+| フィールド | 値                                                                                                            |
+| ---------- | ------------------------------------------------------------------------------------------------------------- |
 | `name`     | 共通項の同一性を決めるキー。候補行から来たものは行の本文がそのまま入る。ページのファイル名は Phase 6 で決める |
-| `evidence` | 根拠の配列。PR/issue 由来は `#番号`、research 由来は `(research)`              |
-| `existing` | 既存ページにあれば `page`、`_candidates.md` にあれば `candidate`、無ければ `none` |
+| `evidence` | 根拠の配列。PR/issue 由来は `#番号`、research 由来は `(research)`                                             |
+| `existing` | 既存ページにあれば `page`、`_candidates.md` にあれば `candidate`、無ければ `none`                             |
 
 ## Phase 4: 最新コードとの突き合わせ
 
@@ -61,12 +61,12 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 4. 壊れていた参照は現行コードを読み直す。決める内容は下表による
 5. 落とした項目が `_candidates.md` に行を持つとき、その行を「棄却」節へ移し、次の行に落とした理由をインデントして書く。Phase 3 手順 7 が用意した削除より優先する
 
-| 確認                                                | 不成立のときに決める内容                             |
-| --------------------------------------------------- | ---------------------------------------------------- |
-| 規約 / 手順が現在の実装でも成立するか               | 落とす。既存ページの項目なら不成立と書き直す文面     |
-| 構造ページの記述が現在の実装と一致するか           | 現行コードに合わせて書き直す文面。落とさない         |
-| lint / hook / CI ですでに機械的に強制されていないか | 落とす                                               |
-| 参照するパス / コマンドが現存するか                 | 現行のパス / コマンドへの張り替え先                  |
+| 確認                                                | 不成立のときに決める内容                         |
+| --------------------------------------------------- | ------------------------------------------------ |
+| 規約 / 手順が現在の実装でも成立するか               | 落とす。既存ページの項目なら不成立と書き直す文面 |
+| 構造ページの記述が現在の実装と一致するか            | 現行コードに合わせて書き直す文面。落とさない     |
+| lint / hook / CI ですでに機械的に強制されていないか | 落とす                                           |
+| 参照するパス / コマンドが現存するか                 | 現行のパス / コマンドへの張り替え先              |
 
 ## Phase 5: 由来リンクの判定
 
@@ -76,11 +76,13 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 
 ## Phase 6: PR 作成
 
-扱うページは Phase 3 の `pages` に限り、`deferred` は PR 本文に残しとして明記する。参照修理と由来修理は上限の外なので、`pages` が 0 件でも実施する。候補への追記だけでも PR を作り、変更が何も無いときだけ作らない。
+扱うページは Phase 3 の `pages` に限り、`deferred` は PR 本文に残しとして明記する。参照修理と由来修理は上限の外なので、`pages` が 0 件でも実施する。候補への追記だけでも PR を作り、変更が何も無いときだけ作らない。triage.py が返す `commits` の要素ごとに 1 コミットとし、1 コミット目の直後に PR を作って以降は同じブランチへ push で足す。最後に `verify_run.py` を通し、失敗したらどの手順であっても worktree とローカルブランチを残さない。
 
 1. `git fetch origin <デフォルトブランチ>` の後、`origin/<デフォルトブランチ>` から隔離 worktree とブランチ `scribe/<yyyymmdd-HHMMSS>` を作る
 2. worktree 内で Phase 3-5 が決めた内容を書き込む。ページは ${CLAUDE_SKILL_DIR}/templates/page.md の骨格に従い、候補行は Phase 3 手順 7 の形で `_candidates.md` へ、参照修理と由来修理は Phase 4-5 が決めた張り替え先で書く
-3. メッセージ `docs(wiki): <共通項名, ...> を追加/更新` でコミットする
-4. push して `gh pr create --base <デフォルトブランチ>` を実行する。タイトル `[scribe] <共通項名, ...> を追加/更新`、ラベル scribe
-5. 本文には追加/昇格/更新したページ、候補への追記、参照修理/由来修理したページ、読んだ PR/issue の範囲と research の件数、検証で落とした項目、打ち切った残しを書く
-6. worktree を削除する
+3. `commits` の要素を先頭から順にコミットする。1 コミット目は自分が含むページに加え `_candidates.md` の更新と参照修理・由来修理も `git add` し、残りの要素は自分が含むページだけを `git add` する。要素ごとにメッセージ `docs(wiki): <要素内の共通項名, ...> を追加/更新` で 1 要素 1 コミットする
+4. 1 コミット目の直後に push して `gh pr create --base <デフォルトブランチ>` を実行する。タイトル `[scribe] <共通項名, ...> を追加/更新`、ラベル scribe。本文には追加/昇格/更新したページ、候補への追記、参照修理/由来修理したページ、読んだ PR/issue の範囲と research の件数、検証で落とした項目、打ち切った残しを書く
+5. 残りの要素は手順 3 でコミットするたびに同じブランチへ push で足す
+6. 全コミットを push し終えたら `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>` を実行する。`<start-count>` は書き込み前の昇格待ち行数、`<expected-commits>` は `commits` の要素数とし、`ok` が true であることを確認する
+7. worktree を削除する
+8. いずれかの手順が失敗したら `git worktree remove --force <worktree>` と `git branch -D scribe/<yyyymmdd-HHMMSS>` を実行し、worktree とローカルブランチを残さない

--- a/.ja/skills/scribe/SKILL.md
+++ b/.ja/skills/scribe/SKILL.md
@@ -76,13 +76,12 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 
 ## Phase 6: PR 作成
 
-扱うページは Phase 3 の `pages` に限り、`deferred` は PR 本文に残しとして明記する。参照修理と由来修理は上限の外なので、`pages` が 0 件でも実施する。候補への追記だけでも PR を作り、変更が何も無いときだけ作らない。triage.py が返す `commits` の要素ごとに 1 コミットとし、1 コミット目の直後に PR を作って以降は同じブランチへ push で足す。最後に `verify_run.py` を通し、失敗したらどの手順であっても worktree とローカルブランチを残さない。
+扱うページは Phase 3 の `pages` に限り、`deferred` は PR 本文に残しとして明記する。参照修理と由来修理は上限の外なので、`pages` が 0 件でも実施する。候補への追記だけでも PR を作り、変更が何も無いときだけ作らない。triage.py が返す `commits` の要素ごとに 1 コミットとし、全要素をコミットして `verify_run.py` を通してから PR を作る。
 
 1. `git fetch origin <デフォルトブランチ>` の後、`origin/<デフォルトブランチ>` から隔離 worktree とブランチ `scribe/<yyyymmdd-HHMMSS>` を作る
 2. worktree 内で Phase 3-5 が決めた内容を書き込む。ページは ${CLAUDE_SKILL_DIR}/templates/page.md の骨格に従い、候補行は Phase 3 手順 7 の形で `_candidates.md` へ、参照修理と由来修理は Phase 4-5 が決めた張り替え先で書く
 3. `commits` の要素を先頭から順にコミットする。1 コミット目は自分が含むページに加え `_candidates.md` の更新と参照修理・由来修理も `git add` し、残りの要素は自分が含むページだけを `git add` する。要素ごとにメッセージ `docs(wiki): <要素内の共通項名, ...> を追加/更新` で 1 要素 1 コミットする
-4. 1 コミット目の直後に push して `gh pr create --base <デフォルトブランチ>` を実行する。タイトル `[scribe] <共通項名, ...> を追加/更新`、ラベル scribe。本文には追加/昇格/更新したページ、候補への追記、参照修理/由来修理したページ、読んだ PR/issue の範囲と research の件数、検証で落とした項目、打ち切った残しを書く
-5. 残りの要素は手順 3 でコミットするたびに同じブランチへ push で足す
-6. 全コミットを push し終えたら `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>` を実行する。`<start-count>` は書き込み前の昇格待ち行数、`<expected-commits>` は `commits` の要素数とし、`ok` が true であることを確認する
-7. worktree を削除する
-8. いずれかの手順が失敗したら `git worktree remove --force <worktree>` と `git branch -D scribe/<yyyymmdd-HHMMSS>` を実行し、worktree とローカルブランチを残さない
+4. `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>` を実行する。`<start-count>` は書き込み前の昇格待ち行数、`<expected-commits>` は `commits` の要素数とし、`ok` が true であることを確認する。false のときは push せず PR も作らない
+5. push して `gh pr create --base <デフォルトブランチ>` を実行する。タイトル `[scribe] <共通項名, ...> を追加/更新`、ラベル scribe。本文には追加/昇格/更新したページをコミットごとに分けて並べ、候補への追記、参照修理/由来修理したページ、読んだ PR/issue の範囲と research の件数、検証で落とした項目、打ち切った残しを書く
+6. worktree を削除する
+7. 手順 4 が false を返したときは worktree を残す。書き込みをやり直せる状態にしておく。手順 5 以降が失敗したときは `git worktree remove --force <worktree>` と `git branch -D scribe/<yyyymmdd-HHMMSS>` を実行し、worktree とローカルブランチを残さない

--- a/.ja/skills/scribe/SKILL.md
+++ b/.ja/skills/scribe/SKILL.md
@@ -76,12 +76,12 @@ allowed-tools: Bash(git:*) Bash(gh:*) Bash(find:*) Bash(python3:*) Read Write Ed
 
 ## Phase 6: PR 作成
 
-扱うページは Phase 3 の `pages` に限り、`deferred` は PR 本文に残しとして明記する。参照修理と由来修理は上限の外なので、`pages` が 0 件でも実施する。候補への追記だけでも PR を作り、変更が何も無いときだけ作らない。triage.py が返す `commits` の要素ごとに 1 コミットとし、全要素をコミットして `verify_run.py` を通してから PR を作る。
+扱うページは Phase 3 の `pages` に限り、`deferred` は PR 本文に残しとして明記する。参照修理と由来修理は上限の外なので、`pages` が 0 件でも実施する。候補への追記だけでも PR を作り、変更が何も無いときだけ作らない。
 
 1. `git fetch origin <デフォルトブランチ>` の後、`origin/<デフォルトブランチ>` から隔離 worktree とブランチ `scribe/<yyyymmdd-HHMMSS>` を作る
 2. worktree 内で Phase 3-5 が決めた内容を書き込む。ページは ${CLAUDE_SKILL_DIR}/templates/page.md の骨格に従い、候補行は Phase 3 手順 7 の形で `_candidates.md` へ、参照修理と由来修理は Phase 4-5 が決めた張り替え先で書く
 3. `commits` の要素を先頭から順にコミットする。1 コミット目は自分が含むページに加え `_candidates.md` の更新と参照修理・由来修理も `git add` し、残りの要素は自分が含むページだけを `git add` する。要素ごとにメッセージ `docs(wiki): <要素内の共通項名, ...> を追加/更新` で 1 要素 1 コミットする
-4. `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>` を実行する。`<start-count>` は書き込み前の昇格待ち行数、`<expected-commits>` は `commits` の要素数とし、`ok` が true であることを確認する。false のときは push せず PR も作らない
+4. `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>` を実行する。`<start-count>` は書き込み前の昇格待ち行数、`<expected-commits>` は `commits` の要素数とし、`ok` が true であることを確認する。false なら手順 5 へ進まない
 5. push して `gh pr create --base <デフォルトブランチ>` を実行する。タイトル `[scribe] <共通項名, ...> を追加/更新`、ラベル scribe。本文には追加/昇格/更新したページをコミットごとに分けて並べ、候補への追記、参照修理/由来修理したページ、読んだ PR/issue の範囲と research の件数、検証で落とした項目、打ち切った残しを書く
 6. worktree を削除する
 7. 手順 4 が false を返したときは worktree を残す。書き込みをやり直せる状態にしておく。手順 5 以降が失敗したときは `git worktree remove --force <worktree>` と `git branch -D scribe/<yyyymmdd-HHMMSS>` を実行し、worktree とローカルブランチを残さない

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -76,13 +76,12 @@ In addition, inspect the 由来 links of every page, including existing pages. V
 
 ## Phase 6: PR creation
 
-Move only the pages in Phase 3's `pages`, and state `deferred` in the PR body as what was left. Reference repairs and 由来 repairs sit outside the cap, so run them even when `pages` is empty. Create a PR even for candidate-only additions, and skip the PR only when there is no change at all. Commit one element of triage.py's `commits` at a time, create the PR right after the first commit, and add the rest by pushing to the same branch. Finally run `verify_run.py`, and on failure at any step leave neither the worktree nor the local branch behind.
+Move only the pages in Phase 3's `pages`, and state `deferred` in the PR body as what was left. Reference repairs and 由来 repairs sit outside the cap, so run them even when `pages` is empty. Create a PR even for candidate-only additions, and skip the PR only when there is no change at all. Commit one element of triage.py's `commits` at a time, and create the PR after every element is committed and `verify_run.py` has passed.
 
 1. After `git fetch origin <default branch>`, create an isolated worktree and branch `scribe/<yyyymmdd-HHMMSS>` from `origin/<default branch>`
 2. Write what Phase 3-5 settled, inside the worktree. Pages follow the skeleton in ${CLAUDE_SKILL_DIR}/templates/page.md, candidate lines go to `_candidates.md` in Phase 3 step 7's form, and the reference and 由来 repairs use the relink targets Phase 4-5 settled
 3. Commit the elements of `commits` in order, one at a time. The first commit also `git add`s the `_candidates.md` update and the reference/由来 repairs alongside its own pages, and the rest of the elements `git add` only their own pages. Commit each element separately with the message `docs(wiki): <that element's pattern names, ...> を追加/更新`
-4. Right after the first commit, push and run `gh pr create --base <default branch>`. Title `[scribe] <pattern names, ...> を追加/更新`, label scribe. In the body, write the added/promoted/updated pages, candidate additions, reference-repaired/由来-repaired pages, the range of PRs/issues read and the count of research files read, the items dropped by verification, and any leftovers
-5. Push the remaining elements to the same branch each time step 3 commits one
-6. Once every commit is pushed, run `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>`. `<start-count>` is the 昇格待ち row count before the write, `<expected-commits>` is the element count of `commits`, and confirm `ok` comes back true
-7. Remove the worktree
-8. If any step fails, run `git worktree remove --force <worktree>` and `git branch -D scribe/<yyyymmdd-HHMMSS>` so neither the worktree nor the local branch is left behind
+4. Run `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>`. `<start-count>` is the 昇格待ち row count before the write, `<expected-commits>` is the element count of `commits`, and confirm `ok` comes back true. On false, neither push nor create the PR
+5. Push and run `gh pr create --base <default branch>`. Title `[scribe] <pattern names, ...> を追加/更新`, label scribe. In the body, list the added/promoted/updated pages grouped per commit, then the candidate additions, the reference-repaired/由来-repaired pages, the range of PRs/issues read and the count of research files read, the items dropped by verification, and any leftovers
+6. Remove the worktree
+7. When step 4 returns false, leave the worktree in place so the write can be redone. When step 5 or later fails, run `git worktree remove --force <worktree>` and `git branch -D scribe/<yyyymmdd-HHMMSS>` so neither the worktree nor the local branch is left behind

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -76,12 +76,12 @@ In addition, inspect the 由来 links of every page, including existing pages. V
 
 ## Phase 6: PR creation
 
-Move only the pages in Phase 3's `pages`, and state `deferred` in the PR body as what was left. Reference repairs and 由来 repairs sit outside the cap, so run them even when `pages` is empty. Create a PR even for candidate-only additions, and skip the PR only when there is no change at all. Commit one element of triage.py's `commits` at a time, and create the PR after every element is committed and `verify_run.py` has passed.
+Move only the pages in Phase 3's `pages`, and state `deferred` in the PR body as what was left. Reference repairs and 由来 repairs sit outside the cap, so run them even when `pages` is empty. Create a PR even for candidate-only additions, and skip the PR only when there is no change at all.
 
 1. After `git fetch origin <default branch>`, create an isolated worktree and branch `scribe/<yyyymmdd-HHMMSS>` from `origin/<default branch>`
 2. Write what Phase 3-5 settled, inside the worktree. Pages follow the skeleton in ${CLAUDE_SKILL_DIR}/templates/page.md, candidate lines go to `_candidates.md` in Phase 3 step 7's form, and the reference and 由来 repairs use the relink targets Phase 4-5 settled
 3. Commit the elements of `commits` in order, one at a time. The first commit also `git add`s the `_candidates.md` update and the reference/由来 repairs alongside its own pages, and the rest of the elements `git add` only their own pages. Commit each element separately with the message `docs(wiki): <that element's pattern names, ...> を追加/更新`
-4. Run `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>`. `<start-count>` is the 昇格待ち row count before the write, `<expected-commits>` is the element count of `commits`, and confirm `ok` comes back true. On false, neither push nor create the PR
+4. Run `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>`. `<start-count>` is the 昇格待ち row count before the write, `<expected-commits>` is the element count of `commits`, and confirm `ok` comes back true. On false, do not go on to step 5
 5. Push and run `gh pr create --base <default branch>`. Title `[scribe] <pattern names, ...> を追加/更新`, label scribe. In the body, list the added/promoted/updated pages grouped per commit, then the candidate additions, the reference-repaired/由来-repaired pages, the range of PRs/issues read and the count of research files read, the items dropped by verification, and any leftovers
 6. Remove the worktree
 7. When step 4 returns false, leave the worktree in place so the write can be redone. When step 5 or later fails, run `git worktree remove --force <worktree>` and `git branch -D scribe/<yyyymmdd-HHMMSS>` so neither the worktree nor the local branch is left behind

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -45,11 +45,11 @@ The patterns worth picking up are procedures that recur as a routine or a conven
 6. Pass that array to `python3 ${CLAUDE_SKILL_DIR}/scripts/triage.py '<JSON array of patterns>' docs/wiki/_candidates.md`. The script reads the candidate lines from both sections of `_candidates.md` into the array, then applies the two-evidence threshold and the per-run page cap, splitting the result into `pages` (create/promote/update), `candidates`, and `deferred` (left for a later run). Do not judge the threshold or the cap yourself
 7. Prepare how `docs/wiki/_candidates.md` changes. `candidates` go under the 単発 section and `deferred` under the 昇格待ち section, and the line of a pattern that became a page is removed. A line takes the form `- <one-line content> <evidence>`, with `#number` and `(research)` listed space-separated. When the line is already there, add only the evidence. The write happens inside Phase 6's worktree
 
-| Field      | Value                                                                                      |
-| ---------- | ------------------------------------------------------------------------------------------ |
+| Field      | Value                                                                                                           |
+| ---------- | --------------------------------------------------------------------------------------------------------------- |
 | `name`     | The key deciding whether two patterns are the same. One from a candidate line carries that line's body verbatim |
-| `evidence` | The array of evidence. `#number` from a PR/issue, `(research)` from a research file        |
-| `existing` | `page` when it sits on an existing page, `candidate` when in `_candidates.md`, else `none` |
+| `evidence` | The array of evidence. `#number` from a PR/issue, `(research)` from a research file                             |
+| `existing` | `page` when it sits on an existing page, `candidate` when in `_candidates.md`, else `none`                      |
 
 ## Phase 4: Cross-check against the latest code
 
@@ -76,11 +76,13 @@ In addition, inspect the 由来 links of every page, including existing pages. V
 
 ## Phase 6: PR creation
 
-Move only the pages in Phase 3's `pages`, and state `deferred` in the PR body as what was left. Reference repairs and 由来 repairs sit outside the cap, so run them even when `pages` is empty. Create a PR even for candidate-only additions, and skip the PR only when there is no change at all.
+Move only the pages in Phase 3's `pages`, and state `deferred` in the PR body as what was left. Reference repairs and 由来 repairs sit outside the cap, so run them even when `pages` is empty. Create a PR even for candidate-only additions, and skip the PR only when there is no change at all. Commit one element of triage.py's `commits` at a time, create the PR right after the first commit, and add the rest by pushing to the same branch. Finally run `verify_run.py`, and on failure at any step leave neither the worktree nor the local branch behind.
 
 1. After `git fetch origin <default branch>`, create an isolated worktree and branch `scribe/<yyyymmdd-HHMMSS>` from `origin/<default branch>`
 2. Write what Phase 3-5 settled, inside the worktree. Pages follow the skeleton in ${CLAUDE_SKILL_DIR}/templates/page.md, candidate lines go to `_candidates.md` in Phase 3 step 7's form, and the reference and 由来 repairs use the relink targets Phase 4-5 settled
-3. Commit with the message `docs(wiki): <pattern names, ...> を追加/更新`
-4. Push and run `gh pr create --base <default branch>`. Title `[scribe] <pattern names, ...> を追加/更新`, label scribe
-5. In the body, write the added/promoted/updated pages, candidate additions, reference-repaired/由来-repaired pages, the range of PRs/issues read and the count of research files read, the items dropped by verification, and any leftovers
-6. Remove the worktree
+3. Commit the elements of `commits` in order, one at a time. The first commit also `git add`s the `_candidates.md` update and the reference/由来 repairs alongside its own pages, and the rest of the elements `git add` only their own pages. Commit each element separately with the message `docs(wiki): <that element's pattern names, ...> を追加/更新`
+4. Right after the first commit, push and run `gh pr create --base <default branch>`. Title `[scribe] <pattern names, ...> を追加/更新`, label scribe. In the body, write the added/promoted/updated pages, candidate additions, reference-repaired/由来-repaired pages, the range of PRs/issues read and the count of research files read, the items dropped by verification, and any leftovers
+5. Push the remaining elements to the same branch each time step 3 commits one
+6. Once every commit is pushed, run `python3 ${CLAUDE_SKILL_DIR}/scripts/verify_run.py <worktree> <start-count> <expected-commits>`. `<start-count>` is the 昇格待ち row count before the write, `<expected-commits>` is the element count of `commits`, and confirm `ok` comes back true
+7. Remove the worktree
+8. If any step fails, run `git worktree remove --force <worktree>` and `git branch -D scribe/<yyyymmdd-HHMMSS>` so neither the worktree nor the local branch is left behind

--- a/skills/scribe/scripts/triage.py
+++ b/skills/scribe/scripts/triage.py
@@ -5,7 +5,7 @@ Each element is {name, evidence: [str], existing: "page"|"candidate"|"none"}. Th
 what this run extracted; the candidate store is read here rather than passed in, so a run cannot
 leave the carried-over rows out of the ranking.
 
-stdout: JSON { pages, candidates, deferred }
+stdout: JSON { pages, candidates, deferred, commits }
 exit: 0, or 2 when an argument is missing
 """
 
@@ -19,8 +19,12 @@ from typing import Literal, TypedDict, cast
 # recurrence, and pageifying it turns a one-off circumstance into a convention.
 EVIDENCE_THRESHOLD = 2
 
-# How many pages one PR moves. Candidate appends and reference repairs are not counted.
+# How many pages one commit moves. Candidate appends and reference repairs are not counted.
 PAGE_CAP = 3
+
+# How many commits one run moves. Provisional: revisit once the first multi-commit PR's merge
+# time is measured.
+COMMIT_CAP = 3
 
 ACTION = {"page": "update", "candidate": "promote", "none": "create"}
 
@@ -46,6 +50,13 @@ class Triaged(Row):
     action: str
 
 
+class Report(TypedDict):
+    pages: list[Triaged]
+    candidates: list[Triaged]
+    deferred: list[Triaged]
+    commits: list[list[Triaged]]
+
+
 def _row(pattern: Pattern) -> Row:
     evidence = pattern.get("evidence") or []
     return {
@@ -56,7 +67,7 @@ def _row(pattern: Pattern) -> Row:
     }
 
 
-def triage(patterns: list[Pattern]) -> dict[str, list[Triaged]]:
+def triage(patterns: list[Pattern]) -> Report:
     rows = [_row(p) for p in patterns]
 
     candidates: list[Triaged] = [
@@ -72,10 +83,16 @@ def triage(patterns: list[Pattern]) -> dict[str, list[Triaged]]:
         )
     ]
 
+    # Each commit takes PAGE_CAP pages; a run stops at COMMIT_CAP commits. Deferred now carries
+    # what the commit cap left behind, not what the page cap left behind.
+    commits = [promoted[i : i + PAGE_CAP] for i in range(0, len(promoted), PAGE_CAP)][:COMMIT_CAP]
+    pages = [page for commit in commits for page in commit]
+
     return {
-        "pages": promoted[:PAGE_CAP],
+        "pages": pages,
         "candidates": candidates,
-        "deferred": promoted[PAGE_CAP:],
+        "deferred": promoted[len(pages) :],
+        "commits": commits,
     }
 
 

--- a/skills/scribe/scripts/triage.py
+++ b/skills/scribe/scripts/triage.py
@@ -83,8 +83,7 @@ def triage(patterns: list[Pattern]) -> Report:
         )
     ]
 
-    # Each commit takes PAGE_CAP pages; a run stops at COMMIT_CAP commits. Deferred now carries
-    # what the commit cap left behind, not what the page cap left behind.
+    # deferred now carries what the commit cap left behind, not what the page cap did.
     commits = [promoted[i : i + PAGE_CAP] for i in range(0, len(promoted), PAGE_CAP)][:COMMIT_CAP]
     pages = [page for commit in commits for page in commit]
 

--- a/skills/scribe/scripts/verify_run.py
+++ b/skills/scribe/scripts/verify_run.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Usage: verify_run.py <worktree> <start-count> <expected-commits>
+
+Reads docs/wiki/_candidates.md and the branch's own commits in <worktree>, and checks that a
+scribe run did what Phase 6 claims: the number of `docs(wiki):` commits matches
+<expected-commits>, and the 昇格待ち rows left over match <start-count> minus the pages those
+commits added.
+
+stdout: JSON { ok, mismatches: [{field, expected, actual}] }
+exit: 0 when ok, 1 otherwise
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import TypedDict
+
+# Phase 6 always commits a run's pages with this fixed prefix (see skills/scribe/SKILL.md Phase 6
+# step 3). Counting commits carrying it is how a run's own commits are told apart from whatever
+# history the worktree's branch point already carries.
+COMMIT_PREFIX = "docs(wiki):"
+
+# Files a page commit can add under docs/wiki that are not themselves a page.
+NOT_A_PAGE = {"_candidates.md", "README.md"}
+
+WIKI_DIR = "docs/wiki"
+
+
+class Mismatch(TypedDict):
+    field: str
+    expected: int
+    actual: int
+
+
+class Report(TypedDict):
+    ok: bool
+    mismatches: list[Mismatch]
+
+
+def _git(repo: Path, *args: str) -> str:
+    proc = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return proc.stdout
+
+
+def run_commits(repo: Path) -> list[str]:
+    """Hashes, oldest first, of commits reachable from HEAD whose subject carries the Phase 6
+    commit prefix."""
+    out = _git(repo, "log", "--reverse", "--format=%H\x1f%s")
+    hashes: list[str] = []
+    for line in out.splitlines():
+        if not line:
+            continue
+        commit_hash, subject = line.split("\x1f", 1)
+        if subject.startswith(COMMIT_PREFIX):
+            hashes.append(commit_hash)
+    return hashes
+
+
+def pages_added(repo: Path, commit_hash: str) -> int:
+    """How many docs/wiki/*.md page files this commit added."""
+    out = _git(
+        repo, "diff-tree", "--no-commit-id", "--name-status", "-r", commit_hash, "--", WIKI_DIR
+    )
+    count = 0
+    for line in out.splitlines():
+        if not line:
+            continue
+        status, path = line.split("\t", 1)
+        name = Path(path).name
+        if status == "A" and name.endswith(".md") and name not in NOT_A_PAGE:
+            count += 1
+    return count
+
+
+def remaining_rows(repo: Path) -> int:
+    """The 昇格待ち row count docs/wiki/_candidates.md carries right now."""
+    path = repo / WIKI_DIR / "_candidates.md"
+    if not path.is_file():
+        return 0
+    inside = False
+    count = 0
+    for line in path.read_text(encoding="utf-8").split("\n"):
+        if line.startswith("## "):
+            inside = line.startswith("## 昇格待ち")
+            continue
+        if inside and line.startswith("- "):
+            count += 1
+    return count
+
+
+def verify(repo: Path, start_count: int, expected_commits: int) -> Report:
+    commits = run_commits(repo)
+    actual_commits = len(commits)
+    committed_pages = sum(pages_added(repo, c) for c in commits)
+    expected_remaining = start_count - committed_pages
+    actual_remaining = remaining_rows(repo)
+
+    mismatches: list[Mismatch] = []
+    if actual_commits != expected_commits:
+        mismatches.append(
+            {"field": "commits", "expected": expected_commits, "actual": actual_commits}
+        )
+    if actual_remaining != expected_remaining:
+        mismatches.append(
+            {"field": "remaining", "expected": expected_remaining, "actual": actual_remaining}
+        )
+
+    return {"ok": not mismatches, "mismatches": mismatches}
+
+
+def main() -> None:
+    repo = Path(sys.argv[1])
+    start_count = int(sys.argv[2])
+    expected_commits = int(sys.argv[3])
+    report = verify(repo, start_count, expected_commits)
+    print(json.dumps(report, ensure_ascii=False))
+    sys.exit(0 if report["ok"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/scribe/scripts/verify_run.py
+++ b/skills/scribe/scripts/verify_run.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 """Usage: verify_run.py <worktree> <start-count> <expected-commits>
 
-Reads docs/wiki/_candidates.md and the branch's own commits in <worktree>, and checks that a
-scribe run did what Phase 6 claims: the number of `docs(wiki):` commits matches
-<expected-commits>, and the 昇格待ち rows left over match <start-count> minus the pages those
-commits added.
+Phase 6 runs this before pushing, so a run that committed fewer elements than triage handed it
+never reaches a PR.
 
 stdout: JSON { ok, mismatches: [{field, expected, actual}] }
 exit: 0 when ok, 1 otherwise
@@ -16,12 +14,10 @@ import sys
 from pathlib import Path
 from typing import TypedDict
 
-# Phase 6 always commits a run's pages with this fixed prefix (see skills/scribe/SKILL.md Phase 6
-# step 3). Counting commits carrying it is how a run's own commits are told apart from whatever
-# history the worktree's branch point already carries.
+# Counting by prefix, not by range: the worktree's branch point already carries history, and a
+# count from HEAD alone would fold it into this run's total.
 COMMIT_PREFIX = "docs(wiki):"
 
-# Files a page commit can add under docs/wiki that are not themselves a page.
 NOT_A_PAGE = {"_candidates.md", "README.md"}
 
 WIKI_DIR = "docs/wiki"
@@ -49,8 +45,6 @@ def _git(repo: Path, *args: str) -> str:
 
 
 def run_commits(repo: Path) -> list[str]:
-    """Hashes, oldest first, of commits reachable from HEAD whose subject carries the Phase 6
-    commit prefix."""
     out = _git(repo, "log", "--reverse", "--format=%H\x1f%s")
     hashes: list[str] = []
     for line in out.splitlines():
@@ -63,7 +57,6 @@ def run_commits(repo: Path) -> list[str]:
 
 
 def pages_added(repo: Path, commit_hash: str) -> int:
-    """How many docs/wiki/*.md page files this commit added."""
     out = _git(
         repo, "diff-tree", "--no-commit-id", "--name-status", "-r", commit_hash, "--", WIKI_DIR
     )
@@ -79,7 +72,6 @@ def pages_added(repo: Path, commit_hash: str) -> int:
 
 
 def remaining_rows(repo: Path) -> int:
-    """The 昇格待ち row count docs/wiki/_candidates.md carries right now."""
     path = repo / WIKI_DIR / "_candidates.md"
     if not path.is_file():
         return 0

--- a/skills/scribe/tests/skill_contract_test.py
+++ b/skills/scribe/tests/skill_contract_test.py
@@ -4,7 +4,6 @@ Run: python3 skills/scribe/tests/skill_contract_test.py
 """
 
 import json
-import os
 import re
 import subprocess
 import sys
@@ -18,9 +17,9 @@ ROOT = HERE.parents[2]
 sys.path.insert(0, str(HERE.parent / "scripts"))
 
 from triage import triage  # noqa: E402
+from verify_run_test import _git, _run_verify  # noqa: E402
 
 TRIAGE = HERE.parent / "scripts" / "triage.py"
-VERIFY_RUN = HERE.parent / "scripts" / "verify_run.py"
 
 LANGS = ["ja", "en"]
 
@@ -282,31 +281,14 @@ class SkillContract(unittest.TestCase):
             rows = "".join(f"- {n} #1 #2\n" for n in waiting)
             return f"# candidates\n\n## 昇格待ち\n\n{rows}\n## 単発\n\n## 棄却\n"
 
-        env = {
-            **os.environ,
-            "GIT_AUTHOR_NAME": "scribe-test",
-            "GIT_AUTHOR_EMAIL": "scribe-test@example.com",
-            "GIT_COMMITTER_NAME": "scribe-test",
-            "GIT_COMMITTER_EMAIL": "scribe-test@example.com",
-        }
-
-        def git(repo: Path, *args: str) -> None:
-            _ = subprocess.run(
-                ["git", "-C", str(repo), *args],
-                check=True,
-                capture_output=True,
-                text=True,
-                env=env,
-            )
-
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp) / "worktree"
             wiki = repo / "docs" / "wiki"
             wiki.mkdir(parents=True)
             _ = (wiki / "_candidates.md").write_text(store(names), encoding="utf-8")
-            git(repo, "init", "-q")
-            git(repo, "add", "-A")
-            git(repo, "commit", "-q", "-m", "chore: seed candidates")
+            _git(repo, "init", "-q")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-q", "-m", "chore: seed candidates")
 
             remaining = list(names)
             for commit_items in commits:
@@ -315,22 +297,11 @@ class SkillContract(unittest.TestCase):
                     _ = (wiki / f"{n}.md").write_text(f"# {n}\n", encoding="utf-8")
                 remaining = [n for n in remaining if n not in committed]
                 _ = (wiki / "_candidates.md").write_text(store(remaining), encoding="utf-8")
-                git(repo, "add", "-A")
-                git(repo, "commit", "-q", "-m", f"docs(wiki): {', '.join(committed)} を追加/更新")
+                _git(repo, "add", "-A")
+                _git(repo, "commit", "-q", "-m", f"docs(wiki): {', '.join(committed)} を追加/更新")
 
             def verify(expected_commits: int) -> tuple[int, dict[str, object]]:
-                proc = subprocess.run(
-                    [
-                        sys.executable,
-                        str(VERIFY_RUN),
-                        str(repo),
-                        str(len(names)),
-                        str(expected_commits),
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
+                proc = _run_verify(repo, len(names), expected_commits)
                 return proc.returncode, cast(dict[str, object], json.loads(proc.stdout))
 
             code, matched = verify(len(commits))

--- a/skills/scribe/tests/skill_contract_test.py
+++ b/skills/scribe/tests/skill_contract_test.py
@@ -4,6 +4,7 @@ Run: python3 skills/scribe/tests/skill_contract_test.py
 """
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -19,6 +20,7 @@ sys.path.insert(0, str(HERE.parent / "scripts"))
 from triage import triage  # noqa: E402
 
 TRIAGE = HERE.parent / "scripts" / "triage.py"
+VERIFY_RUN = HERE.parent / "scripts" / "verify_run.py"
 
 LANGS = ["ja", "en"]
 
@@ -215,6 +217,129 @@ class SkillContract(unittest.TestCase):
         for lang in LANGS:
             think = at(lang, "skills", "think", "SKILL.md").read_text(encoding="utf-8")
             self.assertIn("find_wiki_rule.py", think, f"{lang}: think runs the finder")
+
+    def phase_6(self, lang: str) -> str:
+        doc = skill(lang)
+        return doc[doc.index("## Phase 6") :]
+
+    def test_phase_6_commits_each_element_of_commits(self) -> None:
+        """T-008 両ツリーの Phase 6 が commits の各要素をコミットする手順を持つ"""
+        commit_verb = {"ja": "コミット", "en": "commit"}
+        for lang in LANGS:
+            phase6 = self.phase_6(lang)
+            self.assertIn("commits", phase6, f"{lang}: Phase 6 names triage.py's commits field")
+            steps = [line for line in phase6.split("\n") if re.match(r"^\d+\. ", line)]
+            self.assertTrue(
+                any("commits" in step and commit_verb[lang] in step for step in steps),
+                f"{lang}: a step commits each element of commits",
+            )
+
+    def test_phase_6_places_pr_creation_right_after_the_first_commit(self) -> None:
+        """T-009 両ツリーの Phase 6 が PR 作成を 1 コミット目の直後に置く"""
+        first_commit = {"ja": "1 コミット目", "en": "first commit"}
+        second_commit = {"ja": "2 コミット目", "en": "second commit"}
+        for lang in LANGS:
+            phase6 = self.phase_6(lang)
+            self.assertIn(first_commit[lang], phase6, f"{lang}: Phase 6 names the first commit")
+            self.assertIn("gh pr create", phase6, f"{lang}: Phase 6 creates the PR")
+            start = phase6.index(first_commit[lang])
+            end = phase6.index("gh pr create")
+            self.assertLess(start, end, f"{lang}: PR creation follows the first commit")
+            between = phase6[start:end]
+            self.assertNotIn(
+                second_commit[lang],
+                between,
+                f"{lang}: no later commit sits between the first commit and PR creation",
+            )
+
+    def test_phase_6_runs_verify_run_before_pr_creation(self) -> None:
+        """T-010 両ツリーの Phase 6 が `verify_run.py` を PR 作成前に通す手順を持つ"""
+        for lang in LANGS:
+            phase6 = self.phase_6(lang)
+            self.assertIn("verify_run.py", phase6, f"{lang}: Phase 6 runs verify_run.py")
+            self.assertIn("gh pr create", phase6, f"{lang}: Phase 6 creates the PR")
+            self.assertLess(
+                phase6.index("verify_run.py"),
+                phase6.index("gh pr create"),
+                f"{lang}: verify_run.py runs before PR creation",
+            )
+
+    def test_triage_commits_length_fed_to_verify_run_is_ok_true_and_a_one_off_shift_is_false(
+        self,
+    ) -> None:
+        """T-011 `triage.py` が返す commits の要素数を `verify_run.py` へ渡すと ok が true になり、
+        1 本ずらすと false になる。この接続自体は U-001/U-002 が済ませているので、この境界テスト
+        単体は現状で通る"""
+        names = [f"item{i}" for i in range(7)]
+        patterns = [
+            {"name": n, "evidence": ["#1", "#2"], "existing": "candidate"} for n in names
+        ]
+        report = triage(patterns)
+        commits = report["commits"]
+        self.assertTrue(commits, "triage splits 7 qualifying patterns into 2+ commits")
+
+        def store(waiting: list[str]) -> str:
+            rows = "".join(f"- {n} #1 #2\n" for n in waiting)
+            return f"# candidates\n\n## 昇格待ち\n\n{rows}\n## 単発\n\n## 棄却\n"
+
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "scribe-test",
+            "GIT_AUTHOR_EMAIL": "scribe-test@example.com",
+            "GIT_COMMITTER_NAME": "scribe-test",
+            "GIT_COMMITTER_EMAIL": "scribe-test@example.com",
+        }
+
+        def git(repo: Path, *args: str) -> None:
+            _ = subprocess.run(
+                ["git", "-C", str(repo), *args],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "worktree"
+            wiki = repo / "docs" / "wiki"
+            wiki.mkdir(parents=True)
+            _ = (wiki / "_candidates.md").write_text(store(names), encoding="utf-8")
+            git(repo, "init", "-q")
+            git(repo, "add", "-A")
+            git(repo, "commit", "-q", "-m", "chore: seed candidates")
+
+            remaining = list(names)
+            for commit_items in commits:
+                committed = [cast(str, item["name"]) for item in commit_items]
+                for n in committed:
+                    _ = (wiki / f"{n}.md").write_text(f"# {n}\n", encoding="utf-8")
+                remaining = [n for n in remaining if n not in committed]
+                _ = (wiki / "_candidates.md").write_text(store(remaining), encoding="utf-8")
+                git(repo, "add", "-A")
+                git(repo, "commit", "-q", "-m", f"docs(wiki): {', '.join(committed)} を追加/更新")
+
+            def verify(expected_commits: int) -> tuple[int, dict[str, object]]:
+                proc = subprocess.run(
+                    [
+                        sys.executable,
+                        str(VERIFY_RUN),
+                        str(repo),
+                        str(len(names)),
+                        str(expected_commits),
+                    ],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+                return proc.returncode, cast(dict[str, object], json.loads(proc.stdout))
+
+            code, matched = verify(len(commits))
+            self.assertEqual(code, 0)
+            self.assertEqual(matched["ok"], True)
+
+            code, shifted = verify(len(commits) + 1)
+            self.assertEqual(code, 1)
+            self.assertEqual(shifted["ok"], False)
 
 
 class WikiPageFormat(unittest.TestCase):

--- a/skills/scribe/tests/skill_contract_test.py
+++ b/skills/scribe/tests/skill_contract_test.py
@@ -221,6 +221,12 @@ class SkillContract(unittest.TestCase):
         doc = skill(lang)
         return doc[doc.index("## Phase 6") :]
 
+    def phase_6_steps(self, lang: str) -> str:
+        """The numbered steps alone. The opening prose names the same commands in a different
+        order, so scanning the whole Phase reads an order the steps do not carry."""
+        lines = self.phase_6(lang).split("\n")
+        return "\n".join(line for line in lines if re.match(r"^\d+\. ", line))
+
     def test_phase_6_commits_each_element_of_commits(self) -> None:
         """T-008 両ツリーの Phase 6 が commits の各要素をコミットする手順を持つ"""
         commit_verb = {"ja": "コミット", "en": "commit"}
@@ -233,33 +239,27 @@ class SkillContract(unittest.TestCase):
                 f"{lang}: a step commits each element of commits",
             )
 
-    def test_phase_6_places_pr_creation_right_after_the_first_commit(self) -> None:
-        """T-009 両ツリーの Phase 6 が PR 作成を 1 コミット目の直後に置く"""
-        first_commit = {"ja": "1 コミット目", "en": "first commit"}
-        second_commit = {"ja": "2 コミット目", "en": "second commit"}
+    def test_phase_6_lists_per_commit_pages_in_the_pr_body(self) -> None:
+        """T-009 両ツリーの Phase 6 が、PR 本文へコミットごとに動かしたページを並べる手順を持つ"""
+        per_commit = {"ja": "コミットごと", "en": "per commit"}
         for lang in LANGS:
-            phase6 = self.phase_6(lang)
-            self.assertIn(first_commit[lang], phase6, f"{lang}: Phase 6 names the first commit")
-            self.assertIn("gh pr create", phase6, f"{lang}: Phase 6 creates the PR")
-            start = phase6.index(first_commit[lang])
-            end = phase6.index("gh pr create")
-            self.assertLess(start, end, f"{lang}: PR creation follows the first commit")
-            between = phase6[start:end]
-            self.assertNotIn(
-                second_commit[lang],
-                between,
-                f"{lang}: no later commit sits between the first commit and PR creation",
+            steps = self.phase_6_steps(lang)
+            body_step = next(line for line in steps.split("\n") if "gh pr create" in line)
+            self.assertIn(
+                per_commit[lang],
+                body_step,
+                f"{lang}: the PR body groups the pages per commit",
             )
 
     def test_phase_6_runs_verify_run_before_pr_creation(self) -> None:
         """T-010 両ツリーの Phase 6 が `verify_run.py` を PR 作成前に通す手順を持つ"""
         for lang in LANGS:
-            phase6 = self.phase_6(lang)
-            self.assertIn("verify_run.py", phase6, f"{lang}: Phase 6 runs verify_run.py")
-            self.assertIn("gh pr create", phase6, f"{lang}: Phase 6 creates the PR")
+            steps = self.phase_6_steps(lang)
+            self.assertIn("verify_run.py", steps, f"{lang}: a numbered step runs verify_run.py")
+            self.assertIn("gh pr create", steps, f"{lang}: a numbered step creates the PR")
             self.assertLess(
-                phase6.index("verify_run.py"),
-                phase6.index("gh pr create"),
+                steps.index("verify_run.py"),
+                steps.index("gh pr create"),
                 f"{lang}: verify_run.py runs before PR creation",
             )
 
@@ -270,9 +270,7 @@ class SkillContract(unittest.TestCase):
         1 本ずらすと false になる。この接続自体は U-001/U-002 が済ませているので、この境界テスト
         単体は現状で通る"""
         names = [f"item{i}" for i in range(7)]
-        patterns = [
-            {"name": n, "evidence": ["#1", "#2"], "existing": "candidate"} for n in names
-        ]
+        patterns = [{"name": n, "evidence": ["#1", "#2"], "existing": "candidate"} for n in names]
         report = triage(patterns)
         commits = report["commits"]
         self.assertTrue(commits, "triage splits 7 qualifying patterns into 2+ commits")

--- a/skills/scribe/tests/triage_test.py
+++ b/skills/scribe/tests/triage_test.py
@@ -42,9 +42,24 @@ class Triage(unittest.TestCase):
         self.assertEqual([p["action"] for p in report["pages"]], ["update", "promote"])
 
     def test_pages_past_the_cap_are_deferred_thinnest_evidence_first(self) -> None:
-        """A run moving every qualifying pattern outgrows what one PR can be reviewed for."""
-        report = triage([pattern("a", 2), pattern("b", 5), pattern("c", 3), pattern("d", 4)])
-        self.assertEqual([p["name"] for p in report["pages"]], ["b", "d", "c"])
+        """A run moving every qualifying pattern outgrows what COMMIT_CAP commits can hold."""
+        patterns = [
+            pattern("a", 2),
+            pattern("b", 5),
+            pattern("c", 3),
+            pattern("d", 4),
+            pattern("e", 6),
+            pattern("f", 7),
+            pattern("g", 8),
+            pattern("h", 9),
+            pattern("i", 10),
+            pattern("j", 11),
+        ]
+        report = triage(patterns)
+        self.assertEqual(
+            [p["name"] for p in report["pages"]],
+            ["j", "i", "h", "g", "f", "e", "b", "d", "c"],
+        )
         self.assertEqual([p["name"] for p in report["deferred"]], ["a"])
 
     def test_candidates_do_not_consume_the_page_cap(self) -> None:
@@ -55,7 +70,7 @@ class Triage(unittest.TestCase):
         self.assertEqual(len(report["pages"]), 3)
         self.assertEqual(len(report["candidates"]), 2)
 
-    def test_the_cli_takes_the_array_and_the_store_and_returns_the_three_groups(self) -> None:
+    def test_the_cli_takes_the_array_and_the_store_and_returns_the_four_groups(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "_candidates.md"
             _ = path.write_text("# candidates\n\n## 昇格待ち\n\n## 単発\n", encoding="utf-8")
@@ -67,7 +82,7 @@ class Triage(unittest.TestCase):
             )
         self.assertEqual(proc.returncode, 0)
         report = cast(dict[str, object], json.loads(proc.stdout))
-        self.assertEqual(sorted(report), ["candidates", "deferred", "pages"])
+        self.assertEqual(sorted(report), ["candidates", "commits", "deferred", "pages"])
 
     def test_the_cli_stops_when_the_store_path_is_missing(self) -> None:
         """An optional path would put the carried-over rows back at the caller's discretion,
@@ -152,15 +167,18 @@ class StoreMerge(unittest.TestCase):
     def test_a_store_row_outranks_thinner_fresh_patterns_for_the_page_cap(self) -> None:
         """#504 itself: a row backed seven times sat in 昇格待ち for five runs while patterns
         backed four times took every page. The row reaches the cap only when the script reads
-        the store, since nothing else puts it back into the sort."""
+        the store, since nothing else puts it back into the sort. Nine same-count fresh patterns
+        push the total past COMMIT_CAP * PAGE_CAP so the cap still binds and the thinnest-tied
+        row (the last one in input order) is what gets deferred."""
+        fresh = [pattern(chr(ord("a") + i), 4) for i in range(9)]
         report = run_cli(
-            [pattern("a", 4), pattern("b", 4), pattern("c", 4)],
+            fresh,
             store([f"- {STARVED} #349 #350 #351 #352 #353 #354 (research)"], []),
         )
         self.assertEqual(report["pages"][0]["name"], STARVED)
         self.assertEqual(report["pages"][0]["count"], 7)
-        self.assertEqual(len(report["pages"]), 3)
-        self.assertEqual(len(report["deferred"]), 1)
+        self.assertEqual(len(report["pages"]), 9)
+        self.assertEqual([p["name"] for p in report["deferred"]], ["i"])
 
     def test_both_headings_are_read_and_the_evidence_is_cut_off_the_name(self) -> None:
         """A parse taking 昇格待ち alone drops the 単発 row that a second sighting would promote.
@@ -182,6 +200,41 @@ class StoreMerge(unittest.TestCase):
         self.assertEqual([r["name"] for r in rows], [SHARED])
         self.assertEqual(sorted(rows[0]["evidence"]), ["#167", "#168", "#390"])
         self.assertEqual(rows[0]["count"], 3)
+
+
+class Commits(unittest.TestCase):
+    """The unit moves from per-run to per-commit (#508-ish follow-up to #504): pages promoted in
+    one run now split into PAGE_CAP-sized commits, capped at COMMIT_CAP commits per run."""
+
+    def test_t001_nine_promoted_rows_split_into_three_commits_of_three(self) -> None:
+        """T-001 昇格待ちが 9 行のとき commits が 3 要素になり、各要素が 3 ページを持つ"""
+        patterns = [pattern(f"p{i}", 2) for i in range(9)]
+        report = triage(patterns)
+        self.assertEqual(len(report["commits"]), 3)
+        for commit in report["commits"]:
+            self.assertEqual(len(commit), 3)
+
+    def test_t002_ten_or_more_promoted_rows_cap_commits_at_three_and_defer_the_rest(self) -> None:
+        """T-002 昇格待ちが 10 行以上のとき commits が 3 要素で止まり、超過分が deferred に入る"""
+        patterns = [pattern(f"p{i}", 2) for i in range(10)]
+        report = triage(patterns)
+        self.assertEqual(len(report["commits"]), 3)
+        self.assertEqual([p["name"] for p in report["deferred"]], ["p9"])
+
+    def test_t003_the_output_keys_include_commits_and_pages_equals_commits_flattened(
+        self,
+    ) -> None:
+        """T-003 出力のキーが commits を含めた 4 つになり、pages が commits を平らにしたものと一致する"""
+        report = triage([pattern("a", 2), pattern("b", 1), pattern("c", 3)])
+        self.assertEqual(sorted(report), ["candidates", "commits", "deferred", "pages"])
+        flattened = [item for commit in report["commits"] for item in commit]
+        self.assertEqual(report["pages"], flattened)
+
+    def test_t004_two_promoted_rows_form_one_commit_of_two(self) -> None:
+        """T-004 昇格待ちが 2 行のとき commits が 1 要素になり、その要素が 2 ページを持つ"""
+        report = triage([pattern("a", 2), pattern("b", 2)])
+        self.assertEqual(len(report["commits"]), 1)
+        self.assertEqual(len(report["commits"][0]), 2)
 
 
 if __name__ == "__main__":

--- a/skills/scribe/tests/triage_test.py
+++ b/skills/scribe/tests/triage_test.py
@@ -203,8 +203,8 @@ class StoreMerge(unittest.TestCase):
 
 
 class Commits(unittest.TestCase):
-    """The unit moves from per-run to per-commit (#508-ish follow-up to #504): pages promoted in
-    one run now split into PAGE_CAP-sized commits, capped at COMMIT_CAP commits per run."""
+    """PAGE_CAP moved from per-run to per-commit, so a run's promoted pages split into
+    PAGE_CAP-sized commits and stop at COMMIT_CAP of them."""
 
     def test_t001_nine_promoted_rows_split_into_three_commits_of_three(self) -> None:
         """T-001 昇格待ちが 9 行のとき commits が 3 要素になり、各要素が 3 ページを持つ"""

--- a/skills/scribe/tests/triage_test.py
+++ b/skills/scribe/tests/triage_test.py
@@ -224,7 +224,8 @@ class Commits(unittest.TestCase):
     def test_t003_the_output_keys_include_commits_and_pages_equals_commits_flattened(
         self,
     ) -> None:
-        """T-003 出力のキーが commits を含めた 4 つになり、pages が commits を平らにしたものと一致する"""
+        """T-003 出力のキーが commits を含めた 4 つになり、pages が commits を
+        平らにしたものと一致する"""
         report = triage([pattern("a", 2), pattern("b", 1), pattern("c", 3)])
         self.assertEqual(sorted(report), ["candidates", "commits", "deferred", "pages"])
         flattened = [item for commit in report["commits"] for item in commit]

--- a/skills/scribe/tests/verify_run_test.py
+++ b/skills/scribe/tests/verify_run_test.py
@@ -36,7 +36,8 @@ def _git(repo: Path, *args: str) -> None:
 
 def _candidates(waiting: list[str]) -> str:
     """A store file carrying only the 昇格待ち section verify_run.py has to count."""
-    return "\n".join(["# candidates", "", "## 昇格待ち", "", *(f"- {n}" for n in waiting), "", "## 単発", ""])
+    rows = [f"- {n}" for n in waiting]
+    return "\n".join(["# candidates", "", "## 昇格待ち", "", *rows, "", "## 単発", ""])
 
 
 def _init_worktree(root: Path, start_waiting: list[str]) -> Path:
@@ -69,7 +70,9 @@ def _commit_pages(repo: Path, still_waiting: list[str], names: list[str]) -> lis
     return left
 
 
-def _run_verify(repo: Path, start_count: int, expected_commits: int) -> subprocess.CompletedProcess[str]:
+def _run_verify(
+    repo: Path, start_count: int, expected_commits: int
+) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, str(SCRIPT), str(repo), str(start_count), str(expected_commits)],
         capture_output=True,
@@ -120,7 +123,7 @@ class VerifyRun(unittest.TestCase):
         self.assertEqual(commit_mismatches[0]["expected"], 3)
         self.assertEqual(commit_mismatches[0]["actual"], 2)
 
-    def test_remaining_rows_differ_from_the_computed_value_ok_false_exit_1_mismatches_names_the_row_diff(
+    def test_remaining_rows_off_the_computed_value_is_ok_false_exit_1_naming_the_row_diff(
         self,
     ) -> None:
         """T-007 残り行数が計算値と違うとき ok が false で exit 1 になり mismatches が

--- a/skills/scribe/tests/verify_run_test.py
+++ b/skills/scribe/tests/verify_run_test.py
@@ -1,0 +1,156 @@
+"""Tests for skills/scribe/scripts/verify_run.py.
+
+Run: python3 skills/scribe/tests/verify_run_test.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import cast
+
+HERE = Path(__file__).resolve().parent
+SCRIPT = HERE.parent / "scripts" / "verify_run.py"
+
+GIT_ENV = {
+    **os.environ,
+    "GIT_AUTHOR_NAME": "scribe-test",
+    "GIT_AUTHOR_EMAIL": "scribe-test@example.com",
+    "GIT_COMMITTER_NAME": "scribe-test",
+    "GIT_COMMITTER_EMAIL": "scribe-test@example.com",
+}
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=GIT_ENV,
+    )
+
+
+def _candidates(waiting: list[str]) -> str:
+    """A store file carrying only the 昇格待ち section verify_run.py has to count."""
+    return "\n".join(["# candidates", "", "## 昇格待ち", "", *(f"- {n}" for n in waiting), "", "## 単発", ""])
+
+
+def _init_worktree(root: Path, start_waiting: list[str]) -> Path:
+    """A worktree at the state a run starts from: docs/wiki/_candidates.md seeded with the
+    昇格待ち rows the run begins with, committed as a baseline that is not itself a run commit.
+    """
+    repo = root / "worktree"
+    wiki = repo / "docs" / "wiki"
+    wiki.mkdir(parents=True)
+    _ = (wiki / "_candidates.md").write_text(_candidates(start_waiting), encoding="utf-8")
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "chore: seed candidates")
+    return repo
+
+
+def _commit_pages(repo: Path, still_waiting: list[str], names: list[str]) -> list[str]:
+    """One Phase 6 commit: writes `names` as wiki pages and drops their rows from 昇格待ち,
+    using the fixed `docs(wiki): ... を追加/更新` message the skill always commits with.
+
+    Returns the 昇格待ち rows left after this commit, for the caller to chain into the next one.
+    """
+    wiki = repo / "docs" / "wiki"
+    for name in names:
+        _ = (wiki / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+    left = [n for n in still_waiting if n not in names]
+    _ = (wiki / "_candidates.md").write_text(_candidates(left), encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", f"docs(wiki): {', '.join(names)} を追加/更新")
+    return left
+
+
+def _run_verify(repo: Path, start_count: int, expected_commits: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(repo), str(start_count), str(expected_commits)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class VerifyRun(unittest.TestCase):
+    def test_commit_count_and_expected_value_match_and_remaining_rows_also_match_ok_true_exit_0(
+        self,
+    ) -> None:
+        """T-005 コミット本数と期待値が一致し残り行数も一致するとき ok が true で exit 0 になる"""
+        with tempfile.TemporaryDirectory() as tmp:
+            start = [f"item{i}" for i in range(5)]
+            repo = _init_worktree(Path(tmp), start)
+            left = _commit_pages(repo, start, ["item0", "item1", "item2"])
+            _commit_pages(repo, left, ["item3", "item4"])
+
+            proc = _run_verify(repo, start_count=5, expected_commits=2)
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        report = cast(dict[str, object], json.loads(proc.stdout))
+        self.assertEqual(report["ok"], True)
+        self.assertEqual(report["mismatches"], [])
+
+    def test_commit_count_is_fewer_than_expected_ok_false_exit_1_mismatches_names_the_commit_diff(
+        self,
+    ) -> None:
+        """T-006 コミット本数が期待値より少ないとき ok が false で exit 1 になり mismatches が
+        コミット本数の差を名指す"""
+        with tempfile.TemporaryDirectory() as tmp:
+            start = [f"item{i}" for i in range(5)]
+            repo = _init_worktree(Path(tmp), start)
+            left = _commit_pages(repo, start, ["item0", "item1", "item2"])
+            _commit_pages(repo, left, ["item3", "item4"])
+
+            # 2 commits actually ran, but the caller expected 3 (one short of what triage.py
+            # planned) — the mismatch this scenario exists to catch.
+            proc = _run_verify(repo, start_count=5, expected_commits=3)
+
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        report = cast(dict[str, object], json.loads(proc.stdout))
+        self.assertEqual(report["ok"], False)
+        mismatches = cast(list[dict[str, object]], report["mismatches"])
+        commit_mismatches = [m for m in mismatches if m.get("field") == "commits"]
+        self.assertEqual(len(commit_mismatches), 1)
+        self.assertEqual(commit_mismatches[0]["expected"], 3)
+        self.assertEqual(commit_mismatches[0]["actual"], 2)
+
+    def test_remaining_rows_differ_from_the_computed_value_ok_false_exit_1_mismatches_names_the_row_diff(
+        self,
+    ) -> None:
+        """T-007 残り行数が計算値と違うとき ok が false で exit 1 になり mismatches が
+        行数の差を名指す"""
+        with tempfile.TemporaryDirectory() as tmp:
+            start = [f"item{i}" for i in range(5)]
+            repo = _init_worktree(Path(tmp), start)
+            _commit_pages(repo, start, ["item0", "item1", "item2"])
+
+            # Bug under test: this commit writes both item3 and item4 as pages, but its
+            # _candidates.md only drops item3's row, so item4's stale row survives.
+            wiki = repo / "docs" / "wiki"
+            for name in ("item3", "item4"):
+                _ = (wiki / f"{name}.md").write_text(f"# {name}\n", encoding="utf-8")
+            _ = (wiki / "_candidates.md").write_text(_candidates(["item4"]), encoding="utf-8")
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-q", "-m", "docs(wiki): item3, item4 を追加/更新")
+
+            # 2 commits ran, matching what was expected — only the row count is wrong here.
+            proc = _run_verify(repo, start_count=5, expected_commits=2)
+
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        report = cast(dict[str, object], json.loads(proc.stdout))
+        self.assertEqual(report["ok"], False)
+        mismatches = cast(list[dict[str, object]], report["mismatches"])
+        row_mismatches = [m for m in mismatches if m.get("field") == "remaining"]
+        self.assertEqual(len(row_mismatches), 1)
+        self.assertEqual(row_mismatches[0]["expected"], 0)
+        self.assertEqual(row_mismatches[0]["actual"], 1)
+
+
+if __name__ == "__main__":
+    _ = unittest.main(verbosity=2)


### PR DESCRIPTION
## What & Why

1 起動が `COMMIT_CAP` 本までコミットを重ね、各コミットが `PAGE_CAP` 分のページを動かす。コミット本数と残り行数が script の検査を通らないと PR が出ない。

これまでの cap は 1 起動 1 PR 3 ページで、レビュー負荷とは別に在庫の消化速度も縛っていた。コミット分割でレビューの読み単位（`PAGE_CAP`）とマージの意思決定単位（PR、`COMMIT_CAP` 本まで）を切り離す。

## Review focus

- `skills/scribe/SKILL.md` Phase 6 のコミットループ（手順 3-8）。特に失敗時に worktree とローカルブランチを残さない手順（手順 8）
- `triage.py` が `commits` を `PAGE_CAP` 単位・`COMMIT_CAP` 件で切り出すロジックと、`deferred` の意味が「ページ上限の持ち越し」から「コミット上限の持ち越し」へ変わった点

## Changes

- `triage.py` の出力へ `commits`（コミット単位に分割したページ集合の配列）を追加し、`COMMIT_CAP = 3` を導入
- `verify_run.py` を新設し、worktree の実コミット数と `_candidates.md` の残り行数を期待値と突き合わせる
- `SKILL.md` / `.ja/skills/scribe/SKILL.md` の Phase 6 を、1 コミット 1 PR の手順からコミットのループへ書き換え

## Design Decisions

- `COMMIT_CAP = 3` は暫定値として置く。複数コミット PR のマージ所要時間の実測がまだ無いため、最初の実測を待って見直す（`triage.py` コメント）

## How to Test

1. `find agents hooks skills workflows -name '*_test.py' -print0 | xargs -0 -r -n1 python3`
2. 29 ファイルすべてが OK になることを確認する


---

_下は build workflow の自動検証結果。plan との突合までで、コードの欠陥を探すレビューはしていない。PR の本筋からは外れるので任意だが、status 行の逸脱件数が非ゼロなら見る。_

Closes #506

<details>
<summary><code>verify tests=pass gates=FAIL</code> · <code>scope-deviations 0</code> · <code>missing-tests 0</code> · <code>conformance 3 (2 high)</code></summary>

<details><summary>verify 出力</summary>

```
TEST SUITE: 29/29 Python test files ran, all OK, 0 failures/errors (skills/scribe/tests/verify_run_test.py 大きいものは 12.9s, skills/scribe/tests/skill_contract_test.py 10.1s, skills/scribe/tests/triage_test.py 9.8s が主な所要時間).

LINT/TYPE-CHECK GATES:
- ruff check . (Python, per ruff.toml) -> FAIL, 4x E501 (line too long, >100 chars):
  - skills/scribe/tests/triage_test.py:227:73 (105 > 100)
  - skills/scribe/tests/verify_run_test.py:39:97 (110 > 100)
  - skills/scribe/tests/verify_run_test.py:72:101 (105 > 100)
  - skills/scribe/tests/verify_run_test.py:123:101 (105 > 100)
  ruff.toml already has a per-file-ignore for E501 on "hooks/**/tests/*.py" but not "skills/**/tests/*.py", so these skills-test files are not covered by that ignore.
- oxlint . (JS/MJS, per .oxlintrc.json) -> PASS, exit 0, no findings.
- knip (per knip.json, unused-file/dependency check for workflows/skills JS) -> PASS, exit 0, no findings.
- tsgo (TypeScript type-check) -> not applicable, no tsconfig.json / TS source in the repo.
- mypy -> not installed and no config found; not part of this repo's gate set (only ruff.toml exists for Python).

gates_pass=false solely due to the 4 ruff E501 violations above; everything else (tests, oxlint, knip) is clean. No fixes were applied per instructions.
```

</details>

**実機確認 (merge 前に実施)**
- [ ] 最初の複数コミット PR のマージ所要時間を計測する。`COMMIT_CAP` の再評価トリガがこの値で、既存の 1 コミット PR (0 時間から 7 時間) と比べる

**Issue 適合性 (独立レビュー)**
- `[high] missing` Step 4のPR本文指示は、issue化以前のバージョンから文言が一切変わっておらず、'write the added/promoted/updated pages, candidate additions, reference-repaired/由来-repaired pages, ...' とあるのみで、どのコミットがどのページを動かしたかでグループ化・ラベル付けする指示がない。この基準をカバーするテストも存在しない(T-008からT-011はcommit-loopの機構、PRのタイミング、verify_runの配線を検証するのみで、本文の内容は検証しない)。PlanのU-003のタスク記述もこの受け入れ基準を再掲していない。したがって実装とテストカバレッジの両方からこの基準が欠落している。
  `skills/scribe/SKILL.md:84 (and .ja/skills/scribe/SKILL.md corresponding Phase 6 step 4)` · spec: PR 本文がコミットごとに何のページを動かしたかを並べる
- `[high] wrong` gh pr createはstep 4で最初のコミット直後に実行されるが、verify_run.pyはstep 6で全コミットのpush後にのみ実行される。そのためスクリプトの非ゼロ終了は、PR作成前ではなくPRが既に存在した後に発生する。Step 8の失敗時クリーンアップ(git worktree remove --force、git branch -D)はworktreeとローカルブランチを削除するが、作成済みのPRや既にpush済みのリモートブランチは取り消せない。よってverify_runの失敗は不良なPRの存在を防げず、事前作成ゲートという受け入れ基準の意図に反する。
  `skills/scribe/SKILL.md:83-88 (Phase 6 steps 3-8)` · spec: PR 作成前に script がコミット本数と残り行数を検査し、不一致なら非ゼロ終了する
- `[medium] wrong` テストはphase6.index('verify_run.py') < phase6.index('gh pr create')を検証し、これは成功する。しかしこれが成功するのは、'gh pr create'という文字列がstep 4の番号付き手順に初めて現れるより前に、Phase 6の冒頭文が地の文で'verify_run.py'(line 79: 'Finally run verify_run.py')に言及しているためにすぎない。このテストが本来保証すべき番号付き手順では、実際にはverify_run.pyはstep 4のgh pr createの後、step 6で実行される。テストはgreenのままだがそれが示す手順の順序は偽であり、skill_contract_test.pyを直接実行して確認した(このテストを含む22件すべてがpassする。これは上記SKILL.mdの発見に記載された順序のギャップがあるにもかかわらずである)。
  `skills/scribe/tests/skill_contract_test.py:250-260 (test_phase_6_runs_verify_run_before_pr_creation)` · spec: T-010 両ツリーの Phase 6 が `verify_run.py` を PR 作成前に通す手順を持つ

</details>
