### PR TITLE
docs(wiki): session-start snapshot の候補行へ #505 を足す

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -14,7 +14,7 @@
 - script/agent 出力は JSON stdout、error stderr、banner なしの機械可読形式にする #13 #54
 - 翻訳は情報系 prose のみ、file:line、severity、Closes 等の構造化フィールドは verbatim #175 #176
 - hook payload の形状は smoke test で実測確定し fixture 化してから gate を作る #150 #154
-- session-start snapshot のため hook/agent 定義変更は同一 session で検証できず次 session 検証を明記する #162 #163 #209
+- session-start snapshot のため hook/agent 定義変更は同一 session で検証できず次 session 検証を明記する #162 #163 #209 #505
 - PostToolUse:Agent は launch 時のみ発火し async 完了で 2 度目が来ない。completion 依存の gate は成立しない #150 #154 #160
 - 出力パスの変更前に、予測可能な名前で読む consumer の有無を再確認する #40 #52
 - 前提が harness、upstream の更新で消滅した issue は not planned で close し、消滅した前提を close コメントに残す #136 #184 #210


### PR DESCRIPTION
## What & Why

`session-start snapshot のため hook/agent 定義変更は同一 session で検証できず次 session 検証を明記する` の根拠へ #505 を足す。

#505 で hook を配線した同じセッションで、`git pull` を 5 回打っても発火しなかった。実行権限の欠落 (#519) を直しても変わらず、原因は `settings.json` と hook 定義が session start のスナップショットだったこと。

この行は 2026-07-19 から昇格待ちにある。ページになっていれば、実装前に `find_wiki_rule.py` が引いて `Manual verification` を「次セッションで検証する」と書けた。

## Review focus

- 根拠が 3 件から 4 件になり、次の scribe run で昇格の先頭に来る (`triage.py '[]' docs/wiki/_candidates.md` で確認できる)

## Changes

- `docs/wiki/_candidates.md` の当該行へ `#505` を足す

## Scope

- Not included: ページ化そのもの。次の scribe run が行う
- Not included: #505 の Manual verification。issue 側で更新済み

## How to Test

1. `python3 skills/scribe/scripts/triage.py '[]' docs/wiki/_candidates.md` を実行する
2. `commits[0][0]` がこの行になる
3. `python3 skills/scribe/tests/skill_contract_test.py` が 22 tests OK になる

## Related

- #505 の実装で踏んだ
