### PR TITLE
fix(hooks): gh を絶対パスで解決し失敗を握る

### DIFF
--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -9,6 +9,7 @@ them down.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import time
@@ -19,6 +20,10 @@ import command_scan
 
 # A gh invocation, injected so tests hand over canned stdout instead of a live gh process.
 GhRunner = Callable[[Sequence[str]], str]
+
+# A hook starts with PATH cut down, so a bare `gh` raises FileNotFoundError before any gate
+# runs. The absolute path is the same shape hooks/lifecycle/recall_index.py takes for recall.
+DEFAULT_GH = Path("/opt/homebrew/bin/gh")
 
 # The interval a stamp counts as recent, in the shape hooks/lifecycle/recall_index.py's
 # WINDOW_MINUTES takes. A nudge costs the user's attention, not just gh's rate limit, so the
@@ -43,13 +48,13 @@ def find(command: str) -> Path | None:
     return None
 
 
-def _default_runner(directory: Path) -> GhRunner:
+def _default_runner(directory: Path, gh: Path) -> GhRunner:
     """gh runs with the pull's directory as cwd, so it reads the repository off that
     checkout's git remote rather than off wherever the hook process started."""
 
     def run(args: Sequence[str]) -> str:
         result = subprocess.run(
-            ["gh", *args],
+            [str(gh), *args],
             cwd=directory,
             capture_output=True,
             text=True,
@@ -127,6 +132,7 @@ def should_prompt(
     *,
     stamp: Path | None = None,
     runner: GhRunner | None = None,
+    gh: Path | None = None,
 ) -> bool:
     """The cooldown comes before the gh calls because a pull runs far more often than a merge
     lands: most pulls inside one window have nothing new to find, and asking GitHub each time
@@ -136,10 +142,18 @@ def should_prompt(
     stamp_path = stamp or _default_stamp()
     if _recently_stamped(stamp_path):
         return False
-    call = runner or _default_runner(directory)
-    if _unmerged_scribe_pr_exists(call):
+    binary = gh or Path(os.environ.get("CLAUDE_GH_BIN") or DEFAULT_GH)
+    if runner is None and not (binary.is_file() and os.access(binary, os.X_OK)):
         return False
-    if not _has_new_input(_last_scribe_merge(call), call):
+    call = runner or _default_runner(directory, binary)
+    try:
+        if _unmerged_scribe_pr_exists(call):
+            return False
+        if not _has_new_input(_last_scribe_merge(call), call):
+            return False
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
+        # Auth expiry, a network drop, or a gh output shape this does not parse. None of them
+        # say a backlog is waiting, and a hook that raises here reports an error on a plain pull.
         return False
     _touch(stamp_path)
     return True

--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -21,8 +21,7 @@ import command_scan
 # A gh invocation, injected so tests hand over canned stdout instead of a live gh process.
 GhRunner = Callable[[Sequence[str]], str]
 
-# A hook starts with PATH cut down, so a bare `gh` raises FileNotFoundError before any gate
-# runs. The absolute path is the same shape hooks/lifecycle/recall_index.py takes for recall.
+# A hook starts with PATH cut down, so a bare `gh` raises FileNotFoundError before any gate runs.
 DEFAULT_GH = Path("/opt/homebrew/bin/gh")
 
 # The interval a stamp counts as recent, in the shape hooks/lifecycle/recall_index.py's
@@ -152,8 +151,8 @@ def should_prompt(
         if not _has_new_input(_last_scribe_merge(call), call):
             return False
     except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
-        # Auth expiry, a network drop, or a gh output shape this does not parse. None of them
-        # say a backlog is waiting, and a hook that raises here reports an error on a plain pull.
+        # None of these say a backlog is waiting, and raising here would report a hook error
+        # on a plain pull.
         return False
     _touch(stamp_path)
     return True

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -3,6 +3,7 @@
 Run: python3 hooks/_lib/tests/scribe_trigger_test.py
 """
 
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -54,6 +55,31 @@ class _QueueRunner:
 def _with_wiki(directory: Path) -> Path:
     (directory / "docs" / "wiki").mkdir(parents=True)
     return directory
+
+
+class TestGhBinary(unittest.TestCase):
+    def test_gh_が_path_に無い環境でも例外を投げない(self) -> None:
+        """hook は PATH を /usr/bin へ切り詰められて起動しうる。gh が見つからず例外が出ると
+        additionalContext も stamp も出ないまま、何も起きなかったのと同じ姿になる"""
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = _with_wiki(Path(tmp))
+            stamp = Path(tmp) / "cache" / "last"
+            missing = Path(tmp) / "no-such-gh"
+            self.assertFalse(
+                scribe_trigger.should_prompt(directory, stamp=stamp, gh=missing),
+                "gh が無いときは促さない",
+            )
+
+    def test_gh_が_非ゼロで終わるときも例外を投げない(self) -> None:
+        """認証切れやネットワーク断で gh は非ゼロを返す。促さないだけで済ませる"""
+
+        def failing(args: Sequence[str]) -> str:
+            raise subprocess.CalledProcessError(4, ["gh", *args])
+
+        with tempfile.TemporaryDirectory() as tmp:
+            directory = _with_wiki(Path(tmp))
+            stamp = Path(tmp) / "cache" / "last"
+            self.assertFalse(scribe_trigger.should_prompt(directory, stamp=stamp, runner=failing))
 
 
 class TestShouldPrompt(unittest.TestCase):

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -59,8 +59,7 @@ def _with_wiki(directory: Path) -> Path:
 
 class TestGhBinary(unittest.TestCase):
     def test_gh_が_path_に無い環境でも例外を投げない(self) -> None:
-        """hook は PATH を /usr/bin へ切り詰められて起動しうる。gh が見つからず例外が出ると
-        additionalContext も stamp も出ないまま、何も起きなかったのと同じ姿になる"""
+        """gh が見つからず例外が出ると、何も起きなかったのと見分けが付かない"""
         with tempfile.TemporaryDirectory() as tmp:
             directory = _with_wiki(Path(tmp))
             stamp = Path(tmp) / "cache" / "last"

--- a/hooks/post-bash/tests/scribe_prompt_test.py
+++ b/hooks/post-bash/tests/scribe_prompt_test.py
@@ -75,8 +75,8 @@ class TestScribePrompt(unittest.TestCase):
 
     def gh_stub_dir(self, responses: list[str]) -> tuple[Path, dict[str, str]]:
         """A directory holding the fake `gh`, plus the env vars it reads its queue from.
-        Prepend the directory to PATH so the hook's real `gh` subprocess call resolves this
-        instead of a real gh."""
+        `CLAUDE_GH_BIN` points the hook at this stub: scribe_trigger resolves gh by absolute
+        path, since a hook starts with PATH cut down and a bare name would not resolve."""
         stub_dir = self.root / "gh-stub"
         stub_dir.mkdir()
         stub = stub_dir / "gh"
@@ -85,6 +85,7 @@ class TestScribePrompt(unittest.TestCase):
         responses_file = stub_dir / "responses"
         _ = responses_file.write_text("\n".join(responses), encoding="utf-8")
         return stub_dir, {
+            "CLAUDE_GH_BIN": str(stub),
             "GH_STUB_RESPONSES": str(responses_file),
             "GH_STUB_INDEX": str(stub_dir / "index"),
         }

--- a/hooks/post-bash/tests/scribe_prompt_test.py
+++ b/hooks/post-bash/tests/scribe_prompt_test.py
@@ -75,8 +75,7 @@ class TestScribePrompt(unittest.TestCase):
 
     def gh_stub_dir(self, responses: list[str]) -> tuple[Path, dict[str, str]]:
         """A directory holding the fake `gh`, plus the env vars it reads its queue from.
-        `CLAUDE_GH_BIN` points the hook at this stub: scribe_trigger resolves gh by absolute
-        path, since a hook starts with PATH cut down and a bare name would not resolve."""
+        `CLAUDE_GH_BIN` is the injection point, since scribe_trigger resolves gh by path."""
         stub_dir = self.root / "gh-stub"
         stub_dir.mkdir()
         stub = stub_dir / "gh"


### PR DESCRIPTION
## What & Why

hook から `gh` を絶対パスで解決し、`gh` の失敗を握る。

再起動して実測したところ、`git pull` を打っても促しが出なかった。原因は hook が PATH を切り詰められて起動するため、bare な `gh` が `FileNotFoundError` で落ちていたこと。例外が出ると `additionalContext` も stamp も出ないので、何も起きなかったのと同じ姿になる。

`git` は `/usr/bin/git` にあるので `find()` は通り、`gh` を呼ぶ `should_prompt` の中で落ちていた。

## Review focus

- `DEFAULT_GH` を定数に置き `CLAUDE_GH_BIN` で上書きできる形。`hooks/lifecycle/recall_index.py` が `recall` に対して取っている形と同じ (`DEFAULT_RECALL` + `CLAUDE_RECALL_BIN`)
- `gh` の非ゼロ終了と壊れた JSON も握る判断。認証切れやネットワーク断はどれも backlog が待っていることを意味しない

## Changes

- `hooks/_lib/scribe_trigger.py` が `gh` を絶対パスで解決する。実行可能でなければ促さずに終わる
- `should_prompt` が `OSError` / `CalledProcessError` / `JSONDecodeError` を握る
- テストの gh スタブを PATH 前置から `CLAUDE_GH_BIN` へ変える

## Scope

- Not included: 他の hook が呼ぶ外部コマンド。`gates` などは PATH 上のコマンドとして登録されており、Claude Code が解決する
- Not included: `DEFAULT_GH` のパスを環境に依らない形にすること。`/opt/homebrew/bin/gh` は Homebrew 前提だが、`CLAUDE_GH_BIN` で上書きできる

## Design Decisions

- 例外を握って `False` を返す。hook が raise すると普通の `git pull` がエラー報告になる。促さないだけなら実害がない
- PATH が切り詰められる件は `hook_payload.py`、`gh_filing.py`、`rust_target.py` のコメントに既にあった。ただし python のバージョン問題としてだけ書かれており、外部コマンドの解決には当てられていなかった

## How to Test

1. `python3 hooks/_lib/tests/scribe_trigger_test.py` が 13 tests OK
2. `python3 hooks/post-bash/tests/scribe_prompt_test.py` が 5 tests OK
3. `env -i /usr/bin/python3 hooks/post-bash/scribe_prompt.py <<< '{"tool_input":{"command":"git pull"},"tool_response":{"interrupted":false}}'` が例外なく exit 0
4. 通常環境で同じ入力を渡すと `additionalContext` が出る

## Related

- #505 で入れた hook が実運用で動いていなかった。#519 (実行権限) に続く 2 件目
