### PR TITLE
[scribe] workflow script の import/export 制約, ja-mirror 同期漏れ を追加/更新

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -27,7 +27,6 @@
 - Python の共有コードは同ディレクトリ sibling import・tree 配下の _lib + sys.path.insert・skills/_lib の CLI 分離の 3 階層で置き場が決まる (research)
 - agentType の bare name 解決は plugin-only install で失敗し、workflow() の sibling 相当のフォールバックが無い (research)
 - build.js の Ship stage は plan スコープ外の tracked file 変更も無条件で commit に含める (research)
-- workflow script は import/export で値を共有できず、定数一致はソーステキスト比較テストでのみ担保する #548
 - severity ランクの引き算は NaN フォールスルーで || チェーンを素通りする #548
 - sort の fixture は補助属性の順がソートキーと偶然一致するとフォールスルー欠陥を検出し損ねる #548
 - issue の Alternatives が却下した粒度に実装が逆戻りし、独立した適合性レビューで検出される #547
@@ -44,6 +43,12 @@
 - bug の root cause 特定後は同一生成工程の兄弟 artifact を洗い出し同種欠陥を検証する (research)
 - 自作 CLI は --help 使用例・JSON 出力・--dry-run が揃って欠ける (research)
 - skill に tool を書いて許可するだけでは使われず、既存手段を明示的に禁止する enforcement 文が要る (research)
+- PR 本文に scope 外のファイル変更を列挙しレビューの焦点を宣言スコープ側に示す #554
+- issue 本文の未確認 premise は tentative と明記する #377
+- 実需が未証明の提案は premise 未確認のまま実装せず、再着手条件を残して close する #377
+- 供給の一覧は実行側の定数で持ち、docstring やインライン辞書リテラルへ分散すると契約が陳腐化する #557
+- seam の受け入れテストが新関数を直接呼ぶだけでは足りず、production の実呼び出し口 (CLI main() 等) も同じ経路を通ることを確認する #558
+- 契約に返り値フィールドを追加するときは、早期 return (stopped) 分岐も含めた全 exit path でそのフィールドを持たせる #562
 
 ## 棄却
 

--- a/docs/wiki/ja-mirror-drift.md
+++ b/docs/wiki/ja-mirror-drift.md
@@ -40,3 +40,5 @@ scenes: []
 - #389 13 テンプレートの骨格見出しが `## テンプレート` と `## Template` に割れていた。issue の parser が literal で探すアンカーなので、`.ja` を骨格として渡すと節が 1 つ増えていた
 - #390 英語側の py が全文書き換えで日本語 prose を失う drift が 4 件あり、逆向きの検出を hook と走査テストへ足した
 - #537 research のカーソル判定を mtime から最終コミット時刻へ書き換えるコミットが英語側の SKILL.md だけを直し、`.ja/skills/scribe/SKILL.md` が旧記述のまま残った。同一 PR 内の後続コミットで .ja 側を追従させて解消した
+- #562 codex-herdr の実装で `workflows/code.js` と `workflows/build.js` の変更はコミット 991d4a19 に含まれたが、対応する `.ja` ミラー編集は同一コミットにも他のどのコミットにも含まれず、未コミットの作業ツリー変更のまま残った
+- #554 `workflows/code.js` の no-plan why メッセージから `args.plan` という識別子を落としたが、`.ja/workflows/code.js` 側の対応する文言は変更前のまま残り、両ツリーで停止メッセージの内容が食い違った

--- a/docs/wiki/workflow-const-source-text-check.md
+++ b/docs/wiki/workflow-const-source-text-check.md
@@ -1,0 +1,28 @@
+---
+globs: ["**/workflows/**/*.js"]
+scenes: ["implement"]
+---
+
+# workflow script は import/export で値を共有できず、定数一致はソーステキスト比較テストでのみ担保する
+
+## 内容
+
+workflow script は `export const meta` の 1 箇所しか import/export を使えず、2 つ目以降の `export` は SyntaxError になる。複数の workflow script が同じ定数 (severity のランク、implementer の許容値など) を共有する必要があっても、モジュールとして共有できない。各ファイルが同じ値を独立して持ち、一致はハードコードした期待値ではなく、両ファイルのソーステキストから定数を抽出して比較するテストで担保する。
+
+## 定型手順
+
+1. 複数の workflow script が同じ定数を持つ必要があるかを確認する
+2. import/export では共有できないため、各ファイルにその定数を独立して定義する
+3. テストは期待値を書き写さず、`readFileSync` で両ファイルのソースを読み、定数を抽出して比較する
+4. 抽出した定数が空でないことも合わせて確認し、抽出自体の失敗を「一致」と誤検出しない
+
+## 参照コード
+
+- `workflows/_lib/run-workflow.js` の `checkWorkflowSyntax`(`^export const meta` 以外の `export` を SyntaxError にする実装)
+- `workflows/audit/tests/audit.routing.test.js` の `parseNumericConst`(`audit.js` と `assert.js` のソースから `SEVERITY_RANK` を抽出し比較する)
+
+## 根拠
+
+- #548 `audit.js` と `assert.js` の `SEVERITY_RANK` をソーステキストから抽出して比較する T-105 を追加した
+- #481 build と code の meta 整理で、workflow script が import/export できず `export const meta` の 1 箇所しか剥がされないため、定数はテスト側からソーステキストで読む前提を明記した
+- #367 `implementer` の定数をテスト側からソーステキストで読む前提を、`workflows/_lib/run-workflow.js:166` の実測 (2 つ目以降の `export` は SyntaxError になる) とともに明記した


### PR DESCRIPTION
## 追加/更新したページ (コミット 1)

- 新規: `docs/wiki/workflow-const-source-text-check.md` — workflow script は import/export で値を共有できず、定数一致はソーステキスト比較テストでのみ担保する (根拠 #548 #481 #367、候補から昇格)
- 更新: `docs/wiki/ja-mirror-drift.md` — #562 (herdr 実装で `.ja` 側が未コミットのまま残った) と #554 (why メッセージの EN 変更が `.ja` 側へ反映されなかった) を根拠に追加

## `_candidates.md` への追加 (単発)

- PR 本文に scope 外のファイル変更を列挙しレビューの焦点を宣言スコープ側に示す #554
- issue 本文の未確認 premise は tentative と明記する #377
- 実需が未証明の提案は premise 未確認のまま実装せず、再着手条件を残して close する #377
- 供給の一覧は実行側の定数で持ち、docstring やインライン辞書リテラルへ分散すると契約が陳腐化する #557
- seam の受け入れテストが新関数を直接呼ぶだけでは足りず、production の実呼び出し口 (CLI main() 等) も同じ経路を通ることを確認する #558
- 契約に返り値フィールドを追加するときは、早期 return (stopped) 分岐も含めた全 exit path でそのフィールドを持たせる #562

## 参照 / 由来修理

なし。Phase 4 で `docs/wiki/*.md` 全ページの参照コード (path + symbol) を機械的に検査したが壊れはゼロだった (`posttooluse-agent-launch-only.md` の `hooks.PostToolUse` は dot-path 表記の false positive で、実体は `settings.json` に存在する)。Phase 5 で全ページの由来リンクが指す DR (8 件) も確認し、いずれも `accepted` で supersede なし。

## 読んだ範囲

- 前回 scribe PR #564 の mergedAt (2026-08-27T11:32:02Z) 以降にマージされた scribe ラベル以外の PR: #554, #557, #558, #562
- 同期間に closed した issue: #367, #377, #459, #481, #532
- research: 0 件 (`.claude/workspace/research/*.md` に該当期間の追加・更新なし)

## Phase 4 で落とした項目

なし

## 持ち越し

なし (deferred は空)