### PR TITLE
fix(ci): scribe.yml へ id-token write を足す

### DIFF
--- a/.github/workflows/scribe.yml
+++ b/.github/workflows/scribe.yml
@@ -24,6 +24,8 @@ jobs:
       contents: write
       issues: write
       pull-requests: read
+      # claude-code-action exchanges an OIDC token even under OAuth auth.
+      id-token: write
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:


### PR DESCRIPTION
## What & Why

scribe.yml の初回 run (33034918699) が claude の起動前に落ちた。claude-code-action は OAuth 認証でも OIDC トークンを交換し、`id-token: write` permission が無いと `Could not fetch an OIDC token` で失敗する。permissions に 1 行足す。

失敗通知の経路はこの run で検証できた。`if: failure()` の step が #538 へ run URL をコメントしている。

## Changes

- .github/workflows/scribe.yml の permissions へ `id-token: write` を追加

## Scope

- Not included: gate や claude step の変更。gate は should_run=true を正しく返し、checkout も成功している

## How to Test

1. マージ後に `gh workflow run scribe.yml` を実行する
2. Run scribe step が OIDC エラーなしで起動し、claude が Phase 1 に入る
