### PR TITLE
fix(hooks): cd のチルダを展開する

### DIFF
--- a/hooks/_lib/scribe_trigger.py
+++ b/hooks/_lib/scribe_trigger.py
@@ -40,7 +40,8 @@ def find(command: str) -> Path | None:
     directory = Path.cwd()
     for tokens in command_scan.commands(command):
         if tokens[0] == "cd" and len(tokens) > 1:
-            directory = directory / tokens[1]
+            # `cd ~/.claude` is what the shell expands, not a directory named `~`.
+            directory = directory / Path(tokens[1]).expanduser()
             continue
         if command_scan.starts_with(tokens, ["git", "pull"]):
             return directory

--- a/hooks/_lib/tests/scribe_trigger_test.py
+++ b/hooks/_lib/tests/scribe_trigger_test.py
@@ -32,6 +32,11 @@ class TestFind(unittest.TestCase):
         """`git push` は取り込む動作ではないので何も返らない"""
         self.assertIsNone(scribe_trigger.find("git push origin main"))
 
+    def test_cd_チルダ_は_ホーム_へ展開される(self) -> None:
+        """`cd ~/.claude && git pull` は実際に打たれる形。展開しないと存在しない
+        `<cwd>/~/.claude` を指し、docs/wiki の判定が必ず外れる"""
+        self.assertEqual(scribe_trigger.find("cd ~/.claude && git pull"), Path.home() / ".claude")
+
     def test_cd_path_to_repo_git_pull_は_cd_先を対象にする(self) -> None:
         """`cd /path/to/repo; git pull` は cd 先を対象にする"""
         self.assertEqual(scribe_trigger.find("cd /path/to/repo; git pull"), Path("/path/to/repo"))


### PR DESCRIPTION
## What & Why

`find()` の `cd` 追跡でチルダを展開する。

`cd ~/.claude && git pull` が `<cwd>/~/.claude` を指していた。存在しないディレクトリなので `docs/wiki` の判定が必ず外れ、促しが出なかった。実際に打たれるのはこの形なので、この経路が死んでいると hook は事実上動かない。

## Review focus

- `Path(tokens[1]).expanduser()` に変えただけ。絶対パスのときは `/` 演算子が左辺を捨てるので、`cd /path/to/repo` の挙動は変わらない

## Changes

- `hooks/_lib/scribe_trigger.py` の `cd` 追跡で `expanduser()` を通す
- `hooks/_lib/tests/scribe_trigger_test.py` にチルダのテストを足す

## Scope

- Not included: `$HOME` や `${HOME}` の展開。実測で打たれているのは `~` の形
- Not included: `cd` 以外のチルダ。`--repo` は対象外にしてある

## How to Test

1. `python3 hooks/_lib/tests/scribe_trigger_test.py` が 14 tests OK
2. `python3 -c "import sys; sys.path.insert(0,'hooks/_lib'); import scribe_trigger; print(scribe_trigger.find('cd ~/.claude && git pull'))"` が `/Users/<user>/.claude` を返す

## 見つけ方

hook にログを仕込んで追った。`called` は出るが `should_prompt` まで届かず、`directory=/Users/thkt/.claude/~/.claude` が出て確定した。stamp では判定できない (sandbox が `~/.cache/` への書き込みを拒否するため、hook が走っても stamp が残らない)。

## Related

- #505 で入れた hook が実運用で動いていなかった。#519 (実行権限)、#522 (gh の PATH) に続く 3 件目
