### PR TITLE
docs(wiki): skills の構造ページを足す

### DIFF
--- a/docs/wiki/skills-structure.md
+++ b/docs/wiki/skills-structure.md
@@ -1,0 +1,45 @@
+---
+globs: ["**/skills/**/*"]
+kind: structure
+---
+
+# skill の構造と呼び出し契約
+
+## 内容
+
+skill は `skills/<name>/SKILL.md` を本体とし、Skill tool が読み込む。27 の skill が SKILL.md を持ち、`skills/_lib/` だけが本体を持たない共有ライブラリになる。
+
+## 境界
+
+- skill は Skill tool で起動し、workflow は Workflow tool で起動する。両者は別の機構で、skill から workflow を呼ぶ経路は無い
+- `user-invocable: false` の skill は `/名前` で呼べない。他の skill か agent が参照する側になる。11 件がこれに当たる
+- `skills/_lib/` は SKILL.md を持たず、skill として起動しない。`review_score.py` と `review-harness.md` を読むのは reviewer skill の測定手順で、`rules/development/TESTING.md` と `skills/use-context-reviewer-security/test/README.md` がその経路を書く
+- skill の scripts は他の skill から `${CLAUDE_SKILL_DIR}/../<skill>/scripts/<file>` で呼べる。実在する経路は 3 本で、`issue/validate-issue-body.py`、`research/find-prior-research.py`、`scribe/find_wiki_rule.py` が呼ばれる側になる
+
+## 契約
+
+| 対象 | 契約 |
+| --- | --- |
+| frontmatter の必須 | `name`、`description`、`allowed-tools` の 3 つを 27 件すべてが持つ。`model` は 15 件、`argument-hint` は 13 件、`user-invocable` は 11 件、`context` は 7 件、`agent` は 4 件 |
+| `${CLAUDE_SKILL_DIR}` | skill 自身のディレクトリを指す。`../` で 1 つ上がると `skills/` に届き、他の skill の scripts へ辿れる |
+| `allowed-tools` と呼び出し形 | SKILL.md が書くコマンドと `allowed-tools` の許可が一致しないと拒否される。`Bash(python3:*)` を持たない skill は `python3` で script を呼べない |
+| テストの置き場 | `skills/<name>/tests/*_test.py`。CI は `find agents hooks skills workflows -name '*_test.py'` で拾うので、`docs/` 配下に置くと走らない |
+| テストの ROOT 解決 | `HERE.parents[2]` がリポジトリ root になる。`skills/<name>/tests/` から 3 つ上がった位置 |
+
+## 要求
+
+| 対象 | 要求 | 満たさないときの挙動 |
+| --- | --- | --- |
+| テストの言語側 | 英語側にのみ置く。`.ja/skills/` 配下のテストは 0 件 | `.ja/` に置いたテストは走らない。CI の find が `skills` を起点にする |
+| script の呼び出し | `allowed-tools` に対応する `Bash(...)` を書く | 実行時に拒否される |
+
+## 参照コード
+
+- `skills/_lib/review_score.py`（reviewer skill の Recall と FP Rate を出す。skill 本体を持たない共有ライブラリ側にある）
+- `skills/scribe/scripts/find_wiki_rule.py`（他 skill から `${CLAUDE_SKILL_DIR}/../scribe/scripts/` で呼ばれる側）
+- `.github/workflows/test.yml` の `Python tests`（テストを拾う find の範囲）
+
+## 由来
+
+- `docs/decisions/0055-consolidate-user-invocable-false-skills-under-use-prefix.md`（`user-invocable: false` の skill を `use-` 接頭辞へ統一した DR）
+- `docs/decisions/0042-colocate-skill-specific-scripts-within-skill.md`（skill 固有の script を skill 配下へ置く DR）


### PR DESCRIPTION
## What & Why

`docs/wiki/skills-structure.md` を足す。

構造ページが `workflow-structure.md` の 1 枚しかなく、DR-0106 が決めた「実装者が引く現在形」の受け皿が実質空だった。scribe は `kind: structure` を Phase 3 step 1 で明示的にスキップするので、この種別は人が書くしかない。

`skills/**` を選んだ根拠はこのセッションの実測。SKILL.md の frontmatter を 3 回、テストの置き場と CI の find スコープを 3 回、`${CLAUDE_SKILL_DIR}` の解決先を 2 回読み直した。DR-0106 の「実装者が引けない領域が見つかったら起こす」に当たる。

## Review focus

- `rules/conventions/SKILLS.md` との棲み分け。あちらは書くときの規約、こちらは読む側が前提にできる契約
- 契約節の数値。frontmatter のキーごとの件数、他 skill の scripts を呼ぶ経路 3 本はすべて実測
- `globs` の形。`**/skills/**` は `find_wiki_rule.py` の `glob_to_regexp` が末尾で止まるためマッチしない

## Changes

- `docs/wiki/skills-structure.md` を追加。6 節 (内容/境界/契約/要求/参照コード/由来)
- `globs: ["**/skills/**/*"]` で `skills/*/SKILL.md` と `skills/*/scripts/*` の両方に届く

## Scope

- Not included: `hooks/**` と `rules/**` の構造ページ。同じ形で書けるが 1 枚ずつ出す
- Not included: 構造ページの生成機構。#502 が更新経路、#501 が整合検査を持つ
- Not included: `skills/xlsx/` が空で git 追跡外である件。掃除は別

## Design Decisions

- 要求節に「呼び出し側が満たすべき条件」を書いた。`workflow-structure.md` の要求節は実行時の上限 (unit 3 files、再試行 3 回) だが、skill にはその種の上限が無い。空節を置く代わりに、満たさないと拒否される条件を並べた
- 由来に DR-0055 と DR-0042 を張った。前者が `use-` 接頭辞、後者が skill 配下への script 配置を決めており、どちらも supersede されればページの書き換えが要る

## How to Test

1. `python3 skills/scribe/scripts/find_wiki_rule.py docs/wiki skill skills/dr/SKILL.md skills/dr/scripts/pre-check.py` を実行する
2. `matched` に `skills-structure.md` が出る
3. `python3 skills/scribe/tests/skill_contract_test.py` を実行する
4. 22 tests OK になる (構造ページの 6 節と由来の status が検査される)

## Related

- DR-0106 が構造ページの単位を glob 契約グループと定めた。その 2 枚目
