### PR TITLE
docs(ablate): 削除の実行を retire-rename へ引き継ぐ行を足す

### DIFF
--- a/.ja/skills/ablate/SKILL.md
+++ b/.ja/skills/ablate/SKILL.md
@@ -45,11 +45,11 @@ python3 -c 'import sys; sys.path.insert(0, "skills/ablate/scripts"); sys.path.in
 
 ## Output
 
+レポートが名指したものを実際に外すのは別の実行。削除候補は `docs/wiki/retire-rename-procedure.md` へ渡す。retire で失われる検出層と、それを復活させる判断トリガーはそちらが持つ。この skill は判定までで止まる。
+
 | 項目           | 内容                                                |
 | -------------- | --------------------------------------------------- |
 | レポートのパス | `write_report` が返したパス                         |
 | 削除候補       | レポートの Delete Candidates 節。0 件のときはその旨 |
 | 測定できた数   | Verdicts 節のうち `unmeasured` でない行数           |
 | Usage          | 各要素の発火回数と最終使用日。Harness Elements 内   |
-
-レポートが名指したものを実際に外すのは別の実行。削除候補は `docs/wiki/retire-rename-procedure.md` へ渡す。retire で失われる検出層と、それを復活させる判断トリガーはそちらが持つ。この skill は判定までで止まる。

--- a/.ja/skills/ablate/SKILL.md
+++ b/.ja/skills/ablate/SKILL.md
@@ -51,3 +51,5 @@ python3 -c 'import sys; sys.path.insert(0, "skills/ablate/scripts"); sys.path.in
 | 削除候補       | レポートの Delete Candidates 節。0 件のときはその旨 |
 | 測定できた数   | Verdicts 節のうち `unmeasured` でない行数           |
 | Usage          | 各要素の発火回数と最終使用日。Harness Elements 内   |
+
+レポートが名指したものを実際に外すのは別の実行。削除候補は `docs/wiki/retire-rename-procedure.md` へ渡す。retire で失われる検出層と、それを復活させる判断トリガーはそちらが持つ。この skill は判定までで止まる。

--- a/skills/ablate/SKILL.md
+++ b/skills/ablate/SKILL.md
@@ -51,3 +51,5 @@ python3 -c 'import sys; sys.path.insert(0, "skills/ablate/scripts"); sys.path.in
 | Delete candidates | The report's Delete Candidates section, or that there are none    |
 | Measured count    | Rows in Verdicts that are not `unmeasured`                        |
 | Usage             | Each element's fire count and last-used date, in Harness Elements |
+
+Removing anything the report names is a separate run: hand the delete candidates to `docs/wiki/retire-rename-procedure.md`, which owns the detection layer a retirement loses and the trigger for reviving it. This skill stops at the verdict.

--- a/skills/ablate/SKILL.md
+++ b/skills/ablate/SKILL.md
@@ -45,11 +45,11 @@ python3 -c 'import sys; sys.path.insert(0, "skills/ablate/scripts"); sys.path.in
 
 ## Output
 
+Removing anything the report names is a separate run: hand the delete candidates to `docs/wiki/retire-rename-procedure.md`, which owns the detection layer a retirement loses and the trigger for reviving it. This skill stops at the verdict.
+
 | Item              | Content                                                           |
 | ----------------- | ----------------------------------------------------------------- |
 | Report path       | The path `write_report` returned                                  |
 | Delete candidates | The report's Delete Candidates section, or that there are none    |
 | Measured count    | Rows in Verdicts that are not `unmeasured`                        |
 | Usage             | Each element's fire count and last-used date, in Harness Elements |
-
-Removing anything the report names is a separate run: hand the delete candidates to `docs/wiki/retire-rename-procedure.md`, which owns the detection layer a retirement loses and the trigger for reviving it. This skill stops at the verdict.


### PR DESCRIPTION
## What & Why

#473 の受け入れ基準「削除候補が根拠つきで `docs/audit/` のレポートに出力され、削除の実行は `docs/wiki/retire-rename-procedure.md` へ引き継がれる」の後半が満たされていなかった。`origin/main` の `skills/ablate/` 配下を全ファイル走査して `retire-rename` の言及 0 件を実測した。

## Changes

- `skills/ablate/SKILL.md` の Output 節の下に、削除候補を `docs/wiki/retire-rename-procedure.md` へ渡す 1 文を足す。この skill が判定で止まることを併記
- `.ja/` ミラーへ同じ内容を反映

## How to Test

1. `node --test "skills/ablate/tests/*.test.js"`
2. `npx rumdl check skills/ablate/SKILL.md` と `npx textlint .ja/skills/ablate/SKILL.md`

Closes #473