### PR TITLE
fix(scribe): 棄却へ移した行を残り行数の計算に入れる

### DIFF
--- a/skills/scribe/scripts/verify_run.py
+++ b/skills/scribe/scripts/verify_run.py
@@ -22,6 +22,9 @@ NOT_A_PAGE = {"_candidates.md", "README.md"}
 
 WIKI_DIR = "docs/wiki"
 
+WAITING = "## 昇格待ち"
+REJECTED = "## 棄却"
+
 
 class Mismatch(TypedDict):
     field: str
@@ -71,27 +74,36 @@ def pages_added(repo: Path, commit_hash: str) -> int:
     return count
 
 
-def remaining_rows(repo: Path) -> int:
-    path = repo / WIKI_DIR / "_candidates.md"
-    if not path.is_file():
-        return 0
+def section_rows(text: str, heading: str) -> int:
     inside = False
     count = 0
-    for line in path.read_text(encoding="utf-8").split("\n"):
+    for line in text.split("\n"):
         if line.startswith("## "):
-            inside = line.startswith("## 昇格待ち")
+            inside = line.startswith(heading)
             continue
         if inside and line.startswith("- "):
             count += 1
     return count
 
 
+def _store(repo: Path) -> str:
+    path = repo / WIKI_DIR / "_candidates.md"
+    return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+
+def rejected_added(repo: Path, base: str) -> int:
+    """Phase 4 moves a dropped item's row into 棄却 without producing a page, so a row can leave
+    昇格待ち with no page to account for it."""
+    before = _git(repo, "show", f"{base}:{WIKI_DIR}/_candidates.md")
+    return section_rows(_store(repo), REJECTED) - section_rows(before, REJECTED)
+
+
 def verify(repo: Path, start_count: int, expected_commits: int, base: str) -> Report:
     commits = run_commits(repo, base)
     actual_commits = len(commits)
     committed_pages = sum(pages_added(repo, c) for c in commits)
-    expected_remaining = start_count - committed_pages
-    actual_remaining = remaining_rows(repo)
+    expected_remaining = start_count - committed_pages - rejected_added(repo, base)
+    actual_remaining = section_rows(_store(repo), WAITING)
 
     mismatches: list[Mismatch] = []
     if actual_commits != expected_commits:

--- a/skills/scribe/tests/verify_run_test.py
+++ b/skills/scribe/tests/verify_run_test.py
@@ -97,8 +97,7 @@ def _run_verify(
 
 class VerifyRun(unittest.TestCase):
     def test_a_row_phase_4_moved_to_棄却_counts_against_the_remaining_rows(self) -> None:
-        """Phase 4 drops a row into 棄却 without a page, so counting pages alone reads the store
-        as one row short and refuses a run that did nothing wrong."""
+        """A run that dropped an item is not a run that went wrong."""
         with tempfile.TemporaryDirectory() as tmp:
             start = [f"item{i}" for i in range(5)]
             repo = _init_worktree(Path(tmp), start)

--- a/skills/scribe/tests/verify_run_test.py
+++ b/skills/scribe/tests/verify_run_test.py
@@ -34,10 +34,12 @@ def _git(repo: Path, *args: str) -> None:
     )
 
 
-def _candidates(waiting: list[str]) -> str:
-    """A store file carrying only the 昇格待ち section verify_run.py has to count."""
+def _candidates(waiting: list[str], rejected: list[str] | None = None) -> str:
     rows = [f"- {n}" for n in waiting]
-    return "\n".join(["# candidates", "", "## 昇格待ち", "", *rows, "", "## 単発", ""])
+    dropped = [f"- {n}" for n in rejected or []]
+    return "\n".join(
+        ["# candidates", "", "## 昇格待ち", "", *rows, "", "## 単発", "", "## 棄却", "", *dropped]
+    )
 
 
 def _init_worktree(root: Path, start_waiting: list[str]) -> Path:
@@ -94,6 +96,28 @@ def _run_verify(
 
 
 class VerifyRun(unittest.TestCase):
+    def test_a_row_phase_4_moved_to_棄却_counts_against_the_remaining_rows(self) -> None:
+        """Phase 4 drops a row into 棄却 without a page, so counting pages alone reads the store
+        as one row short and refuses a run that did nothing wrong."""
+        with tempfile.TemporaryDirectory() as tmp:
+            start = [f"item{i}" for i in range(5)]
+            repo = _init_worktree(Path(tmp), start)
+            base = _base(repo)
+            wiki = repo / "docs" / "wiki"
+            for n in ["item0", "item1"]:
+                _ = (wiki / f"{n}.md").write_text(f"# {n}\n", encoding="utf-8")
+            _ = (wiki / "_candidates.md").write_text(
+                _candidates(["item3", "item4"], rejected=["item2"]), encoding="utf-8"
+            )
+            _git(repo, "add", "-A")
+            _git(repo, "commit", "-q", "-m", "docs(wiki): item0, item1 を追加/更新")
+
+            proc = _run_verify(repo, start_count=5, expected_commits=1, base=base)
+
+        self.assertEqual(proc.returncode, 0, proc.stdout)
+        report = cast(dict[str, object], json.loads(proc.stdout))
+        self.assertEqual(report["ok"], True)
+
     def test_commit_count_and_expected_value_match_and_remaining_rows_also_match_ok_true_exit_0(
         self,
     ) -> None:


### PR DESCRIPTION
## What & Why

`verify_run.py` の残り行数の計算へ、棄却節に移った行を入れる。

実運用で ok が false になった。remaining は expected 15 に対し actual 14。Phase 4 が落とした項目の行は #474 の経路で棄却節へ移り、ページを持たないまま昇格待ちから減る。ページ数だけを引く計算では 1 行足りない読みになり、正しく走った run を拒む。

## Review focus

- `rejected_added` が base の `_candidates.md` と現在を比べる形。引数を増やさずに済む
- `remaining_rows` を `section_rows` へ一般化し、昇格待ちと棄却で同じ関数を使う

## Changes

- `section_rows(text, heading)` を足し、`remaining_rows` を置き換える
- `rejected_added(repo, base)` が `git show <base>:docs/wiki/_candidates.md` と現在を比べて棄却節の増加分を返す
- `expected_remaining` から棄却の増加分も引く
- テストの `_candidates` が棄却節を持てるようにし、棄却が起きた run のテストを足す

## Scope

- Not included: 単発節の行数。ページ化されないので昇格待ちの計算に入らない
- Not included: 引数の追加。base は #514 で入った第 4 引数をそのまま使う

## How to Test

1. `python3 skills/scribe/tests/verify_run_test.py` を実行する
2. 4 tests OK になる
3. `expected_remaining` から `- rejected_added(repo, base)` を消す
4. `test_a_row_phase_4_moved_to_棄却_counts_against_the_remaining_rows` が落ちる

実際の scribe run (昇格待ち 23 から 14、棄却 1 から 2、追加ページ 8、3 コミット) に対して ok が true になることを確認済み。

## Related

- #474 が足した棄却節の経路を計算に入れる
- #506 で入れた検査の 2 件目の実運用バグ。1 件目は #514
