### PR TITLE
[Bug] label-from-issue.yml の参照 action が消滅し push ごとに startup failure が積まれる

### DIFF
--- a/.github/workflows/label-from-issue.yml
+++ b/.github/workflows/label-from-issue.yml
@@ -13,16 +13,35 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - name: Apply priority labels
-        uses: stefanbuck/[email protected]
-        with:
-          template: bug.yml
-          section: priority
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Apply priority labels (feature)
-        uses: stefanbuck/[email protected]
-        with:
-          template: feature.yml
-          section: priority
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # Not a marketplace action: stefanbuck/issue-action was deleted from GitHub, and every
+      # push then produced a startup_failure run for this file. The form renders Priority as a
+      # `## Priority` section, so awk over the body needs no dependency to go stale.
+      - name: Apply the priority label the issue form selected
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          body=$(gh issue view "$NUMBER" --repo "$REPO" --json body --jq .body)
+          priority=$(printf '%s\n' "$body" | awk '
+            /^## Priority[[:space:]]*$/ { grab = 1; next }
+            /^## / { grab = 0 }
+            grab && NF { print $1; exit }
+          ')
+          case "$priority" in
+            high|medium|low) ;;
+            *)
+              echo "no priority section in the form body (read: '${priority}'); leaving labels alone"
+              exit 0
+              ;;
+          esac
+          # --remove-label on a label the issue lacks exits non-zero, so the removals are
+          # filtered to the ones actually on the issue before the add.
+          current=$(gh issue view "$NUMBER" --repo "$REPO" --json labels --jq '.labels[].name')
+          for stale in high medium low; do
+            [ "$stale" = "$priority" ] && continue
+            printf '%s\n' "$current" | grep -qx "priority:${stale}" || continue
+            gh issue edit "$NUMBER" --repo "$REPO" --remove-label "priority:${stale}"
+          done
+          gh issue edit "$NUMBER" --repo "$REPO" --add-label "priority:${priority}"


### PR DESCRIPTION
## What & Why

`stefanbuck/issue-action` のリポジトリが GitHub から消えており、workflow を評価できず push のたびに startup failure の run が積まれていた。直近 20 run のうち 8 件が push 起因の failure。issue フォームからの priority ラベル付与も動いていない。

後継候補として issue が挙げた `stefanbuck/advanced-issue-labeler` も `gh api` で 404 を返したので、外部 action への依存を外す方を採った。

## Review focus

- awk が `## Priority` 節の直下の値だけを取り、次の `##` で止まること
- `--remove-label` を issue が実際に持つラベルに絞っていること。持たないラベルを外そうとすると非ゼロ終了し、`set -e` で job が落ちる
- Priority 節を持たない issue で label を触らずに 0 で終わること

## Changes

- `stefanbuck/[email protected]` を使う 2 step を、`gh` で本文を読む 1 step へ置き換えた
- `priority:high` / `priority:medium` / `priority:low` のうち選択されたものだけを残す

## How to Test

1. `gh api repos/stefanbuck/issue-action` が 404 を返すことを確認する
2. マージ後、任意のブランチへ push し、Actions に `label-from-issue.yml` の failure run が増えないことを確認する
3. bug フォームから issue を 1 件立て、選んだ priority のラベルが付くことを確認する
4. その issue を編集して priority を変え、古いラベルが外れて新しいラベルが付くことを確認する

**実機確認 (merge 前は不可)**

startup failure は workflow ファイルが default branch に載って初めて解消するため、2 以降はマージ後に確認する。

## Verification

stub した `gh` に対してスクリプト本体を 2 通り走らせた。

| 入力 | 結果 |
| --- | --- |
| `## Priority` に high、既存ラベル `priority:low` | `--remove-label priority:low` と `--add-label priority:high` の 2 回だけ呼ぶ。exit 0 |
| Priority 節なし | `leaving labels alone` を出し label 編集 0 回。exit 0 |

実 issue 3 件 (#539 / #535 / #507) の本文に awk を掛け、前者 2 件が `medium`、Priority 節を持たない #507 が空を返すことを確認した。

Closes #539