### PR TITLE
[scribe] 非致命的な入力欠落のstderr報告 を追加/更新

### DIFF
--- a/docs/wiki/script-output-json-stdout-no-banner.md
+++ b/docs/wiki/script-output-json-stdout-no-banner.md
@@ -7,7 +7,7 @@ scenes: ["implement"]
 
 ## 内容
 
-skill や workflow から呼ぶ script の出力は、成功時は JSON 1 つを stdout へ、エラーは stderr へ分離する。banner や絵文字などの装飾は出力から外す。呼び出し側の LLM が結果を機械的にパースする前提であり、人間向けの整形はその判定を誤らせる。
+skill や workflow から呼ぶ script の出力は、成功時は JSON 1 つを stdout へ、エラーは stderr へ分離する。banner や絵文字などの装飾は出力から外す。呼び出し側の LLM が結果を機械的にパースする前提であり、人間向けの整形はその判定を誤らせる。入力の一部を判定で捨てて exit 0 のまま処理を続ける場合も、落ちたことを stderr へ書く。stdout の JSON はキー構成が呼び出し側の契約になっており、そこへ落ちた分を差し込むとキーが増えて契約を壊すため、stderr が報告先になる。
 
 ## 定型手順
 
@@ -15,13 +15,17 @@ skill や workflow から呼ぶ script の出力は、成功時は JSON 1 つを
 2. エラーメッセージは stderr へ書き、exit code で成否を区別する
 3. banner や絵文字、装飾的な区切り線を出力から外す
 4. 呼び出し側 (skill の `allowed-tools`、agent の prompt) が JSON をそのままパースできることを確かめる
+5. 入力の一部を判定で捨てて処理を続けるときは、件数と対象行そのものを stderr へ書く
 
 ## 参照コード
 
 - `skills/scribe/scripts/triage.py` (stdout に JSON、usage エラーは stderr へ書き exit 2)
+- `skills/scribe/scripts/triage.py` の `read_store`（証拠マーカー除去で本文が空になった行を、件数と本文つきで stderr へ出す）
 - `skills/dr/scripts/validate-dr.py` (stdout に `{file, errors, warnings, checks}` の JSON)
 
 ## 根拠
 
 - #13 `/adr` skill 刷新で script 出力を JSON on stdout, errors on stderr, no banners or emoji に統一した
 - #54 `/assert` reviewer の verdict を JSON decision block に分離し、Markdown 散文を非権威化した
+- #533 `read_store` が本文の無い候補行を無言で落とし、落ちたことが stdout の JSON にも stderr にも残らなかった
+- #544 落ちた行の件数と本文を stderr へ出すよう修正した。stdout は 4 キー固定の契約を保ったまま


### PR DESCRIPTION
## 更新したページ

### commit 1: docs(wiki): 非致命的な入力の欠落もstderrへ出す（exit 0のまま黙って進まない） を追加/更新

- `docs/wiki/script-output-json-stdout-no-banner.md`（更新）: 入力の一部を判定で捨てて exit 0 のまま処理を続ける場合も、落ちたことを stderr へ書くという手順を追加。stdout の JSON は呼び出し側の契約になっており、キーを増やせないため stderr が報告先になる旨を明記した。参照コードに `triage.py` の `read_store` を追加し、根拠に #533 #544 を追加した。

## 候補の追加

なし（今回抽出した唯一の共通項は既存ページへの更新で、`docs/wiki/_candidates.md` に変更なし）

## 参照/由来 修復

なし（既存 37 ページの参照コードを全件機械照合し、破損なし。由来リンクを持つ DR (#0059 #0073 #0055 #0042 #0105 #0087 #0081 #0090) は全て status: accepted で supersede なし）

## 読んだ範囲

- PR: #544（前回 scribe マージ 2026-08-27T07:28:27Z 以降にマージされた分。search から `-label:scribe`）
- PR: #545（同上。抽出結果: パターンなし。`rules/conventions/PROSE.md` § Delete the Excess と `agents/reviewers/reviewer-prompt.md` の既存閾値を単一箇所へ適用した一回限りの設計判断であり、新しい共通項ではないと判断した）
- issue: #533, #496（同上の期間で closed）
- research: 0 件（`.claude/workspace/research/*.md` に前回マージ以降の追加/更新なし。リポジトリが shallow clone だったため `git fetch --unshallow` してから確認した）

## 落とした項目

なし

## 持ち越し

なし（`deferred` は空）