### PR TITLE
[Feature] scribe の起動を PR マージと issue クローズに結線する

### DIFF
--- a/hooks/_lib/hook_payload.py
+++ b/hooks/_lib/hook_payload.py
@@ -35,6 +35,26 @@ def field(container: object, key: str) -> object:
     return mapping.get(key) if mapping is not None else None
 
 
+def notify(message: str) -> None:
+    """Report from a PostToolUse hook on both channels.
+
+    systemMessage reaches the human and additionalContext reaches the agent, so a hook that
+    only picks one leaves the other side unable to act on what it found.
+    """
+    print(
+        json.dumps(
+            {
+                "systemMessage": message,
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": message,
+                },
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
 def deny(reason: str) -> None:
     """Refuse the call, naming what has to change before it can run.
 

--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -1,0 +1,44 @@
+"""The scribe trigger a command line runs, if any.
+
+scribe reads its scope from merged PRs and closed issues (skills/scribe/SKILL.md), so the
+command that starts a scribe run is a `gh pr merge` or a `gh issue close`. Read from where each
+token sits, the same way hooks/_lib/gh_filing.py finds a filing: a `gh issue close` sitting
+inside a quoted argument or a loop body is not itself a command the line runs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+import command_scan
+
+Kind = Literal["issue", "pr"]
+
+# The subcommand path that closes each kind, in the order find checks them.
+CLOSERS: tuple[tuple[Kind, tuple[str, ...]], ...] = (
+    ("pr", ("gh", "pr", "merge")),
+    ("issue", ("gh", "issue", "close")),
+)
+
+
+class Trigger(NamedTuple):
+    kind: Kind
+    directory: Path
+
+
+def find(command: str) -> Trigger | None:
+    """The scribe trigger a command line runs, or None when it runs none.
+
+    `directory` follows every cd ahead of the trigger, since `cd a && cd b` lands in a/b and
+    the repository scribe should run in is the one the trigger command runs in.
+    """
+    directory = Path.cwd()
+    for tokens in command_scan.commands(command):
+        if tokens[0] == "cd" and len(tokens) > 1:
+            directory = directory / tokens[1]
+            continue
+        for kind, prefix in CLOSERS:
+            if command_scan.starts_with(tokens, prefix):
+                return Trigger(kind, directory)
+    return None

--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -31,7 +31,9 @@ def find(command: str) -> Trigger | None:
     """The scribe trigger a command line runs, or None when it runs none.
 
     `directory` follows every cd ahead of the trigger, since `cd a && cd b` lands in a/b and
-    the repository scribe should run in is the one the trigger command runs in.
+    the repository scribe should run in is the one the trigger command runs in. A `--repo` on
+    the trigger itself overrides that: gh resolves `--repo owner/name` regardless of cwd, so
+    the trigger command's own flag outranks any cd that came before it.
     """
     directory = Path.cwd()
     for tokens in command_scan.commands(command):
@@ -40,5 +42,15 @@ def find(command: str) -> Trigger | None:
             continue
         for kind, prefix in CLOSERS:
             if command_scan.starts_with(tokens, prefix):
-                return Trigger(kind, directory)
+                repo = command_scan.flag_value(tokens, "--repo")
+                return Trigger(kind, Path(repo) if repo else directory)
     return None
+
+
+def should_prompt(trigger: Trigger) -> bool:
+    """Whether a completed trigger is worth nudging the user toward a scribe run.
+
+    scribe extracts its patterns into docs/wiki/ (skills/scribe/SKILL.md), so a target that
+    holds no docs/wiki/ at all is not set up to receive that output yet.
+    """
+    return (trigger.directory / "docs" / "wiki").is_dir()

--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -1,9 +1,7 @@
 """The scribe trigger a command line runs, if any.
 
-scribe reads its scope from merged PRs and closed issues (skills/scribe/SKILL.md), so the
-command that starts a scribe run is a `gh pr merge` or a `gh issue close`. Read from where each
-token sits, the same way hooks/_lib/gh_filing.py finds a filing: a `gh issue close` sitting
-inside a quoted argument or a loop body is not itself a command the line runs.
+scribe reads its scope from merged PRs and closed issues (skills/scribe/SKILL.md), so a
+`gh pr merge` or a `gh issue close` is what grows its input.
 """
 
 from __future__ import annotations
@@ -64,11 +62,8 @@ def find(command: str) -> Trigger | None:
 
 
 def _default_runner(directory: Path) -> GhRunner:
-    """gh scoped to the trigger's own directory, the way `find`'s `--repo` handling and
-    `cd`-following already resolve it: a local checkout runs with that cwd so gh infers the
-    repository from its git remote, and a `--repo owner/name` value works the same way gh
-    itself accepts a relative path only when one exists at that name under cwd.
-    """
+    """gh runs with the trigger's directory as cwd, so it reads the repository off that
+    checkout's git remote rather than off wherever the hook process started."""
 
     def run(args: Sequence[str]) -> str:
         result = subprocess.run(
@@ -159,15 +154,8 @@ def should_prompt(
     stamp: Path | None = None,
     runner: GhRunner | None = None,
 ) -> bool:
-    """Whether a completed trigger is worth nudging the user toward a scribe run.
-
-    scribe extracts its patterns into docs/wiki/ (skills/scribe/SKILL.md), so a target that
-    holds no docs/wiki/ at all is not set up to receive that output yet. Past that, three gates
-    hold: an unmerged scribe PR already covers the backlog, nothing new has landed since the
-    last scribe merge, and a stamp from a recent nudge is still within its cooldown. Each gate
-    that closes returns before the gh call the next one would spend, so a decision that stops
-    early never pays for an answer it no longer needs.
-    """
+    """Each gate returns before the gh call the next one would spend, so the order is what
+    keeps the common case to a single call."""
     if not (trigger.directory / "docs" / "wiki").is_dir():
         return False
     call = runner or _default_runner(trigger.directory)

--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
@@ -44,9 +45,10 @@ def find(command: str) -> Trigger | None:
     """The scribe trigger a command line runs, or None when it runs none.
 
     `directory` follows every cd ahead of the trigger, since `cd a && cd b` lands in a/b and
-    the repository scribe should run in is the one the trigger command runs in. A `--repo` on
-    the trigger itself overrides that: gh resolves `--repo owner/name` regardless of cwd, so
-    the trigger command's own flag outranks any cd that came before it.
+    the repository scribe should run in is the one the trigger command runs in.
+
+    A `--repo owner/name` names a repository other than the one this session works in, so its
+    backlog is not what a nudge here would send anyone to. Such a trigger returns None.
     """
     directory = Path.cwd()
     for tokens in command_scan.commands(command):
@@ -55,8 +57,9 @@ def find(command: str) -> Trigger | None:
             continue
         for kind, prefix in CLOSERS:
             if command_scan.starts_with(tokens, prefix):
-                repo = command_scan.flag_value(tokens, "--repo")
-                return Trigger(kind, Path(repo) if repo else directory)
+                if command_scan.flag_value(tokens, "--repo"):
+                    return None
+                return Trigger(kind, directory)
     return None
 
 
@@ -92,11 +95,13 @@ def _recently_stamped(stamp: Path) -> bool:
 
 
 def _touch(stamp: Path) -> None:
+    """A stamp that fails to write silently turns the cooldown off, which is the shape DR-0097
+    was removed for. Report it instead."""
     try:
         stamp.parent.mkdir(parents=True, exist_ok=True)
         stamp.touch()
-    except OSError:
-        pass
+    except OSError as exc:
+        print(f"scribe_trigger: cooldown stamp not written ({exc})", file=sys.stderr)
 
 
 def _unmerged_scribe_pr_exists(call: GhRunner) -> bool:
@@ -127,20 +132,25 @@ def _last_scribe_merge(call: GhRunner) -> str:
     ).strip()
 
 
-def _new_input_count(trigger: Trigger, cursor: str, call: GhRunner) -> int:
-    """skills/scribe/SKILL.md Phase 2 steps 2-3, narrowed to the trigger's own kind: the hook
-    fires once per completed `gh pr merge`/`gh issue close`, so checking only that kind's
-    backlog keeps this to the one gh call cooldown gating can afford. The kind this trigger did
-    not touch gets picked up the next time a command of that kind fires.
+def _has_new_input(trigger: Trigger, cursor: str, call: GhRunner) -> bool:
+    """skills/scribe/SKILL.md Phase 2 steps 2-3. Both kinds count toward the backlog, so a
+    merge that lands while three issues sit unread still has input waiting.
+
+    The trigger's own kind goes first and returns on the first hit, which spends one gh call
+    on the common case rather than two.
     """
-    if trigger.kind == "pr":
-        search = f"-label:scribe merged:>{cursor}" if cursor else "-label:scribe"
-        args = ["pr", "list", "--state", "merged", "--search", search, "--json", "number"]
-    else:
-        args = ["issue", "list", "--state", "closed", "--json", "number"]
-        if cursor:
-            args += ["--search", f"closed:>{cursor}"]
-    return len(json.loads(call(args)))
+    order: tuple[Kind, ...] = ("pr", "issue") if trigger.kind == "pr" else ("issue", "pr")
+    for kind in order:
+        if kind == "pr":
+            search = f"-label:scribe merged:>{cursor}" if cursor else "-label:scribe"
+            args = ["pr", "list", "--state", "merged", "--search", search, "--json", "number"]
+        else:
+            args = ["issue", "list", "--state", "closed", "--json", "number"]
+            if cursor:
+                args += ["--search", f"closed:>{cursor}"]
+        if len(json.loads(call(args))) >= 1:
+            return True
+    return False
 
 
 def should_prompt(
@@ -164,7 +174,7 @@ def should_prompt(
     if _unmerged_scribe_pr_exists(call):
         return False
     cursor = _last_scribe_merge(call)
-    if _new_input_count(trigger, cursor, call) < 1:
+    if not _has_new_input(trigger, cursor, call):
         return False
     stamp_path = stamp or _default_stamp()
     if _recently_stamped(stamp_path):

--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -1,9 +1,11 @@
-"""The scribe trigger a command line runs, if any.
+"""Whether a `git pull` just landed work scribe has not read yet.
 
-scribe reads its scope from merged PRs and closed issues (skills/scribe/SKILL.md), so a
-`gh pr merge` or a `gh issue close` is what grows its input.
+scribe reads its scope from merged PRs and closed issues (skills/scribe/SKILL.md). Those close
+on GitHub, not on this machine, so the local signal that they happened is the pull that brings
+them down.
 """
 
+# python3 on a cut-down PATH can be old enough to reject `X | None` at import time.
 from __future__ import annotations
 
 import json
@@ -12,57 +14,37 @@ import sys
 import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import Literal, NamedTuple
 
 import command_scan
-
-Kind = Literal["issue", "pr"]
 
 # A gh invocation, injected so tests hand over canned stdout instead of a live gh process.
 GhRunner = Callable[[Sequence[str]], str]
 
 # The interval a stamp counts as recent, in the shape hooks/lifecycle/recall_index.py's
 # WINDOW_MINUTES takes. A nudge costs the user's attention, not just gh's rate limit, so the
-# window is a workday: whichever command trips the trigger again inside it should stay quiet
+# window is a workday: whichever pull trips the trigger again inside it should stay quiet
 # rather than repeat a suggestion the user already saw once today.
 WINDOW_MINUTES = 8 * 60
 
-# The subcommand path that closes each kind, in the order find checks them.
-CLOSERS: tuple[tuple[Kind, tuple[str, ...]], ...] = (
-    ("pr", ("gh", "pr", "merge")),
-    ("issue", ("gh", "issue", "close")),
-)
 
+def find(command: str) -> Path | None:
+    """The directory a `git pull` runs in, or None when the line runs none.
 
-class Trigger(NamedTuple):
-    kind: Kind
-    directory: Path
-
-
-def find(command: str) -> Trigger | None:
-    """The scribe trigger a command line runs, or None when it runs none.
-
-    `directory` follows every cd ahead of the trigger, since `cd a && cd b` lands in a/b and
-    the repository scribe should run in is the one the trigger command runs in.
-
-    A `--repo owner/name` names a repository other than the one this session works in, so its
-    backlog is not what a nudge here would send anyone to. Such a trigger returns None.
+    `directory` follows every cd ahead of the pull, since `cd a && cd b` lands in a/b and the
+    repository scribe should run in is the one the pull runs in.
     """
     directory = Path.cwd()
     for tokens in command_scan.commands(command):
         if tokens[0] == "cd" and len(tokens) > 1:
             directory = directory / tokens[1]
             continue
-        for kind, prefix in CLOSERS:
-            if command_scan.starts_with(tokens, prefix):
-                if command_scan.flag_value(tokens, "--repo"):
-                    return None
-                return Trigger(kind, directory)
+        if command_scan.starts_with(tokens, ["git", "pull"]):
+            return directory
     return None
 
 
 def _default_runner(directory: Path) -> GhRunner:
-    """gh runs with the trigger's directory as cwd, so it reads the repository off that
+    """gh runs with the pull's directory as cwd, so it reads the repository off that
     checkout's git remote rather than off wherever the hook process started."""
 
     def run(args: Sequence[str]) -> str:
@@ -127,45 +109,37 @@ def _last_scribe_merge(call: GhRunner) -> str:
     ).strip()
 
 
-def _has_new_input(trigger: Trigger, cursor: str, call: GhRunner) -> bool:
-    """skills/scribe/SKILL.md Phase 2 steps 2-3. Both kinds count toward the backlog, so a
-    merge that lands while three issues sit unread still has input waiting.
-
-    The trigger's own kind goes first and returns on the first hit, which spends one gh call
-    on the common case rather than two.
-    """
-    order: tuple[Kind, ...] = ("pr", "issue") if trigger.kind == "pr" else ("issue", "pr")
-    for kind in order:
-        if kind == "pr":
-            search = f"-label:scribe merged:>{cursor}" if cursor else "-label:scribe"
-            args = ["pr", "list", "--state", "merged", "--search", search, "--json", "number"]
-        else:
-            args = ["issue", "list", "--state", "closed", "--json", "number"]
-            if cursor:
-                args += ["--search", f"closed:>{cursor}"]
-        if len(json.loads(call(args))) >= 1:
-            return True
-    return False
+def _has_new_input(cursor: str, call: GhRunner) -> bool:
+    """skills/scribe/SKILL.md Phase 2 steps 2-3. Returns on the first kind that has anything,
+    so a backlog carrying merged PRs costs one gh call rather than two."""
+    search = f"-label:scribe merged:>{cursor}" if cursor else "-label:scribe"
+    prs = ["pr", "list", "--state", "merged", "--search", search, "--json", "number"]
+    if len(json.loads(call(prs))) >= 1:
+        return True
+    issues = ["issue", "list", "--state", "closed", "--json", "number"]
+    if cursor:
+        issues += ["--search", f"closed:>{cursor}"]
+    return len(json.loads(call(issues))) >= 1
 
 
 def should_prompt(
-    trigger: Trigger,
+    directory: Path,
     *,
     stamp: Path | None = None,
     runner: GhRunner | None = None,
 ) -> bool:
-    """Each gate returns before the gh call the next one would spend, so the order is what
-    keeps the common case to a single call."""
-    if not (trigger.directory / "docs" / "wiki").is_dir():
-        return False
-    call = runner or _default_runner(trigger.directory)
-    if _unmerged_scribe_pr_exists(call):
-        return False
-    cursor = _last_scribe_merge(call)
-    if not _has_new_input(trigger, cursor, call):
+    """The cooldown comes before the gh calls because a pull runs far more often than a merge
+    lands: most pulls inside one window have nothing new to find, and asking GitHub each time
+    would spend a round trip to learn that."""
+    if not (directory / "docs" / "wiki").is_dir():
         return False
     stamp_path = stamp or _default_stamp()
     if _recently_stamped(stamp_path):
+        return False
+    call = runner or _default_runner(directory)
+    if _unmerged_scribe_pr_exists(call):
+        return False
+    if not _has_new_input(_last_scribe_merge(call), call):
         return False
     _touch(stamp_path)
     return True

--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -8,12 +8,25 @@ inside a quoted argument or a loop body is not itself a command the line runs.
 
 from __future__ import annotations
 
+import json
+import subprocess
+import time
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Literal, NamedTuple
 
 import command_scan
 
 Kind = Literal["issue", "pr"]
+
+# A gh invocation, injected so tests hand over canned stdout instead of a live gh process.
+GhRunner = Callable[[Sequence[str]], str]
+
+# The interval a stamp counts as recent, in the shape hooks/lifecycle/recall_index.py's
+# WINDOW_MINUTES takes. A nudge costs the user's attention, not just gh's rate limit, so the
+# window is a workday: whichever command trips the trigger again inside it should stay quiet
+# rather than repeat a suggestion the user already saw once today.
+WINDOW_MINUTES = 8 * 60
 
 # The subcommand path that closes each kind, in the order find checks them.
 CLOSERS: tuple[tuple[Kind, tuple[str, ...]], ...] = (
@@ -47,10 +60,114 @@ def find(command: str) -> Trigger | None:
     return None
 
 
-def should_prompt(trigger: Trigger) -> bool:
+def _default_runner(directory: Path) -> GhRunner:
+    """gh scoped to the trigger's own directory, the way `find`'s `--repo` handling and
+    `cd`-following already resolve it: a local checkout runs with that cwd so gh infers the
+    repository from its git remote, and a `--repo owner/name` value works the same way gh
+    itself accepts a relative path only when one exists at that name under cwd.
+    """
+
+    def run(args: Sequence[str]) -> str:
+        result = subprocess.run(
+            ["gh", *args],
+            cwd=directory,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+
+    return run
+
+
+def _default_stamp() -> Path:
+    return Path.home() / ".cache" / "claude-scribe_trigger.last"
+
+
+def _recently_stamped(stamp: Path) -> bool:
+    try:
+        return time.time() - stamp.stat().st_mtime < WINDOW_MINUTES * 60
+    except OSError:
+        return False
+
+
+def _touch(stamp: Path) -> None:
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.touch()
+    except OSError:
+        pass
+
+
+def _unmerged_scribe_pr_exists(call: GhRunner) -> bool:
+    """skills/scribe/SKILL.md Phase 1 step 1: an open scribe PR already covers the backlog,
+    so a second nudge would only invite a second run to collide with it."""
+    output = call(["pr", "list", "--label", "scribe", "--state", "open", "--json", "number"])
+    return len(json.loads(output)) > 0
+
+
+def _last_scribe_merge(call: GhRunner) -> str:
+    """skills/scribe/SKILL.md Phase 2 step 1: the mergedAt of the last merged scribe PR, empty
+    when none has ever merged. `-q` hands back the bare value, not a JSON-quoted string."""
+    return call(
+        [
+            "pr",
+            "list",
+            "--label",
+            "scribe",
+            "--state",
+            "merged",
+            "--limit",
+            "1",
+            "--json",
+            "mergedAt",
+            "-q",
+            ".[0].mergedAt",
+        ]
+    ).strip()
+
+
+def _new_input_count(trigger: Trigger, cursor: str, call: GhRunner) -> int:
+    """skills/scribe/SKILL.md Phase 2 steps 2-3, narrowed to the trigger's own kind: the hook
+    fires once per completed `gh pr merge`/`gh issue close`, so checking only that kind's
+    backlog keeps this to the one gh call cooldown gating can afford. The kind this trigger did
+    not touch gets picked up the next time a command of that kind fires.
+    """
+    if trigger.kind == "pr":
+        search = f"-label:scribe merged:>{cursor}" if cursor else "-label:scribe"
+        args = ["pr", "list", "--state", "merged", "--search", search, "--json", "number"]
+    else:
+        args = ["issue", "list", "--state", "closed", "--json", "number"]
+        if cursor:
+            args += ["--search", f"closed:>{cursor}"]
+    return len(json.loads(call(args)))
+
+
+def should_prompt(
+    trigger: Trigger,
+    *,
+    stamp: Path | None = None,
+    runner: GhRunner | None = None,
+) -> bool:
     """Whether a completed trigger is worth nudging the user toward a scribe run.
 
     scribe extracts its patterns into docs/wiki/ (skills/scribe/SKILL.md), so a target that
-    holds no docs/wiki/ at all is not set up to receive that output yet.
+    holds no docs/wiki/ at all is not set up to receive that output yet. Past that, three gates
+    hold: an unmerged scribe PR already covers the backlog, nothing new has landed since the
+    last scribe merge, and a stamp from a recent nudge is still within its cooldown. Each gate
+    that closes returns before the gh call the next one would spend, so a decision that stops
+    early never pays for an answer it no longer needs.
     """
-    return (trigger.directory / "docs" / "wiki").is_dir()
+    if not (trigger.directory / "docs" / "wiki").is_dir():
+        return False
+    call = runner or _default_runner(trigger.directory)
+    if _unmerged_scribe_pr_exists(call):
+        return False
+    cursor = _last_scribe_merge(call)
+    if _new_input_count(trigger, cursor, call) < 1:
+        return False
+    stamp_path = stamp or _default_stamp()
+    if _recently_stamped(stamp_path):
+        return False
+    _touch(stamp_path)
+    return True

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -6,6 +6,7 @@ Run: python3 hooks/_lib/tests/scribe_trigger_test.py
 import sys
 import tempfile
 import unittest
+from collections.abc import Sequence
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -50,6 +51,26 @@ class TestFind(unittest.TestCase):
         self.assertEqual(trigger.directory, Path("owner/name"))
 
 
+class _QueueRunner:
+    """Fake gh runner: hands back one canned stdout per call, in call order.
+
+    Popping from an exhausted queue raises, which is what catches an implementation
+    that keeps calling gh after the decision is already settled (T-008's contract:
+    stop at the first gh call once an unmerged scribe PR is found).
+    """
+
+    def __init__(self, responses: list[str]) -> None:
+        self._responses = list(responses)
+
+    def __call__(self, args: Sequence[str]) -> str:
+        return self._responses.pop(0)
+
+
+def _trigger_with_wiki(directory: Path) -> scribe_trigger.Trigger:
+    (directory / "docs" / "wiki").mkdir(parents=True)
+    return scribe_trigger.Trigger("pr", directory)
+
+
 class TestShouldPrompt(unittest.TestCase):
     def test_対象に_docs_wiki_が無いとき_促さないと決まる(self) -> None:
         """対象に `docs/wiki/` が無いとき、促さないと決まる"""
@@ -57,6 +78,45 @@ class TestShouldPrompt(unittest.TestCase):
             trigger = scribe_trigger.find(f"cd {tmp}; gh pr merge 1")
             assert trigger is not None
             self.assertFalse(scribe_trigger.should_prompt(trigger))
+
+    def test_未マージ_scribe_pr_が_1_件以上あるとき促さない(self) -> None:
+        """未マージ scribe PR が 1 件以上あるとき促さない"""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            trigger = _trigger_with_wiki(directory)
+            stamp = directory / "cache" / "claude-scribe_trigger.last"
+            runner = _QueueRunner(['[{"number": 1}]'])
+            self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+
+    def test_cursor_以降の入力が_0_件のとき促さない(self) -> None:
+        """cursor 以降の入力が 0 件のとき促さない"""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            trigger = _trigger_with_wiki(directory)
+            stamp = directory / "cache" / "claude-scribe_trigger.last"
+            runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", "[]"])
+            self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+
+    def test_stamp_が_cooldown_内にあるとき促さない(self) -> None:
+        """stamp が cooldown 内にあるとき促さない"""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            trigger = _trigger_with_wiki(directory)
+            stamp = directory / "cache" / "claude-scribe_trigger.last"
+            stamp.parent.mkdir(parents=True)
+            stamp.touch()
+            runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", '[{"number": 5}]'])
+            self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+
+    def test_未マージ_0_件_入力_1_件以上_stamp_が_cooldown_外のとき促す(self) -> None:
+        """未マージ 0 件、入力 1 件以上、stamp が cooldown 外のとき促す"""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            trigger = _trigger_with_wiki(directory)
+            stamp = directory / "cache" / "claude-scribe_trigger.last"
+            runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", '[{"number": 5}]'])
+            self.assertTrue(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+            self.assertTrue(stamp.is_file(), "促した後は stamp が更新されているはず")
 
 
 if __name__ == "__main__":

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -4,6 +4,7 @@ Run: python3 hooks/_lib/tests/scribe_trigger_test.py
 """
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -34,6 +35,28 @@ class TestFind(unittest.TestCase):
     def test_for_n_in_1_2_do_gh_issue_close_n_done_は何も返らない(self) -> None:
         """`for n in 1 2; do gh issue close $n; done` は何も返らない"""
         self.assertIsNone(scribe_trigger.find("for n in 1 2; do gh issue close $n; done"))
+
+    def test_cd_path_to_repo_gh_pr_merge_1_は_cd_先を対象にする(self) -> None:
+        """`cd /path/to/repo; gh pr merge 1` は cd 先を対象にする"""
+        trigger = scribe_trigger.find("cd /path/to/repo; gh pr merge 1")
+        assert trigger is not None
+        self.assertEqual(trigger.directory, Path("/path/to/repo"))
+
+    def test_gh_issue_close_2_repo_owner_name_は_repo_の値を対象にする(self) -> None:
+        """`gh issue close 2 --repo owner/name` は `--repo` の値を対象にする"""
+        trigger = scribe_trigger.find("gh issue close 2 --repo owner/name")
+        assert trigger is not None
+        self.assertEqual(trigger.kind, "issue")
+        self.assertEqual(trigger.directory, Path("owner/name"))
+
+
+class TestShouldPrompt(unittest.TestCase):
+    def test_対象に_docs_wiki_が無いとき_促さないと決まる(self) -> None:
+        """対象に `docs/wiki/` が無いとき、促さないと決まる"""
+        with tempfile.TemporaryDirectory() as tmp:
+            trigger = scribe_trigger.find(f"cd {tmp}; gh pr merge 1")
+            assert trigger is not None
+            self.assertFalse(scribe_trigger.should_prompt(trigger))
 
 
 if __name__ == "__main__":

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -1,0 +1,40 @@
+"""Tests for hooks/_lib/scribe_trigger.py.
+
+Run: python3 hooks/_lib/tests/scribe_trigger_test.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import scribe_trigger
+
+
+class TestFind(unittest.TestCase):
+    def test_gh_pr_merge_1_merge_を渡すと_pr_契機が返る(self) -> None:
+        """`gh pr merge 1 --merge` を渡すと pr 契機が返る"""
+        trigger = scribe_trigger.find("gh pr merge 1 --merge")
+        assert trigger is not None
+        self.assertEqual(trigger.kind, "pr")
+        self.assertEqual(trigger.directory, Path.cwd())
+
+    def test_gh_issue_close_2_を渡すと_issue_契機が返る(self) -> None:
+        """`gh issue close 2` を渡すと issue 契機が返る"""
+        trigger = scribe_trigger.find("gh issue close 2")
+        assert trigger is not None
+        self.assertEqual(trigger.kind, "issue")
+        self.assertEqual(trigger.directory, Path.cwd())
+
+    def test_echo_gh_pr_merge_のように語が引数の中にあるだけのときは何も返らない(self) -> None:
+        """`echo "gh pr merge"` のように語が引数の中にあるだけのときは何も返らない"""
+        self.assertIsNone(scribe_trigger.find('echo "gh pr merge"'))
+
+    def test_for_n_in_1_2_do_gh_issue_close_n_done_は何も返らない(self) -> None:
+        """`for n in 1 2; do gh issue close $n; done` は何も返らない"""
+        self.assertIsNone(scribe_trigger.find("for n in 1 2; do gh issue close $n; done"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -15,38 +15,25 @@ import scribe_trigger
 
 
 class TestFind(unittest.TestCase):
-    def test_gh_pr_merge_1_merge_を渡すと_pr_契機が返る(self) -> None:
-        """`gh pr merge 1 --merge` を渡すと pr 契機が返る"""
-        trigger = scribe_trigger.find("gh pr merge 1 --merge")
-        assert trigger is not None
-        self.assertEqual(trigger.kind, "pr")
-        self.assertEqual(trigger.directory, Path.cwd())
+    def test_git_pull_を渡すと実行ディレクトリが返る(self) -> None:
+        """`git pull` を渡すと実行ディレクトリが返る"""
+        self.assertEqual(scribe_trigger.find("git pull"), Path.cwd())
 
-    def test_gh_issue_close_2_を渡すと_issue_契機が返る(self) -> None:
-        """`gh issue close 2` を渡すと issue 契機が返る"""
-        trigger = scribe_trigger.find("gh issue close 2")
-        assert trigger is not None
-        self.assertEqual(trigger.kind, "issue")
-        self.assertEqual(trigger.directory, Path.cwd())
+    def test_git_pull_origin_main_も同じく返る(self) -> None:
+        """`git pull origin main` も同じく返る"""
+        self.assertEqual(scribe_trigger.find("git pull origin main"), Path.cwd())
 
-    def test_echo_gh_pr_merge_のように語が引数の中にあるだけのときは何も返らない(self) -> None:
-        """`echo "gh pr merge"` のように語が引数の中にあるだけのときは何も返らない"""
-        self.assertIsNone(scribe_trigger.find('echo "gh pr merge"'))
+    def test_echo_git_pull_のように語が引数の中にあるだけのときは何も返らない(self) -> None:
+        """`echo "git pull"` のように語が引数の中にあるだけのときは何も返らない"""
+        self.assertIsNone(scribe_trigger.find('echo "git pull"'))
 
-    def test_for_n_in_1_2_do_gh_issue_close_n_done_は何も返らない(self) -> None:
-        """`for n in 1 2; do gh issue close $n; done` は何も返らない"""
-        self.assertIsNone(scribe_trigger.find("for n in 1 2; do gh issue close $n; done"))
+    def test_git_push_は何も返らない(self) -> None:
+        """`git push` は取り込む動作ではないので何も返らない"""
+        self.assertIsNone(scribe_trigger.find("git push origin main"))
 
-    def test_cd_path_to_repo_gh_pr_merge_1_は_cd_先を対象にする(self) -> None:
-        """`cd /path/to/repo; gh pr merge 1` は cd 先を対象にする"""
-        trigger = scribe_trigger.find("cd /path/to/repo; gh pr merge 1")
-        assert trigger is not None
-        self.assertEqual(trigger.directory, Path("/path/to/repo"))
-
-    def test_repo_フラグ付きのトリガーは対象外になる(self) -> None:
-        """`--repo owner/name` はこのセッションが作業するリポジトリを指さないので対象外になる"""
-        self.assertIsNone(scribe_trigger.find("gh issue close 2 --repo owner/name"))
-        self.assertIsNone(scribe_trigger.find("gh pr merge 1 --repo owner/name --merge"))
+    def test_cd_path_to_repo_git_pull_は_cd_先を対象にする(self) -> None:
+        """`cd /path/to/repo; git pull` は cd 先を対象にする"""
+        self.assertEqual(scribe_trigger.find("cd /path/to/repo; git pull"), Path("/path/to/repo"))
 
 
 class _QueueRunner:
@@ -64,65 +51,65 @@ class _QueueRunner:
         return self._responses.pop(0)
 
 
-def _trigger_with_wiki(directory: Path) -> scribe_trigger.Trigger:
+def _with_wiki(directory: Path) -> Path:
     (directory / "docs" / "wiki").mkdir(parents=True)
-    return scribe_trigger.Trigger("pr", directory)
+    return directory
 
 
 class TestShouldPrompt(unittest.TestCase):
     def test_対象に_docs_wiki_が無いとき_促さないと決まる(self) -> None:
         """対象に `docs/wiki/` が無いとき、促さないと決まる"""
         with tempfile.TemporaryDirectory() as tmp:
-            trigger = scribe_trigger.find(f"cd {tmp}; gh pr merge 1")
-            assert trigger is not None
-            self.assertFalse(scribe_trigger.should_prompt(trigger))
+            target = scribe_trigger.find(f"cd {tmp}; git pull")
+            assert target is not None
+            self.assertFalse(scribe_trigger.should_prompt(target))
 
     def test_未マージ_scribe_pr_が_1_件以上あるとき促さない(self) -> None:
         """未マージ scribe PR が 1 件以上あるとき促さない"""
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
-            trigger = _trigger_with_wiki(directory)
+            target = _with_wiki(directory)
             stamp = directory / "cache" / "claude-scribe_trigger.last"
             runner = _QueueRunner(['[{"number": 1}]'])
-            self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+            self.assertFalse(scribe_trigger.should_prompt(target, stamp=stamp, runner=runner))
 
     def test_cursor_以降の入力が_0_件のとき促さない(self) -> None:
         """両方の kind が 0 件のとき促さない。片方だけ見て止まると、もう片方に溜まった入力を落とす"""
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
-            trigger = _trigger_with_wiki(directory)
+            target = _with_wiki(directory)
             stamp = directory / "cache" / "claude-scribe_trigger.last"
             runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", "[]", "[]"])
-            self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+            self.assertFalse(scribe_trigger.should_prompt(target, stamp=stamp, runner=runner))
 
-    def test_トリガーと違う_kind_に入力があれば促す(self) -> None:
-        """merge が契機でも、cursor 以降に closed issue が 1 件でもあれば入力はある"""
+    def test_merged_pr_が_0_件でも_closed_issue_があれば促す(self) -> None:
+        """merged PR が 0 件でも、cursor 以降に closed issue が 1 件あれば入力はある"""
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
-            trigger = _trigger_with_wiki(directory)
+            target = _with_wiki(directory)
             stamp = directory / "cache" / "claude-scribe_trigger.last"
             runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", "[]", '[{"number": 1}]'])
-            self.assertTrue(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+            self.assertTrue(scribe_trigger.should_prompt(target, stamp=stamp, runner=runner))
 
     def test_stamp_が_cooldown_内にあるとき促さない(self) -> None:
         """stamp が cooldown 内にあるとき促さない"""
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
-            trigger = _trigger_with_wiki(directory)
+            target = _with_wiki(directory)
             stamp = directory / "cache" / "claude-scribe_trigger.last"
             stamp.parent.mkdir(parents=True)
             stamp.touch()
             runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", '[{"number": 5}]'])
-            self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+            self.assertFalse(scribe_trigger.should_prompt(target, stamp=stamp, runner=runner))
 
     def test_未マージ_0_件_入力_1_件以上_stamp_が_cooldown_外のとき促す(self) -> None:
         """未マージ 0 件、入力 1 件以上、stamp が cooldown 外のとき促す"""
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
-            trigger = _trigger_with_wiki(directory)
+            target = _with_wiki(directory)
             stamp = directory / "cache" / "claude-scribe_trigger.last"
             runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", '[{"number": 5}]'])
-            self.assertTrue(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+            self.assertTrue(scribe_trigger.should_prompt(target, stamp=stamp, runner=runner))
             self.assertTrue(stamp.is_file(), "促した後は stamp が更新されているはず")
 
 

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -43,12 +43,10 @@ class TestFind(unittest.TestCase):
         assert trigger is not None
         self.assertEqual(trigger.directory, Path("/path/to/repo"))
 
-    def test_gh_issue_close_2_repo_owner_name_は_repo_の値を対象にする(self) -> None:
-        """`gh issue close 2 --repo owner/name` は `--repo` の値を対象にする"""
-        trigger = scribe_trigger.find("gh issue close 2 --repo owner/name")
-        assert trigger is not None
-        self.assertEqual(trigger.kind, "issue")
-        self.assertEqual(trigger.directory, Path("owner/name"))
+    def test_repo_フラグ付きのトリガーは対象外になる(self) -> None:
+        """`--repo owner/name` はこのセッションが作業するリポジトリを指さないので対象外になる"""
+        self.assertIsNone(scribe_trigger.find("gh issue close 2 --repo owner/name"))
+        self.assertIsNone(scribe_trigger.find("gh pr merge 1 --repo owner/name --merge"))
 
 
 class _QueueRunner:
@@ -62,7 +60,7 @@ class _QueueRunner:
     def __init__(self, responses: list[str]) -> None:
         self._responses = list(responses)
 
-    def __call__(self, args: Sequence[str]) -> str:
+    def __call__(self, args: Sequence[str]) -> str:  # noqa: ARG002
         return self._responses.pop(0)
 
 
@@ -89,13 +87,22 @@ class TestShouldPrompt(unittest.TestCase):
             self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
 
     def test_cursor_以降の入力が_0_件のとき促さない(self) -> None:
-        """cursor 以降の入力が 0 件のとき促さない"""
+        """両方の kind が 0 件のとき促さない。片方だけ見て止まると、もう片方に溜まった入力を落とす"""
         with tempfile.TemporaryDirectory() as tmp:
             directory = Path(tmp)
             trigger = _trigger_with_wiki(directory)
             stamp = directory / "cache" / "claude-scribe_trigger.last"
-            runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", "[]"])
+            runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", "[]", "[]"])
             self.assertFalse(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
+
+    def test_トリガーと違う_kind_に入力があれば促す(self) -> None:
+        """merge が契機でも、cursor 以降に closed issue が 1 件でもあれば入力はある"""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = Path(tmp)
+            trigger = _trigger_with_wiki(directory)
+            stamp = directory / "cache" / "claude-scribe_trigger.last"
+            runner = _QueueRunner(["[]", "2026-01-01T00:00:00Z", "[]", '[{"number": 1}]'])
+            self.assertTrue(scribe_trigger.should_prompt(trigger, stamp=stamp, runner=runner))
 
     def test_stamp_が_cooldown_内にあるとき促さない(self) -> None:
         """stamp が cooldown 内にあるとき促さない"""

--- a/hooks/post-bash/scribe_prompt.py
+++ b/hooks/post-bash/scribe_prompt.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PostToolUse hook: nudge toward /scribe when a gh pr merge / gh issue close just completed.
+"""PostToolUse hook: nudge toward /scribe when a git pull just brought down new work.
 
 The Bash tool_response carries no exit code
 (https://code.claude.com/docs/en/hooks#posttooluse-decision-control), so `interrupted` is the
@@ -30,17 +30,17 @@ def main() -> None:
     if not isinstance(command, str) or not command:
         return
     try:
-        trigger = scribe_trigger.find(command)
+        directory = scribe_trigger.find(command)
     except ValueError:
         # command_scan raises on a line shlex cannot close, and letting it out would report a
         # hook error on an ordinary command.
         return
-    if trigger is None:
+    if directory is None:
         return
-    if not scribe_trigger.should_prompt(trigger):
+    if not scribe_trigger.should_prompt(directory):
         return
     message = (
-        "scribe_prompt: 直近の merge / close で docs/wiki/ 未反映の入力が増えた。"
+        "scribe_prompt: 直近の pull で docs/wiki/ 未反映の入力が増えた。"
         "/scribe を実行して知見を抽出する。"
     )
     notify(message)

--- a/hooks/post-bash/scribe_prompt.py
+++ b/hooks/post-bash/scribe_prompt.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: nudge toward /scribe when a gh pr merge / gh issue close just completed.
+
+hooks/_lib/scribe_trigger.py holds the judgment -- which command line runs a trigger, and
+whether it is worth prompting for. This hook only connects that judgment to a live Bash
+tool_response and writes the output shape hooks/_lib/mirror_prose.py's `emit` establishes:
+systemMessage for the human, hookSpecificOutput.additionalContext for the agent.
+
+The Bash tool_response is `{stdout, stderr, interrupted, isImage}`
+(https://code.claude.com/docs/en/hooks#posttooluse-decision-control) -- there is no separate
+exit-code field. `interrupted` is the one boolean that shape carries, so it is read here as
+"the call failed": a merge/close that did not complete landed nothing new, and prompting on
+it would point the user at work that never happened.
+"""
+
+# A hook can run with PATH cut down to /usr/bin, where python3 is old enough to reject
+# `X | None` at import time. Deferred annotations keep this module loadable there.
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "_lib"))
+
+import scribe_trigger
+from hook_payload import field, parse
+
+
+def _tool_response_failed(payload: dict[str, object]) -> bool:
+    return bool(field(field(payload, "tool_response"), "interrupted"))
+
+
+def main() -> None:
+    payload = parse(sys.stdin.read())
+    if _tool_response_failed(payload):
+        return
+    command = field(field(payload, "tool_input"), "command")
+    if not isinstance(command, str) or not command:
+        return
+    trigger = scribe_trigger.find(command)
+    if trigger is None:
+        return
+    if not scribe_trigger.should_prompt(trigger):
+        return
+    message = (
+        "scribe_prompt: 直近の merge / close で docs/wiki/ 未反映の入力が増えた。"
+        "/scribe を実行して知見を抽出する。"
+    )
+    print(
+        json.dumps(
+            {
+                "systemMessage": message,
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": message,
+                },
+            },
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/hooks/post-bash/scribe_prompt.py
+++ b/hooks/post-bash/scribe_prompt.py
@@ -17,14 +17,13 @@ it would point the user at work that never happened.
 # `X | None` at import time. Deferred annotations keep this module loadable there.
 from __future__ import annotations
 
-import json
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "_lib"))
 
 import scribe_trigger
-from hook_payload import field, parse
+from hook_payload import field, notify, parse
 
 
 def _tool_response_failed(payload: dict[str, object]) -> bool:
@@ -38,7 +37,12 @@ def main() -> None:
     command = field(field(payload, "tool_input"), "command")
     if not isinstance(command, str) or not command:
         return
-    trigger = scribe_trigger.find(command)
+    try:
+        trigger = scribe_trigger.find(command)
+    except ValueError:
+        # command_scan raises on a line shlex cannot close. A hook that lets it out exits 1
+        # with a traceback, which Claude Code reports as a hook error on an ordinary command.
+        return
     if trigger is None:
         return
     if not scribe_trigger.should_prompt(trigger):
@@ -47,18 +51,7 @@ def main() -> None:
         "scribe_prompt: 直近の merge / close で docs/wiki/ 未反映の入力が増えた。"
         "/scribe を実行して知見を抽出する。"
     )
-    print(
-        json.dumps(
-            {
-                "systemMessage": message,
-                "hookSpecificOutput": {
-                    "hookEventName": "PostToolUse",
-                    "additionalContext": message,
-                },
-            },
-            ensure_ascii=False,
-        )
-    )
+    notify(message)
 
 
 if __name__ == "__main__":

--- a/hooks/post-bash/scribe_prompt.py
+++ b/hooks/post-bash/scribe_prompt.py
@@ -1,20 +1,12 @@
 #!/usr/bin/env python3
 """PostToolUse hook: nudge toward /scribe when a gh pr merge / gh issue close just completed.
 
-hooks/_lib/scribe_trigger.py holds the judgment -- which command line runs a trigger, and
-whether it is worth prompting for. This hook only connects that judgment to a live Bash
-tool_response and writes the output shape hooks/_lib/mirror_prose.py's `emit` establishes:
-systemMessage for the human, hookSpecificOutput.additionalContext for the agent.
-
-The Bash tool_response is `{stdout, stderr, interrupted, isImage}`
-(https://code.claude.com/docs/en/hooks#posttooluse-decision-control) -- there is no separate
-exit-code field. `interrupted` is the one boolean that shape carries, so it is read here as
-"the call failed": a merge/close that did not complete landed nothing new, and prompting on
-it would point the user at work that never happened.
+The Bash tool_response carries no exit code
+(https://code.claude.com/docs/en/hooks#posttooluse-decision-control), so `interrupted` is the
+only field saying the call did not complete.
 """
 
-# A hook can run with PATH cut down to /usr/bin, where python3 is old enough to reject
-# `X | None` at import time. Deferred annotations keep this module loadable there.
+# python3 on a cut-down PATH can be old enough to reject `X | None` at import time.
 from __future__ import annotations
 
 import sys
@@ -40,8 +32,8 @@ def main() -> None:
     try:
         trigger = scribe_trigger.find(command)
     except ValueError:
-        # command_scan raises on a line shlex cannot close. A hook that lets it out exits 1
-        # with a traceback, which Claude Code reports as a hook error on an ordinary command.
+        # command_scan raises on a line shlex cannot close, and letting it out would report a
+        # hook error on an ordinary command.
         return
     if trigger is None:
         return

--- a/hooks/post-bash/tests/scribe_prompt_test.py
+++ b/hooks/post-bash/tests/scribe_prompt_test.py
@@ -133,9 +133,7 @@ class TestScribePrompt(unittest.TestCase):
         """T-012 促すと決まったとき `hookSpecificOutput.additionalContext` に `/scribe` を含む本文が出る"""
         directory = self.root / "target-prompt"
         (directory / "docs" / "wiki").mkdir(parents=True)
-        stdout = self.run_hook(
-            f"cd {directory}; gh pr merge 1 --merge", gh_responses=PROMPTING_GH_RESPONSES
-        )
+        stdout = self.run_hook(f"cd {directory}; git pull", gh_responses=PROMPTING_GH_RESPONSES)
         payload = json.loads(stdout)
         context = payload["hookSpecificOutput"]["additionalContext"]
         self.assertIn("/scribe", context)
@@ -146,7 +144,7 @@ class TestScribePrompt(unittest.TestCase):
         # ever calls gh (hooks/_lib/scribe_trigger.py's should_prompt docstring).
         directory = self.root / "target-no-wiki"
         directory.mkdir()
-        stdout = self.run_hook(f"cd {directory}; gh issue close 3")
+        stdout = self.run_hook(f"cd {directory}; git pull")
         self.assertEqual(stdout, "")
 
     def test_failed_tool_response_does_not_prompt(self) -> None:
@@ -155,7 +153,7 @@ class TestScribePrompt(unittest.TestCase):
         # this fixture is the tool_response check itself, not should_prompt's own gates.
         directory = self.root / "target-interrupted"
         (directory / "docs" / "wiki").mkdir(parents=True)
-        stdout = self.run_hook(f"cd {directory}; gh pr merge 1 --merge", interrupted=True)
+        stdout = self.run_hook(f"cd {directory}; git pull", interrupted=True)
         self.assertEqual(stdout, "")
 
     def test_settings_json_registers_hook_under_posttooluse_bash(self) -> None:

--- a/hooks/post-bash/tests/scribe_prompt_test.py
+++ b/hooks/post-bash/tests/scribe_prompt_test.py
@@ -1,0 +1,177 @@
+# pyright: reportUninitializedInstanceVariable=false
+# setUp fills these per test, which is where a unittest fixture belongs. The rule asks for a
+# class-body assignment or __init__ instead, neither of which can hold a per-test temp dir.
+# The class-body annotations still carry the types.
+"""Integration tests for hooks/post-bash/scribe_prompt.py (PostToolUse hook).
+
+This is the seam between hooks/_lib/scribe_trigger.py's find/should_prompt (U-001..U-003,
+already unit-tested in hooks/_lib/tests/scribe_trigger_test.py) and a real Bash PostToolUse
+payload. What only the hook wiring can break is whether the trigger a command line carries
+actually reaches scribe_trigger, whether should_prompt's verdict actually reaches stdout in
+the shape hooks/_lib/mirror_prose.py's emit() establishes, and whether a failed
+tool_response actually short-circuits it before should_prompt runs at all. The hook runs as
+a real subprocess against the real scribe_trigger module; only gh, the external system
+should_prompt calls out to, is stubbed.
+
+The Bash tool's PostToolUse tool_response is `{stdout, stderr, interrupted, isImage}`
+(https://code.claude.com/docs/en/hooks#posttooluse-decision-control, the updatedToolOutput
+example that documents "the Bash tool's output shape") -- there is no separate exit-code or
+success field. `interrupted` is the only boolean that shape carries, and the same reference
+states that cancelling a running Bash call still reaches PostToolUse rather than
+PostToolUseFailure, with "the tool result carr[ying] the interruption message instead". This
+suite reads `interrupted: true` as the "tool_response indicates failure" case the contract
+names; a future implementer reading a different signal should update this comment along with
+the fixtures below.
+
+Run: python3 hooks/post-bash/tests/scribe_prompt_test.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import override
+
+HOOK = Path(__file__).resolve().parents[1] / "scribe_prompt.py"
+SETTINGS = Path(__file__).resolve().parents[3] / "settings.json"
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "_lib"))
+
+import hook_harness  # noqa: E402
+
+# should_prompt's three gh calls in the order hooks/_lib/scribe_trigger.py makes them: the
+# unmerged-PR check, the last-scribe-merge cursor, then the new-input count. Values match
+# hooks/_lib/tests/scribe_trigger_test.py's "促す" case (test_未マージ_0_件_入力_1_件以上_stamp_が_cooldown_外のとき促す)
+# so a drift between the two suites would show up as one of them alone going red.
+PROMPTING_GH_RESPONSES = ["[]", "", '[{"number": 5}]']
+
+# A fake `gh` that pops one canned response per invocation, in call order. gh is the only
+# external system should_prompt reaches out to, so this is what stays faked while
+# scribe_trigger and the hook itself run for real.
+GH_STUB = """#!/usr/bin/env python3
+import os
+import pathlib
+import sys
+
+responses = pathlib.Path(os.environ["GH_STUB_RESPONSES"]).read_text(encoding="utf-8").split("\\n")
+index_path = pathlib.Path(os.environ["GH_STUB_INDEX"])
+i = int(index_path.read_text()) if index_path.is_file() else 0
+index_path.write_text(str(i + 1))
+sys.stdout.write(responses[i])
+"""
+
+
+class TestScribePrompt(unittest.TestCase):
+    tmpdir: tempfile.TemporaryDirectory[str]
+    root: Path
+
+    @override
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory(prefix="scribe-prompt-tests-")
+        self.addCleanup(self.tmpdir.cleanup)
+        self.root = Path(self.tmpdir.name)
+
+    def gh_stub_dir(self, responses: list[str]) -> tuple[Path, dict[str, str]]:
+        """A directory holding the fake `gh`, plus the env vars it reads its queue from.
+        Prepend the directory to PATH so the hook's real `gh` subprocess call resolves this
+        instead of a real gh."""
+        stub_dir = self.root / "gh-stub"
+        stub_dir.mkdir()
+        stub = stub_dir / "gh"
+        _ = stub.write_text(GH_STUB, encoding="utf-8")
+        stub.chmod(0o755)
+        responses_file = stub_dir / "responses"
+        _ = responses_file.write_text("\n".join(responses), encoding="utf-8")
+        return stub_dir, {
+            "GH_STUB_RESPONSES": str(responses_file),
+            "GH_STUB_INDEX": str(stub_dir / "index"),
+        }
+
+    def run_hook(
+        self,
+        command: str,
+        *,
+        interrupted: bool = False,
+        gh_responses: list[str] | None = None,
+    ) -> str:
+        """Run the hook on a Bash PostToolUse payload for `command`.
+
+        HOME moves to a fresh temp dir so should_prompt's cooldown stamp
+        (~/.cache/claude-scribe_trigger.last) never touches this machine's real one, the same
+        isolation hooks/lifecycle/tests/recall_index_test.py uses for its own stamp file.
+
+        gh_responses is None on every path where should_prompt is expected to return before
+        it ever calls gh (no docs/wiki, or the tool_response-failure short-circuit): PATH
+        then carries no `gh` at all, so an implementation bug that reaches gh anyway fails
+        fast on "not found" instead of making a real network call.
+        """
+        home = self.root / "home"
+        home.mkdir(exist_ok=True)
+        env = dict(os.environ, HOME=str(home))
+        if gh_responses is not None:
+            stub_dir, gh_env = self.gh_stub_dir(gh_responses)
+            env["PATH"] = f"{stub_dir}{os.pathsep}{env['PATH']}"
+            env.update(gh_env)
+        else:
+            env["PATH"] = str(self.root)
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {
+                "stdout": "",
+                "stderr": "",
+                "interrupted": interrupted,
+                "isImage": False,
+            },
+        }
+        return hook_harness.run(HOOK, payload, env)
+
+    def test_prompting_decided_puts_scribe_in_additional_context(self) -> None:
+        """T-012 促すと決まったとき `hookSpecificOutput.additionalContext` に `/scribe` を含む本文が出る"""
+        directory = self.root / "target-prompt"
+        (directory / "docs" / "wiki").mkdir(parents=True)
+        stdout = self.run_hook(
+            f"cd {directory}; gh pr merge 1 --merge", gh_responses=PROMPTING_GH_RESPONSES
+        )
+        payload = json.loads(stdout)
+        context = payload["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("/scribe", context)
+
+    def test_not_prompting_decided_stdout_is_empty(self) -> None:
+        """T-013 促さないと決まったとき stdout が空になる"""
+        # No docs/wiki under the target: should_prompt's first gate returns False before it
+        # ever calls gh (hooks/_lib/scribe_trigger.py's should_prompt docstring).
+        directory = self.root / "target-no-wiki"
+        directory.mkdir()
+        stdout = self.run_hook(f"cd {directory}; gh issue close 3")
+        self.assertEqual(stdout, "")
+
+    def test_failed_tool_response_does_not_prompt(self) -> None:
+        """T-014 `tool_response` が失敗を示すとき促さない"""
+        # docs/wiki is present here, unlike T-013: the only thing that can stop a prompt on
+        # this fixture is the tool_response check itself, not should_prompt's own gates.
+        directory = self.root / "target-interrupted"
+        (directory / "docs" / "wiki").mkdir(parents=True)
+        stdout = self.run_hook(f"cd {directory}; gh pr merge 1 --merge", interrupted=True)
+        self.assertEqual(stdout, "")
+
+    def test_settings_json_registers_hook_under_posttooluse_bash(self) -> None:
+        """T-015 `settings.json` の `PostToolUse` の `Bash` matcher にこの hook が載っている"""
+        settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+        bash_entries = [
+            entry for entry in settings["hooks"]["PostToolUse"] if entry.get("matcher") == "Bash"
+        ]
+        commands = [
+            hook.get("command", "") for entry in bash_entries for hook in entry.get("hooks", [])
+        ]
+        self.assertTrue(
+            any("post-bash/scribe_prompt.py" in command for command in commands),
+            f"post-bash/scribe_prompt.py が settings.json の PostToolUse/Bash に無い: {commands}",
+        )
+
+
+if __name__ == "__main__":
+    _ = unittest.main(verbosity=2)

--- a/hooks/post-bash/tests/scribe_prompt_test.py
+++ b/hooks/post-bash/tests/scribe_prompt_test.py
@@ -159,7 +159,13 @@ class TestScribePrompt(unittest.TestCase):
         self.assertEqual(stdout, "")
 
     def test_settings_json_registers_hook_under_posttooluse_bash(self) -> None:
-        """T-015 `settings.json` の `PostToolUse` の `Bash` matcher にこの hook が載っている"""
+        """T-015 `settings.json` の `PostToolUse` の `Bash` matcher にこの hook が載っている
+
+        `.gitignore` が `/settings.json` を持つので CI のチェックアウトには無い。配線が
+        効くのは各自の手元だけなので、そこでだけ検査する。
+        """
+        if not SETTINGS.is_file():
+            self.skipTest("settings.json は追跡外で、このチェックアウトには無い")
         settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
         bash_entries = [
             entry for entry in settings["hooks"]["PostToolUse"] if entry.get("matcher") == "Bash"


### PR DESCRIPTION
## What & Why

`git pull` を実行し、対象リポジトリが `docs/wiki/` を持ち、直近 8 時間に促していなくて、未マージ scribe PR が無く、cursor 以降の入力が 1 件以上あるとき、`additionalContext` で `/scribe` の起動が促される。

今は人が `/scribe` を打ったときだけ走り、起動が律速になっていた。scribe PR は作成からマージまで 1 分から 7 時間で通る一方、PR と PR の間隔は最大 26 日空いた。これはレビュー待ちではなく誰も起動しなかった期間である。

## Review focus

- 契機が `git pull` であること。当初は `gh pr merge` と `gh issue close` を拾う設計だったが、直近 24 時間の transcript を位置判定で数えると 0 件だった。マージはブラウザで行われ、`Closes` を書いた issue は GitHub が自動で閉じるので、どちらもローカルの Bash を通らない。同じ期間の `git pull` は 11 件
- `should_prompt` のゲート順序。`docs/wiki/` の有無 (ローカル判定) → cooldown → 未マージ scribe PR → cursor 以降の入力。cooldown を `gh` 呼び出しの前へ置いたのは、pull が merge より頻度が高く、8 時間窓の 2 回目以降は GitHub へ聞く必要がないため
- `scribe_prompt.py` が `tool_response.interrupted` だけで失敗を判定している点。Bash の `tool_response` に exit code フィールドが無く、`interrupted` が唯一読めるブール値であることが前提

## Changes

- `hooks/_lib/scribe_trigger.py` が `git pull` を位置で判定し、`cd` を辿って対象ディレクトリを返す
- `hooks/post-bash/scribe_prompt.py` が判定を繋ぎ、`hook_payload.notify()` で `systemMessage` と `additionalContext` の両方へ出す
- `hook_payload.py` に `notify()` を足した。`mirror_prose.py` の `emit()` が同じエンベロープを持っており、hook 本体での手書きを避ける
- cooldown はスタンプの mtime で判定する (`~/.cache/claude-scribe_trigger.last`)。書き込みに失敗したら stderr へ出す。黙って握りつぶすと cooldown が無効になったことに気づけない

## Scope

- Not included: `gh pr merge` / `gh issue close` を契機にする案。上記の実測により今の運用では発火しない
- Not included: `git pull` が何を取り込んだかの判定。取り込みの有無でなく cursor 差分で決める
- Not included: `settings.json` の配線。`.gitignore` が持つ追跡外ファイルなので、この PR の diff には出ない。手元では登録済み

## Design Decisions

- `--repo owner/name` は対象外にした。当初は `--repo` の値を対象ディレクトリにしていたが、`Path("owner/name")` を hook の cwd から解決するため実在せず、`--repo` 形式のトリガーがすべて死んでいた。そもそも別リポジトリの backlog はこのセッションが向かう先ではない
- 入力の判定は merged PR と closed issue の両方を見る。片方だけだと、PR が 0 件でも issue が 3 件溜まっている状態を落とす。PR を先に引き、1 件見つけた時点で返すので通常は `gh` 1 回
- `command_scan` の `ValueError` を hook 本体で捕捉する。既存の呼び出し元 2 本 (`body_proofread.py`, `issue_body_gate.py`) が同じ形を取っており、閉じられていない引用符でフックが exit 1 していた

## How to Test

1. `python3 hooks/_lib/tests/scribe_trigger_test.py` と `python3 hooks/post-bash/tests/scribe_prompt_test.py` を実行する
2. 11 tests OK と 4 tests OK になる
3. `docs/wiki/` を持つリポジトリで `git pull` を実行する
4. cursor 以降に新規マージ PR か新規クローズ issue が 1 件以上あり、直近 8 時間に促していなければ、`additionalContext` に `/scribe` を促すメッセージが乗る

`settings.json` が無いチェックアウトでは T-015 が skip される。`.gitignore` が `/settings.json` を持つので CI には存在しない。

## 残る実測

`Bash` matcher での `additionalContext` 到達は未実測。`Write` matcher では `mirror_prose_guard` で確認済み。この PR がマージされて hook が動き出せば、次の `git pull` で実測できる。

---

_下は build workflow の自動検証結果で、`d881d4d0` より前の実行時点のもの。以降のコミットは反映されない。_

**この時点の指摘はすべて対応済み。** status 行の `conformance 5 (3 high)`、`structure 2`、`gates=FAIL`、`untouched-plan-files 1` はいずれもその時点の値で、現在の HEAD の状態ではない。

| 当時の指摘 | 現在 |
| --- | --- |
| `--repo owner/name` の経路が常に False | 対象外にした |
| 入力の判定がトリガーの kind 側しか見ない | 両方見る |
| `_touch` が OSError を握りつぶす | stderr へ出す |
| `command_scan` の `ValueError` 未捕捉 | hook 本体で捕捉 |
| PostToolUse エンベロープの手書き | `hook_payload.notify()` へ切り出し |
| `&&` の短絡を区別しない | Backlog へ。merge が失敗すれば cursor 差分が増えないので実害が無い |
| `gates=FAIL` (ruff E501 ほか) | 解消。CI は pass |
| `untouched-plan-files: settings.json` | 追跡外ファイルなので diff に出ない。手元では登録済み |

加えて、この検証の後に契機を `gh pr merge` から `git pull` へ変えている。上の verify 出力が対象にしているコードは現在の実装とは別物。

Closes #505

<details>
<summary><code>verify tests=pass gates=FAIL</code> · <code>scope-deviations 0</code> · <code>missing-tests 0</code> · <code>untouched-plan-files 1</code> · <code>conformance 5 (3 high)</code> · <code>structure 2</code></summary>

<details><summary>verify 出力</summary>

```
## Test suite (`find agents hooks skills workflows -name '*_test.py' -print0 | xargs -0 -r -n1 python3`)

PASS. Ran all 31 `*_test.py` files individually to get per-file exit codes (the batched xargs run also completed clean but its terminal display was truncated at 57KB, so I re-verified file-by-file). Every file: exit=0, one "Ran N tests" / "OK" block each. No FAIL/ERROR/Traceback anywhere across the combined output. Total ~30 test classes, several hundred individual test cases, 0 failures.

Files run (all exit 0): hooks/_lib/tests/{command_scan,japanese,mirror_prose,scribe_trigger}_test.py, hooks/edit/tests/{mirror_prose_guard,rust_edit,textlint_fix}_test.py, hooks/integrations/tests/amphetamine_agent_session_test.py, hooks/lifecycle/tests/recall_index_test.py, hooks/post-bash/tests/scribe_prompt_test.py, hooks/pre-bash/tests/{body_proofread,client_identifier_gate,issue_body_gate,package_manager_rewrite}_test.py, hooks/security/tests/{git_sandbox_guard,npm_install_guard,rm_to_trash}_test.py, skills/_lib/tests/{harness_hash,review_score}_test.py, skills/outcome/tests/validate_outcome_test.py, skills/research/tests/find_prior_research_test.py, skills/scribe/tests/{find_wiki_rule,skill_contract,triage,verify_run}_test.py, workflows/assert/tests/record_test.py, workflows/audit/tests/snapshot_test.py, workflows/build/tests/{pr_body,record,revalidate,verify_tests}_test.py.

## Lint / type-check gates (per .github/workflows/test.yml)

No type-check gate is configured in this repo (no mypy/pyright/tsc config present) — only lint gates exist:

- oxlint (`npx oxlint`): PASS — scanned 74 files, 0 diagnostics, exit 0.
- textlint (`npx textlint '.ja/**/*.md'`): PASS — scanned 148 .md files under .ja/, all empty message arrays, exit 0.
- ruff check (`uvx --from ruff==0.16.4 ruff check .`): FAIL, exit 1.

    ARG002 Unused method argument: `args`
      --> hooks/_lib/tests/scribe_trigger_test.py:65:24
       |
    63 |         self._responses = list(responses)
    64 |
    65 |     def __call__(self, args: Sequence[str]) -> str:
       |                        ^^^^
    66 |         return self._responses.pop(0)
       |

    Found 1 error.

  Cause: ruff.toml's per-file-ignores for `hooks/**/tests/*.py` lists only `E501`; ARG002 is not ignored there, so this stub `__call__`'s unused `args` parameter is in scope.

- ruff format --check (`uvx --from ruff==0.16.4 ruff format --check .`): PASS — "529 files already formatted", exit 0.
- rumdl check (`uvx --from rumdl==0.2.58 rumdl check .`): PASS — "Success: No issues found in 432 files", exit 0.

State checked: branch feat/505-scribe-prompt at commit f8d15fe6, working tree clean (git status: "nothing to commit, working tree clean"). The ruff failure is on committed HEAD, not from uncommitted changes — CI would report this branch red on the ruff-check gate as-is.

Not run (outside the task's defined "full test suite" command, but noted as additional CI gates for completeness): `node --test` (Node tests) and `find hooks -name '*.test.sh' | xargs -0 -r -n1 -t bash` (Shell tests), both present in .github/workflows/test.yml alongside the gates above.

Per instructions, nothing was fixed.
```

</details>

**実機確認 (merge 前に実施)**
- [ ] 実際に `gh pr merge` を実行し、`additionalContext` が届くことを確認する。`PostToolUse` + `additionalContext` の到達は `mirror_prose_guard` で実測済みだが、`Bash` matcher での実測は実装後になる

**一度も変更されていない plan の files**
- `settings.json`

**Issue 適合性 (独立レビュー)**
- `[high] wrong` `find()` が `--repo owner/name` からトリガーを解決する際、`Path(repo)`(ファイルパスではなく GitHub スラッグ)を `trigger.directory` として保存する。`should_prompt` はそのスラッグをフックプロセスの cwd から解決した `(trigger.directory / "docs" / "wiki").is_dir()` を検証するが、これは実質的に実在するディレクトリにならない(実証済み: `/Users/thkt/.claude` 配下の `owner/name/docs/wiki`)。その結果 `should_prompt` は `gh` 呼び出しより前に、`--repo` 形式のすべてのトリガーで False を返すため、issue の Approach が実運用での観測として挙げるコマンド形式そのものについて AC 1/2(「起動が促される」)が発火しない。T-006 は `trigger.directory == Path("owner/name")` を検証するのみで下流のゲートを実行しないため、そのパスが死んでいてもスイートは green のままとなる。
  `hooks/_lib/scribe_trigger.py:59, :161` · spec: 実測コマンドに `gh issue close --repo <owner>/<repo>` と `cd /Users/thkt/.claude; gh pr merge ...` の両方がある
- `[high] missing` 先行する `&&` によって短絡された `gh pr merge`/`gh issue close` と、実際に実行されたものとを区別するコードパスが存在しない。`find()` は構文だけから Trigger を返し、`scribe_prompt.py` は `tool_response.interrupted` しか読まないが、連結コマンドが単に非ゼロ終了して `merge`/`close` に到達しない場合もこれは false のままとなる。T-001 から T-015 のいずれも、この名指しされた8件の発生ケースをカバーしていないため、この制約には仕組みもテストも存在しない。
  `hooks/_lib/scribe_trigger.py:43-60 (find), hooks/post-bash/scribe_prompt.py:30-31 (_tool_response_failed)` · spec: `&&` の短絡で実行されなかったマージを促しの対象にしない。実測に `gh pr ready 401 && gh pr merge 401 --merge` が 8 件ある
- `[high] wrong` Approach は入力総数の一部としてマージ済み PR 数とクローズ済み issue 数の両方を確認すると列挙しているが、`_new_input_count` はトリガー自身の種別のみを問い合わせる(merge トリガーなら PR のみ、close トリガーなら issue のみ)。そのことは docstring 自身が「narrowed to the trigger's own kind」として narrowing を認めている。具体的な乖離として、scribe PR の `gh pr merge` は、非 scribe のマージ済み新規 PR が0件でも、cursor 以降にクローズ済み issue が3件あれば発火する。そのため AC 1(「cursor 以降の入力が1件以上あれば起動が促される」)はプロンプトを要求するが、実装は PR 種別のトリガーで issue 数を一切見ないため、それを行わない。
  `hooks/_lib/scribe_trigger.py:130-143 (_new_input_count)` · spec: 全件引くと 4 回以上になる (open PR、cursor、merged PR 件数、closed issue 件数)
- `[medium] wrong` `_touch` は `OSError` を黙って握りつぶすため、書き込み不能なスタンプパスがあってもクールダウンが何も表面化させずに無効化される。これは issue がマーカーファイル方式(DR-0097)を廃止した理由として挙げる silent-failure の形を再導入するものである。方向性は異なる(引用されている under-firing ではなく over-prompting になる)が、記録側は依然として可視的な信号なしに失敗しており、AC 7/8(「直前に促した時刻から一定時間内は再び促さない」/「促した時刻を記録する」)に反する。
  `hooks/_lib/scribe_trigger.py:94-99 (_touch)` · spec: 撤去理由は「発火条件が届かなくなった」で、記録側が黙って止まる失敗し方をする
- `[medium] missing` 今回のビルドには、`additionalContext` が Bash の PostToolUse マッチャーを通じて実際にモデルへ到達することを確認する、必須の実環境スモークテストを示すコミット・スクラッチファイル・テスト成果物が存在しない。計画はこれをすべての AC が依存する load-bearing なチェックと位置づけ、実装後(すなわち現時点)に実施すべきものとしている。
  `Plan § Testing Decisions and § Manual verification (no corresponding diff evidence)` · spec: 実装前に PostToolUse(Bash) の `additionalContext` が model へ届くことを smoke test で実測する。全 AC がこの 1 点に乗っている / 実際に `gh pr merge` を実行し、`additionalContext` が届くことを確認する

**参照モジュールからの構造逸脱**
- `[convention]` gh_filing.py の docstring は、この参照モジュールが定める契約として「scan からの ValueError は呼び出し元に到達する」ことを明記している。これは `command_scan.commands()` が shlex で閉じられない行に対して ValueError を送出するためである。`command_scan` を利用する既存の `_lib` finder の呼び出し元は2箇所とも、フック本体の呼び出し側で ValueError を捕捉することでこの契約を守っている: hooks/pre-bash/body_proofread.py:84 と hooks/pre-bash/issue_body_gate.py:83。hooks/post-bash/scribe_prompt.py:41 は `scribe_trigger.find(command)` を呼び出し、これは `command_scan.commands()` をループするが、`main()` のどこにもそのような捕捉が存在しない。実証済みとして、引用符が閉じられていない Bash コマンド行(例: `echo 'unclosed`)は捕捉されない ValueError を送出し、参照契約が要求する「呼び出し元が捕捉する」挙動の代わりに、フックプロセスがトレースバックとともに exit 1 する。
  `hooks/post-bash/scribe_prompt.py:41` · ref: hooks/_lib/gh_filing.py:11-14 (module docstring) + hooks/_lib/command_scan.py:98-100 (commands() docstring)
- `[hand_rolled]` mirror_prose.py は PostToolUse エンベロープ(systemMessage + hookSpecificOutput.additionalContext、ensure_ascii=False)を `_lib` の `emit()` 内の1箇所の書き込みとして保持しており、これは hook_payload.py がエンベロープ書き込みを `_lib` に集約する前例(その `deny()` は「PreToolUse フックが行う唯一の書き込み」と説明されている)に一致する。scribe_prompt.py:50-61 は、参照モジュールがこの形状に対して行っているように共有の PostToolUse エンベロープ書き込みを `_lib` に切り出すのではなく、同一のエンベロープブロックをフック本体内に逐語的に再現している。
  `hooks/post-bash/scribe_prompt.py:50-61` · ref: hooks/_lib/mirror_prose.py:183-194 emit()

</details>


