### PR TITLE
[scribe] reference_module ポインタ欠落、変更起因でないテスト失敗の明示 を追加/更新

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -53,7 +53,8 @@
 - grep によるコード内出現検査は、コメントや文字列リテラル内の一致を除外しないと偽陽性になる #571
 - 個別の名前付き受け入れテストを全量一括検査へ吸収すると、独立した追跡可能性を失う #575
 - 新しい .ja ミラー対を追加する script は、同ファイル内の MIRRORED_PAIRS 等の回帰リストへも同一コミットで登録しないと、その対だけ行一致を守る自動テストの対象外のまま残る #577
-- plan が reference_module に指定した既存 skill の構造 (SKILL.md の phase 記載、templates/ のテンプレファイル) は、コード呼び出し列の一致だけでは揃わず、新規追加した script や report section の SKILL.md 未記載・template 欠如が merge まで残る #577
+- hako.sh の run_agent/run_login は agents.sh の agent 名検証より前に workspace 解決 (git clone) を実行し、validate-then-assemble の順序を逆転させている。未知の agent 名でも検証失敗前にクローンの副作用が生じ、後始末もされない #556
+- 参照モジュールが 1 ファイル内で T-NNN を T-001 から再採番する規約を持つとき、新規追加した複数ファイルに渡って単一の連番を通すと、後続ファイルがどこも T-001 から採番されない構造逸脱として検出される #556
 
 ## 棄却
 

--- a/docs/wiki/pre-existing-failure-disclosure.md
+++ b/docs/wiki/pre-existing-failure-disclosure.md
@@ -24,3 +24,5 @@ PR の verify でテストが失敗したとき、その PR の変更に起因�
 - #222 verify 出力に「deliberate manual-acceptance gate、not a code defect、no fix was attempted」と記録した
 - #226「fail 2 件は EN/JA 同一の manual acceptance gate で、変更前から赤」と明記した
 - #548 #549 pyright の全リポジトリ実行が対象ブランチと無関係な既存 11 件のエラーで exit 1 になることを、対象外ファイルの列挙とともに verify 節で明示した
+- #581 pyright 27 件のエラーを、ブランチ自身のコミットより前に対象ファイルが最後に触られたことを commit 履歴で確認し、pre-existing baseline findings であって regression でないと verify 節に明記した
+- #556 pyright 11 件のエラーを、対象ファイルが 2026-08-23 以前のコミットで最後に触られたことをもとに pre-existing と分類し、修正を行わなかった旨を verify 節に明記した

--- a/docs/wiki/reference-module-pointer-gap.md
+++ b/docs/wiki/reference-module-pointer-gap.md
@@ -1,0 +1,27 @@
+---
+globs: ["skills/**/SKILL.md", "skills/**/references/*.md", "skills/**/templates/*.md"]
+scenes: ["pr-create"]
+---
+
+# reference_module を複製した新規ファイルへ SKILL.md がポインタを持たない
+
+## 内容
+
+plan の `reference_module` (kind: module) が指す既存 skill の構造を複製するとき、参照元と同じ役割のファイルを新規作成しただけでは足りない。参照元の SKILL.md がその役割のファイルへ本文中で明示的なポインタ (節見出しやパス言及) を持っているなら、複製先の SKILL.md にも同じ形のポインタが要る。無いと、ファイルは作られていても呼び出し元の本文だけを読む読者やエージェントからは辿れない状態のまま merge される。
+
+## 定型手順
+
+1. `reference_module` (kind: module) が指す既存 skill の SKILL.md を読み、複製する各ファイル (references/、templates/ 配下) について、本文中に明示的なポインタ (節見出し、パスの言及) があるかを確認する
+2. 複製先の SKILL.md 本体に、同じ形のポインタが実在するかを `grep` で確認する
+3. ポインタが無ければ、SKILL.md へポインタを足す。列や骨格の内容そのものを重複させず、ファイルへの参照だけを書く
+4. conformance レビューがこの欠落を Missing/partial として検出できるよう、reference_module の記述に「呼び出し元 SKILL.md からの到達可能性」を含める
+
+## 参照コード
+
+- `agents/reviewers/reviewer-conformance.md` の Missing/partial（spec が求める記述が本文に欠けている場合を検出する区分）
+- `skills/think/templates/plan.md` の Reference module（files/conventions は複製するファイル一覧を持つが、呼び出し元 SKILL.md からの到達性は検査しない）
+
+## 根拠
+
+- #577 plan が reference_module に指定した既存 skill の構造を複製する際、新規追加した script や report section が SKILL.md に未記載のまま merge まで残った
+- #582 census が SKILL.md 内で `references/decision-criteria.md` と `templates/report-template.md` へ明示的なポインタを持つのに対し、ablate の SKILL.md (本差分では未変更) は新規作成した `references/measurement-criteria.md` と `templates/report-template.md` のどちらにも一度も言及せず、独立した conformance レビューが Missing/partial として検出した


### PR DESCRIPTION
## 追加/更新したページ (commit 1)

- `docs/wiki/reference-module-pointer-gap.md`（新規、candidate `#577` から昇格）: plan の reference_module (kind: module) が複製元 skill の SKILL.md ポインタを、複製先が持たないまま merge される件。根拠 #577, #582
- `docs/wiki/pre-existing-failure-disclosure.md`（更新）: 変更起因でないテスト失敗を verify 節で切り分ける運用に、新規根拠 #581, #556 を追加

## candidate への追加

- hako.sh の run_agent/run_login が agents.sh の agent 名検証より前に workspace 解決 (git clone) を実行する validate-then-assemble 順序逆転 (#556)
- 参照モジュールの T-NNN 採番規約 (ファイルごとに T-001 から再開) を、複数ファイルに渡る単一連番へ置き換えると構造逸脱として検出される (#556)

## 参照/由来の修復

なし。既存 46 ページ全件の参照コードを機械的に確認し、壊れた参照・superseded な由来リンクは無かった。`workflow-structure.md` (kind: structure) の境界/契約/要求も現行コードと突き合わせ、乖離なし。

## スコープ

- 読んだ PR: #556, #581, #582 (mergedAt 範囲 2026-08-27T17:24 - 2026-08-27T18:47)
- 読んだ issue: #468, #483, #488, #489
- 読んだ research ファイル: 33件 (`.claude/workspace/research/*.md`)

## 検証で落とした項目

なし

## 持ち越し

なし (昇格待ちへの繰り越しは発生しなかった)