### PR TITLE
docs(outcome): 同じリポを複数人が回す状態を射程に入れる

### DIFF
--- a/.claude/OUTCOME.md
+++ b/.claude/OUTCOME.md
@@ -8,11 +8,11 @@ AI 開発ハーネスの品質保証を LLM の裁量から決定論的な層へ
 
 - AI agent は、harness が定めた品質ゲート (hook / workflow / reviewer) を裁量で迂回できない状態で開発作業を行う
 - 人間 (thkt) は、AI 成果物の検証を hook と workflow の決定論的な層に委ね、自身は判断が必要な残余のみをレビューする
-- harness は、同じリポジトリへ向けた自動起動が複数の起動元から重なっても、成果物を壊さず、重複した提案を残さない
+- harness は、同じリポジトリへ向けた更新が複数の作業者から重なっても、成果物を壊さず、重複した提案を残さない
 
 ## Non-goals
 
-- チーム他メンバーへの配布や汎用 plugin marketplace 公開を第一目的にしない。個人 harness 最適化が主
+- harness 自体を他メンバーのマシンへ配布することは目指さない。汎用 plugin marketplace への公開もしない
 - Claude Code 本体機能の再実装はしない
 
 ## Constraints


### PR DESCRIPTION
## What & Why

同じリポジトリを複数人が回す状態が射程に入る。`docs/wiki/` と `docs/wiki/_candidates.md` を 2 人が同時に更新しても、成果物が壊れず重複した提案も残らない。

これまで Non-goals が「配布」と「複数人運用」をひとまとめに外していた。そのため複数人を前提にした設計は、Non-goal 領域の変更に見えていた。#527 のロックがその例になる。

## Changes

- Non-goals から複数人運用を外し、harness 自体の配布だけを残す
- Behavior の主語を「複数の起動元」から「複数の作業者」へ移す

## Scope

- Not included: Behavior 2 の主語 (人間 (thkt))。レビュー体制の話であり、今回の射程変更が直接要求するものではない
- Not included: #527 のロックの実装。射程が変わったことでこの issue が生きるが、形は別途

## How to Test

`.claude/OUTCOME.md` の Non-goals と Behavior を読み、複数人運用が Non-goal から外れていることを確認する。
