### PR TITLE
ci(test): 失敗時だけ git の gc 設定を出す

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,19 @@ jobs:
       - name: Python tests
         run: find agents hooks skills workflows -name '*_test.py' -print0 | xargs -0 -r -n1 python3
 
+      # Runs only on a failed suite (#589). A test that builds a git repo under
+      # tempfile.TemporaryDirectory has failed here in teardown with
+      # "Directory not empty: 'pack'", and the same commit passed on rerun. The values below
+      # are the ones a local run cannot observe: macOS reproduced 0 failures in 20 runs.
+      - name: git settings on failure
+        if: failure()
+        run: |
+          git --version
+          echo "gc.auto=$(git config --get gc.auto || echo unset)"
+          echo "gc.autoDetach=$(git config --get gc.autoDetach || echo unset)"
+          echo "TMPDIR=${TMPDIR:-unset}"
+          find "${TMPDIR:-/tmp}" -maxdepth 4 -name pack -path '*objects*' -exec ls -la {} +
+
       # glob でなく find なのは、bash 3.2 に globstar が無く ** の階層解釈が版で割れるため。
       # Python tests と同じ形で、階層が増えても suite を落とさない。-t が実行行を stderr へ出す。
       - name: Shell tests


### PR DESCRIPTION
## What & Why

#589 の 1 つ目の受け入れ基準を満たす。原因の推測に基づく修正は含まない。

テストの後始末が `OSError: [Errno 39] Directory not empty: 'pack'` で落ちたとき、切り分けに要る値が runner 上に残らない。ローカルの macOS では `python3 skills/scribe/tests/verify_run_test.py` を 20 回連続で走らせて失敗 0 件で、機序は CI 側でしか観測できない。

## Changes

- `.github/workflows/test.yml` の Python tests の直後へ `git settings on failure` ステップを足す。`if: failure()` を付けたので green な run には何も足さない
- 出す値は `git --version`、`gc.auto`、`gc.autoDetach`、`TMPDIR`、`$TMPDIR` 配下に残った `objects/*/pack` の中身

## Design Decisions

- `gc.auto=0` をテストの環境変数へ入れる案は採らなかった。ローカルで再現しないため、入れても直ったかどうかを確かめる手段が今は無い。#589 の Constraints に「機序が確定するまで修正を当てない」と書いたとおり、観測を先に置く
- 診断を常時実行でなく `if: failure()` にした。green な run の出力を増やすと、本当に読みたい失敗時の出力が埋もれる

## How to Test

1. `uvx --from pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` で YAML が解釈できる
2. `run` ブロックを取り出して `bash -n` に通すと構文エラーが出ない
3. CI が green な run でこのステップを飛ばす
