### PR TITLE
workflow スクリプトを Codex 上で実行する runner を追加する

### DIFF
--- a/.ja/rules/conventions/WORKFLOWS.md
+++ b/.ja/rules/conventions/WORKFLOWS.md
@@ -18,7 +18,7 @@ paths:
 | スクリプトのファイル名 | `workflows/<name>.js`。`<name>` がそのまま `Workflow({name})` で解決される名前                    |
 | name の形              | 英単語 1 語で、workflow が行う操作を表す。helper, utils, tools のような汎用名は操作名へ置き換える |
 | 補助スクリプト         | `workflows/<name>/` へ置く。直下へ `.js` を置くと、補助のつもりでも workflow として登録される     |
-| 共有ハーネス           | `workflows/_lib/` へ置く。テストから import する用途に限る                                        |
+| 共有ハーネス           | `workflows/_lib/` へ置く。テストが import するものと、別ホストで script を評価する runner に限る  |
 
 ## 参照記法
 

--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,9 @@
     "skills/**/*.{js,mjs}",
     ".ja/skills/**/*.{js,mjs}"
   ],
+  "ignoreBinaries": [
+    "codex"
+  ],
   "ignoreDependencies": [
     "oxfmt",
     "^@?textlint"

--- a/rules/conventions/WORKFLOWS.md
+++ b/rules/conventions/WORKFLOWS.md
@@ -18,7 +18,7 @@ Discovery reads `workflows/` flat and registers only the `.js` files directly un
 | Script filename   | `workflows/<name>.js`. That `<name>` is the name `Workflow({name})` resolves                                                         |
 | Shape of the name | One English word naming the operation the workflow performs. Replace generic names like helper, utils, tools with the operation name |
 | Helper script     | Place under `workflows/<name>/`. A `.js` directly under `workflows/` registers as a workflow                                         |
-| Shared harness    | Place under `workflows/_lib/`. Limited to the use imported from tests                                                                |
+| Shared harness    | Place under `workflows/_lib/`. Limited to what tests import and to a runner that evaluates the scripts on another host               |
 
 ## Reference notation
 

--- a/workflows/_lib/codex-run.js
+++ b/workflows/_lib/codex-run.js
@@ -1,12 +1,9 @@
-#!/usr/bin/env node
 // Runs a workflow script (workflows/<name>.js) on Codex.
 //
 // Claude Code supplies agent() from its own subagent runtime. Codex has no equivalent, so
 // each agent() call becomes one `codex exec` child process here. The rest of the evaluation
 // form -- the vm context, the banned Date / Math globals, parallel and pipeline semantics --
 // is reused from run-workflow.js, which already reproduces what production does.
-//
-// Usage: node workflows/_lib/codex-run.mjs <workflow> --repo <abs path> [--issue N] [--base B]
 import { spawn } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { availableParallelism, tmpdir } from "node:os";
@@ -14,7 +11,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { runWorkflow } from "./run-workflow.js";
 
-export const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
 // build.js and code.js name only haiku and sonnet. The three tiers line up with Codex's
 // current-generation coding models; one CODEX_MODEL_<TIER> variable overrides one entry.
@@ -58,6 +55,10 @@ const acceptsNull = (schema) => {
 
 const described = (schema, description) => (description ? { ...schema, description } : schema);
 
+// An object or array schema that also declared null keeps that branch around the rewritten form.
+const keepNullBranch = (out, includesNull, description) =>
+  includesNull ? described(nullable(out), description) : out;
+
 export function strictify(schema) {
   if (!schema || typeof schema !== "object") return schema;
 
@@ -81,12 +82,12 @@ export function strictify(schema) {
       },
       schema.description,
     );
-    return typeIncludesNull ? described(nullable(out), schema.description) : out;
+    return keepNullBranch(out, typeIncludesNull, schema.description);
   }
 
   if (bare.includes("array")) {
     const out = described({ type: "array", items: strictify(schema.items) }, schema.description);
-    return typeIncludesNull ? described(nullable(out), schema.description) : out;
+    return keepNullBranch(out, typeIncludesNull, schema.description);
   }
 
   if (!typeIncludesNull) return { ...schema };
@@ -159,6 +160,21 @@ export function findSchemaViolation(value, schema, path = "") {
   if (value === null && !acceptsNull(schema)) return `${here} is null`;
   return "";
 }
+
+// ---- Prompt assembly --------------------------------------------------------------------
+// Every string codex reads is built here, so changing what an agent is told does not mean
+// reading through the stage loop.
+
+// The agent definition carries the behavior and the workflow script carries the task. The rule
+// keeps them apart so the model does not read the task as one more clause of the behavior.
+const withPreamble = (preamble, prompt) => (preamble ? `${preamble}\n\n---\n\n${prompt}` : prompt);
+
+// findSchemaViolation names a required field that came back missing or null, so the retry asks
+// for that field to be filled. Asking instead for extra fields to be dropped answers a
+// violation the strict-mode schema cannot produce.
+const schemaCorrection = (reason) =>
+  `\n\nThe previous attempt returned a value that did not fit the output schema (${reason}). ` +
+  `Answer again with every declared field filled, using null only where the schema allows it.`;
 
 // ---- Agent definitions -----------------------------------------------------------------
 // agentType names a Claude Code subagent. general-purpose is a Claude Code built-in with no
@@ -301,7 +317,7 @@ export function createStubs({ repo, concurrency = DEFAULT_CONCURRENCY, onLog = (
       const outPath = join(tmp, `out-${id}.json`);
       if (opts.schema) writeFileSync(schemaPath, JSON.stringify(strictify(opts.schema)));
 
-      const base = preamble ? `${preamble}\n\n---\n\n${prompt}` : prompt;
+      const base = withPreamble(preamble, prompt);
       let correction = "";
 
       for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
@@ -345,9 +361,7 @@ export function createStubs({ repo, concurrency = DEFAULT_CONCURRENCY, onLog = (
           return value;
         } catch (err) {
           onLog(`[${label}] response did not fit the schema: ${err.message}`);
-          correction =
-            `\n\nThe previous attempt returned a value that did not fit the output schema ` +
-            `(${err.message}). Return only the fields the schema declares.`;
+          correction = schemaCorrection(err.message);
         }
       }
       // The Agent tool returns null when a subagent dies after its retries, and the workflow
@@ -373,7 +387,7 @@ export function createStubs({ repo, concurrency = DEFAULT_CONCURRENCY, onLog = (
   return stubs;
 }
 
-export async function runOnCodex(name, args, { concurrency, onLog = () => {} } = {}) {
+async function runOnCodex(name, args, { concurrency, onLog = () => {} } = {}) {
   const path = resolveWorkflowPath(name);
   const tmp = mkdtempSync(join(process.env.TMPDIR || tmpdir(), "codex-run-"));
   try {
@@ -424,7 +438,7 @@ if (invokedDirectly) {
   const { name, args, concurrency } = parseArgv(process.argv.slice(2));
   if (!name || !args.repo) {
     process.stderr.write(
-      "usage: node workflows/_lib/codex-run.mjs <workflow> --repo <abs path> " +
+      "usage: node workflows/_lib/codex-run.js <workflow> --repo <abs path> " +
         "[--issue N] [--base B] [--concurrency N] [--args <json>]\n",
     );
     process.exit(2);

--- a/workflows/_lib/codex-run.mjs
+++ b/workflows/_lib/codex-run.mjs
@@ -1,0 +1,437 @@
+#!/usr/bin/env node
+// Runs a workflow script (workflows/<name>.js) on Codex.
+//
+// Claude Code supplies agent() from its own subagent runtime. Codex has no equivalent, so
+// each agent() call becomes one `codex exec` child process here. The rest of the evaluation
+// form -- the vm context, the banned Date / Math globals, parallel and pipeline semantics --
+// is reused from run-workflow.js, which already reproduces what production does.
+//
+// Usage: node workflows/_lib/codex-run.mjs <workflow> --repo <abs path> [--issue N] [--base B]
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { availableParallelism, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { runWorkflow } from "./run-workflow.js";
+
+export const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// build.js and code.js name only haiku and sonnet. The three tiers line up with Codex's
+// current-generation coding models; one CODEX_MODEL_<TIER> variable overrides one entry.
+export const MODEL_MAP = {
+  haiku: process.env.CODEX_MODEL_HAIKU || "gpt-5.6-luna",
+  sonnet: process.env.CODEX_MODEL_SONNET || "gpt-5.6-terra",
+  opus: process.env.CODEX_MODEL_OPUS || "gpt-5.6-sol",
+};
+
+const DEFAULT_EFFORT = process.env.CODEX_EFFORT || "medium";
+// A stage that writes code takes longer than one that relays a value, so the ceiling is set
+// for the slowest stage rather than per label.
+const DEFAULT_TIMEOUT_MS = Number(process.env.CODEX_TIMEOUT_MS || 1_800_000);
+// Claude caps in-process agents at min(16, cpus - 2). Child processes carry no such cap, so
+// pipeline() over a long unit list would spawn one codex per unit at once without this.
+const DEFAULT_CONCURRENCY = Math.max(1, Math.min(16, availableParallelism() - 2));
+// One retry, because the failures worth retrying (a dropped connection, a response that
+// misses the schema) do not repeat on every attempt.
+const ATTEMPTS = 2;
+
+// ---- Schema translation ----------------------------------------------------------------
+// codex exec --output-schema runs OpenAI structured outputs in strict mode, which rejects a
+// schema whose `required` omits any declared property:
+//   'required' is required to be supplied and to be an array including every key in properties.
+// The workflow scripts write `required` as a subset on purpose (obj(required, properties)),
+// so every optional property is made required and nullable here instead, and the nulls are
+// dropped again before the value reaches the script.
+
+const NULL_SCHEMA = { type: "null" };
+const nullable = (schema) => ({ anyOf: [schema, NULL_SCHEMA] });
+
+const typeList = (type) => (Array.isArray(type) ? type : [type]);
+
+// A schema declaring neither a type nor a shape constrains nothing, so a null under it is a
+// value rather than a violation.
+const acceptsNull = (schema) => {
+  if (!schema || typeof schema !== "object") return true;
+  if (typeList(schema.type).includes("null")) return true;
+  return schema.type === undefined && !schema.properties && !schema.items;
+};
+
+const described = (schema, description) => (description ? { ...schema, description } : schema);
+
+export function strictify(schema) {
+  if (!schema || typeof schema !== "object") return schema;
+
+  const types = typeList(schema.type);
+  const typeIncludesNull = types.includes("null");
+  const bare = types.filter((t) => t !== "null");
+
+  if (bare.includes("object") || schema.properties) {
+    const properties = {};
+    const originallyRequired = new Set(schema.required || []);
+    for (const [key, value] of Object.entries(schema.properties || {})) {
+      const translated = strictify(value);
+      properties[key] = originallyRequired.has(key) ? translated : nullable(translated);
+    }
+    const out = described(
+      {
+        type: "object",
+        additionalProperties: false,
+        required: Object.keys(properties),
+        properties,
+      },
+      schema.description,
+    );
+    return typeIncludesNull ? described(nullable(out), schema.description) : out;
+  }
+
+  if (bare.includes("array")) {
+    const out = described({ type: "array", items: strictify(schema.items) }, schema.description);
+    return typeIncludesNull ? described(nullable(out), schema.description) : out;
+  }
+
+  if (!typeIncludesNull) return { ...schema };
+  const scalar = { ...schema, type: bare.length === 1 ? bare[0] : bare };
+  return described(nullable(scalar), schema.description);
+}
+
+// The inverse of the optional-to-nullable rewrite: a null standing where the original schema
+// declared an optional property is the absence the script expects, so the key is removed. A
+// null under a property the original marked required is a real value and stays.
+export function pruneNulls(value, schema) {
+  if (!schema || typeof schema !== "object" || value === null || typeof value !== "object") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    if (!schema.items) return value;
+    return value.map((item) => pruneNulls(item, schema.items));
+  }
+
+  const types = typeList(schema.type);
+  if (types.includes("object") || schema.properties) {
+    const required = new Set(schema.required || []);
+    const out = {};
+    for (const [key, child] of Object.entries(value)) {
+      if (child === null && !required.has(key)) continue;
+      out[key] = pruneNulls(child, (schema.properties || {})[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+// Strict mode makes every property required and nullable, so the API is free to answer null
+// where the original schema requires a value. A null reaching the script is not the absence
+// the script branches on: build.js's oversizedUnits reads u.files.length, and a null there
+// throws inside the vm as a run failure rather than a recorded degradation. This walks the
+// original schema and names the first such spot, which the caller turns into a retry.
+export function findSchemaViolation(value, schema, path = "") {
+  if (!schema || typeof schema !== "object") return "";
+  const here = path || "the response";
+  const types = typeList(schema.type);
+
+  if (types.includes("array") || schema.items) {
+    if (value === null) return acceptsNull(schema) ? "" : `${here} is null`;
+    if (!Array.isArray(value)) return `${here} is not an array`;
+    for (let index = 0; index < value.length; index++) {
+      const found = findSchemaViolation(value[index], schema.items, `${here}[${index}]`);
+      if (found) return found;
+    }
+    return "";
+  }
+
+  if (types.includes("object") || schema.properties) {
+    if (value === null) return acceptsNull(schema) ? "" : `${here} is null`;
+    if (typeof value !== "object") return `${here} is not an object`;
+    const properties = schema.properties || {};
+    for (const key of schema.required || []) {
+      const childPath = path ? `${path}.${key}` : key;
+      if (!(key in value)) return `${childPath} is missing`;
+      if (value[key] === null && !acceptsNull(properties[key])) return `${childPath} is null`;
+    }
+    for (const [key, child] of Object.entries(value)) {
+      const found = findSchemaViolation(child, properties[key], path ? `${path}.${key}` : key);
+      if (found) return found;
+    }
+    return "";
+  }
+
+  if (value === null && !acceptsNull(schema)) return `${here} is null`;
+  return "";
+}
+
+// ---- Agent definitions -----------------------------------------------------------------
+// agentType names a Claude Code subagent. general-purpose is a Claude Code built-in with no
+// file in this repository, and a bare `codex exec` was measured returning a 611-character
+// issue body verbatim under a strict schema, so that type takes no preamble. The rest carry
+// their behavior in agents/**/<name>.md, whose body becomes the preamble.
+
+const WRITE_TOOLS = /\b(Edit|Write|NotebookEdit|MultiEdit)\b/;
+
+let agentIndex = null;
+const indexAgents = () => {
+  if (agentIndex) return agentIndex;
+  agentIndex = new Map();
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.name.endsWith(".md")) agentIndex.set(entry.name.replace(/\.md$/, ""), full);
+    }
+  };
+  const agentsDir = join(ROOT, "agents");
+  if (existsSync(agentsDir)) walk(agentsDir);
+  return agentIndex;
+};
+
+export function loadAgent(agentType) {
+  if (!agentType || agentType === "general-purpose") return { preamble: "", readOnly: false };
+  const path = indexAgents().get(agentType);
+  // A missing definition is not a reason to stop the run, so the stage proceeds with the
+  // prompt alone and the caller logs the loss.
+  if (!path) return { preamble: "", readOnly: false, missing: true };
+
+  const source = readFileSync(path, "utf8");
+  const match = source.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+  const frontmatter = match ? match[1] : "";
+  const body = match ? match[2] : source;
+  const tools = (frontmatter.match(/^tools:\s*(.*)$/m) || [])[1] || "";
+  // Codex cannot enforce a per-tool allowlist. A definition granting no write tool runs under
+  // the read-only sandbox, which is the closest approximation of that allowlist.
+  return { preamble: body.trim(), readOnly: Boolean(tools) && !WRITE_TOOLS.test(tools) };
+}
+
+// ---- codex exec ------------------------------------------------------------------------
+
+const runCodexOnce = ({ prompt, model, effort, schemaPath, outPath, sandbox, cwd, timeoutMs }) =>
+  new Promise((done) => {
+    const argv = [
+      "exec",
+      "--skip-git-repo-check",
+      "-C",
+      cwd,
+      "-s",
+      sandbox,
+      "-c",
+      'approval_policy="never"',
+      "-m",
+      model,
+      "-c",
+      `model_reasoning_effort="${effort}"`,
+    ];
+    // gh and git push reach the network, which the workspace-write sandbox blocks by default.
+    if (sandbox === "workspace-write") {
+      argv.push("-c", "sandbox_workspace_write.network_access=true");
+    }
+    if (schemaPath) argv.push("--output-schema", schemaPath);
+    // `-` reads the prompt from stdin, which keeps an issue body or a JSON payload off argv.
+    argv.push("-o", outPath, "-");
+
+    const child = spawn("codex", argv, { stdio: ["pipe", "pipe", "pipe"] });
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+
+    child.stdout.on("data", () => {});
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      done({ code: -1, stderr: String(err.message), timedOut: false });
+    });
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      done({ code, stderr: stderr.slice(-4000), timedOut });
+    });
+
+    child.stdin.end(prompt);
+  });
+
+// ---- Runner ----------------------------------------------------------------------------
+
+const makeSlots = (limit) => {
+  let active = 0;
+  const waiting = [];
+  return async (task) => {
+    if (active >= limit) await new Promise((r) => waiting.push(r));
+    active++;
+    try {
+      return await task();
+    } finally {
+      active--;
+      const next = waiting.shift();
+      if (next) next();
+    }
+  };
+};
+
+// stubs.workflow and runOnCodex both need the path a name resolves to, and the same missing-name
+// message build.js's sibling() matches on, so both go through this rather than repeating either.
+const resolveWorkflowPath = (name) => {
+  const path = join(ROOT, "workflows", `${name}.js`);
+  if (!existsSync(path)) throw new Error(`workflow('${name}'): no workflow with that name`);
+  return path;
+};
+
+// The pool belongs to one createStubs call. stubs.workflow hands the same stubs object to the
+// nested run, so build and the code workflow it nests share one pool; two concurrent
+// runOnCodex calls would each hold their own and the cap would apply twice.
+export function createStubs({ repo, concurrency = DEFAULT_CONCURRENCY, onLog = () => {}, tmp }) {
+  const withSlot = makeSlots(concurrency);
+  const stubs = {};
+  let serial = 0;
+
+  stubs.agent = async (prompt, opts = {}) =>
+    withSlot(async () => {
+      const id = ++serial;
+      const label = opts.label || opts.agentType || "agent";
+      const { preamble, readOnly, missing } = loadAgent(opts.agentType);
+      if (missing) {
+        onLog(`[${label}] agents/${opts.agentType}.md is missing; running with no preamble.`);
+      }
+
+      const model = MODEL_MAP[opts.model] || MODEL_MAP.sonnet;
+      const effort = opts.effort || DEFAULT_EFFORT;
+      const sandbox = readOnly ? "read-only" : "workspace-write";
+      const schemaPath = opts.schema ? join(tmp, `schema-${id}.json`) : "";
+      const outPath = join(tmp, `out-${id}.json`);
+      if (opts.schema) writeFileSync(schemaPath, JSON.stringify(strictify(opts.schema)));
+
+      const base = preamble ? `${preamble}\n\n---\n\n${prompt}` : prompt;
+      let correction = "";
+
+      for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+        onLog(`[${label}] codex ${model}/${effort} ${sandbox} (attempt ${attempt}/${ATTEMPTS})`);
+        const run = await runCodexOnce({
+          prompt: base + correction,
+          model,
+          effort,
+          schemaPath,
+          outPath,
+          sandbox,
+          cwd: repo,
+          timeoutMs: DEFAULT_TIMEOUT_MS,
+        });
+
+        if (run.timedOut) {
+          correction = "";
+          onLog(`[${label}] killed at ${DEFAULT_TIMEOUT_MS} ms.`);
+          continue;
+        }
+        if (run.code !== 0) {
+          correction = "";
+          const tail = run.stderr.split("\n").slice(-3).join(" ");
+          onLog(`[${label}] codex exited ${run.code}. ${tail}`);
+          continue;
+        }
+
+        let raw = "";
+        try {
+          raw = readFileSync(outPath, "utf8");
+        } catch {
+          onLog(`[${label}] codex wrote no final message.`);
+          continue;
+        }
+        if (!opts.schema) return raw.trim();
+
+        try {
+          const value = pruneNulls(JSON.parse(raw), opts.schema);
+          const violation = findSchemaViolation(value, opts.schema);
+          if (violation) throw new Error(violation);
+          return value;
+        } catch (err) {
+          onLog(`[${label}] response did not fit the schema: ${err.message}`);
+          correction =
+            `\n\nThe previous attempt returned a value that did not fit the output schema ` +
+            `(${err.message}). Return only the fields the schema declares.`;
+        }
+      }
+      // The Agent tool returns null when a subagent dies after its retries, and the workflow
+      // scripts branch on that null, so the same value is returned rather than a throw.
+      onLog(`[${label}] gave up after ${ATTEMPTS} attempts; the stage returns null.`);
+      return null;
+    });
+
+  // build.js's sibling() falls back to the plugin namespace only when the message matches this
+  // shape, so an unresolved name throws it verbatim rather than returning undefined.
+  stubs.workflow = async (name, wfArgs) => {
+    const path = resolveWorkflowPath(name);
+    onLog(`[workflow] ${name}`);
+    const nested = await runWorkflow(path, {
+      args: wfArgs,
+      stubs,
+      onLog,
+      onPhase: (title) => onLog(`== ${name}: ${title}`),
+    });
+    return nested.result;
+  };
+
+  return stubs;
+}
+
+export async function runOnCodex(name, args, { concurrency, onLog = () => {} } = {}) {
+  const path = resolveWorkflowPath(name);
+  const tmp = mkdtempSync(join(process.env.TMPDIR || tmpdir(), "codex-run-"));
+  try {
+    const stubs = createStubs({ repo: args.repo, concurrency, onLog, tmp });
+    const { result } = await runWorkflow(path, {
+      args,
+      stubs,
+      onLog,
+      onPhase: (title) => onLog(`== ${title}`),
+    });
+    return result;
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+// ---- CLI --------------------------------------------------------------------------------
+
+// --args carries whatever the caller typed, so its keys are copied one by one onto a
+// null-prototype target rather than merged, which keeps a "__proto__" key a plain own
+// property instead of a write through the prototype chain.
+const mergeArgs = (target, source) => {
+  if (!source || typeof source !== "object") return;
+  for (const key of Object.keys(source)) target[key] = source[key];
+};
+
+export function parseArgv(argv) {
+  const [name, ...rest] = argv;
+  const args = Object.create(null);
+  let concurrency;
+  for (let i = 0; i < rest.length; i++) {
+    const flag = rest[i];
+    const value = rest[i + 1];
+    if (flag === "--repo") args.repo = resolve(value);
+    else if (flag === "--issue") args.issue = value;
+    else if (flag === "--base") args.base = value;
+    else if (flag === "--concurrency") concurrency = Number(value);
+    else if (flag === "--args") mergeArgs(args, JSON.parse(value));
+    else throw new Error(`unknown flag: ${flag}`);
+    i++;
+  }
+  return { name, args, concurrency };
+}
+
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const { name, args, concurrency } = parseArgv(process.argv.slice(2));
+  if (!name || !args.repo) {
+    process.stderr.write(
+      "usage: node workflows/_lib/codex-run.mjs <workflow> --repo <abs path> " +
+        "[--issue N] [--base B] [--concurrency N] [--args <json>]\n",
+    );
+    process.exit(2);
+  }
+  const result = await runOnCodex(name, args, {
+    concurrency,
+    onLog: (message) => process.stderr.write(`${message}\n`),
+  });
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}

--- a/workflows/_lib/run-workflow.js
+++ b/workflows/_lib/run-workflow.js
@@ -205,14 +205,29 @@ export function checkWorkflowSyntax(scriptPath) {
   );
 }
 
-// runWorkflow(scriptPath, { args, stubs }) -> { result, calls, logs }
+// runWorkflow(scriptPath, { args, stubs, onLog, onPhase }) -> { result, calls, logs }
 // stubs.agent / stubs.workflow receive (prompt|name, opts|args) and return the stub result.
 // stubs.pipeline receives (items, ...stages) and replaces the default pipeline implementation.
 // calls captures the agent / workflow / phase invocations.
-export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
+// onLog / onPhase mirror each log() and phase() call as the run makes it, for a caller driving
+// a real run that cannot wait for the returned arrays. Both default to no-op, so a caller that
+// omits them observes exactly what it observed before they existed.
+export async function runWorkflow(scriptPath, options = {}) {
+  const { args = {}, stubs = {}, onLog = () => {}, onPhase = () => {} } = options;
   const source = readFileSync(scriptPath, "utf8").replace(/^export const meta/m, "const meta");
   const calls = { agent: [], workflow: [], phase: [] };
   const logs = [];
+  // A caller's own reporting must not decide whether the workflow keeps running, so a throw
+  // from onLog / onPhase is dropped here rather than surfacing inside the script.
+  const mirror = (notify) => (value) => {
+    try {
+      notify(value);
+    } catch {
+      /* the run continues */
+    }
+  };
+  const notifyPhase = mirror(onPhase);
+  const notifyLog = mirror(onLog);
 
   const agent = asProductionThrow(async (prompt, opts = {}) => {
     const hostPrompt = rehome(prompt);
@@ -258,10 +273,14 @@ export async function runWorkflow(scriptPath, { args = {}, stubs = {} } = {}) {
     );
   });
   const phase = asProductionThrow((title) => {
-    calls.phase.push(rehome(title));
+    const hostTitle = rehome(title);
+    calls.phase.push(hostTitle);
+    notifyPhase(hostTitle);
   });
   const log = asProductionThrow((message) => {
-    logs.push(rehome(message));
+    const hostMessage = rehome(message);
+    logs.push(hostMessage);
+    notifyLog(hostMessage);
   });
 
   // The supply side of PRODUCTION_GLOBALS. budget holds the state of a run with no token

--- a/workflows/_lib/tests/codex-run.test.js
+++ b/workflows/_lib/tests/codex-run.test.js
@@ -15,7 +15,7 @@ import {
   parseArgv,
   pruneNulls,
   strictify,
-} from "../codex-run.mjs";
+} from "../codex-run.js";
 
 // The shape workflows/build.js's obj(required, properties) produces: required is a subset of
 // properties on purpose, which is what OpenAI strict mode rejects.

--- a/workflows/_lib/tests/codex-run.test.js
+++ b/workflows/_lib/tests/codex-run.test.js
@@ -1,0 +1,246 @@
+// Behavior tests for the Codex runner's pure seams: the strict-mode schema translation, its
+// inverse, the agent-definition lookup, and the argv parse. The codex child process is never
+// spawned here, so nothing in this file reaches the network.
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  createStubs,
+  findSchemaViolation,
+  loadAgent,
+  MODEL_MAP,
+  parseArgv,
+  pruneNulls,
+  strictify,
+} from "../codex-run.mjs";
+
+// The shape workflows/build.js's obj(required, properties) produces: required is a subset of
+// properties on purpose, which is what OpenAI strict mode rejects.
+const FETCH_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["found", "body"],
+  properties: {
+    found: { type: "boolean" },
+    body: { type: "string", description: "The issue body verbatim" },
+    title: { type: "string", description: "The issue title verbatim" },
+  },
+};
+
+test("strictify moves every declared property into required", () => {
+  const out = strictify(FETCH_SCHEMA);
+  assert.deepEqual(out.required, ["found", "body", "title"]);
+  assert.equal(out.additionalProperties, false);
+});
+
+test("strictify makes a property outside the original required nullable", () => {
+  const out = strictify(FETCH_SCHEMA);
+  assert.deepEqual(out.properties.title.anyOf[1], { type: "null" });
+  assert.equal(out.properties.body.type, "string");
+});
+
+test("strictify keeps an originally required property free of the null branch", () => {
+  const out = strictify(FETCH_SCHEMA);
+  assert.equal(out.properties.found.anyOf, undefined);
+  assert.equal(out.properties.found.type, "boolean");
+});
+
+test("strictify descends into array items", () => {
+  const schema = {
+    type: "object",
+    required: ["units"],
+    properties: {
+      units: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" }, note: { type: "string" } },
+        },
+      },
+    },
+  };
+  const items = strictify(schema).properties.units.items;
+  assert.deepEqual(items.required, ["id", "note"]);
+  assert.deepEqual(items.note ?? items.properties.note.anyOf[1], { type: "null" });
+});
+
+test("strictify gives an object declared with no required list every key as nullable", () => {
+  // build.js's reference_module is written this way: properties with no required list at all.
+  const schema = {
+    type: ["object", "null"],
+    properties: { kind: { type: "string" }, reason: { type: "string" } },
+  };
+  const out = strictify(schema);
+  const object = out.anyOf[0];
+  assert.deepEqual(out.anyOf[1], { type: "null" });
+  assert.deepEqual(object.required, ["kind", "reason"]);
+  assert.equal(object.additionalProperties, false);
+});
+
+test("strictify adds additionalProperties false to an object that omitted it", () => {
+  const out = strictify({ type: "object", properties: { a: { type: "string" } } });
+  assert.equal(out.additionalProperties, false);
+});
+
+test("pruneNulls drops a null standing for a property the original left optional", () => {
+  const value = pruneNulls({ found: true, body: "x", title: null }, FETCH_SCHEMA);
+  assert.deepEqual(value, { found: true, body: "x" });
+});
+
+test("pruneNulls keeps a null under a property the original marked required", () => {
+  const schema = {
+    type: "object",
+    required: ["reference_module"],
+    properties: { reference_module: { type: ["object", "null"] } },
+  };
+  assert.deepEqual(pruneNulls({ reference_module: null }, schema), { reference_module: null });
+});
+
+test("pruneNulls descends into array items", () => {
+  const schema = {
+    type: "object",
+    required: ["units"],
+    properties: {
+      units: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" }, note: { type: "string" } },
+        },
+      },
+    },
+  };
+  const value = pruneNulls({ units: [{ id: "T-001", note: null }] }, schema);
+  assert.deepEqual(value, { units: [{ id: "T-001" }] });
+});
+
+test("strictify and pruneNulls round-trip a response back to the shape the script expects", () => {
+  strictify(FETCH_SCHEMA);
+  assert.deepEqual(pruneNulls({ found: false, body: "", title: null }, FETCH_SCHEMA), {
+    found: false,
+    body: "",
+  });
+});
+
+test("loadAgent gives general-purpose no preamble and the write sandbox", () => {
+  assert.deepEqual(loadAgent("general-purpose"), { preamble: "", readOnly: false });
+});
+
+test("loadAgent reads a reviewer definition and marks it read-only", () => {
+  const loaded = loadAgent("reviewer-conformance");
+  assert.equal(loaded.missing, undefined);
+  assert.ok(loaded.preamble.length > 0);
+  assert.equal(loaded.readOnly, true);
+});
+
+test("loadAgent reports a missing definition instead of throwing", () => {
+  const loaded = loadAgent("reviewer-does-not-exist");
+  assert.equal(loaded.missing, true);
+  assert.equal(loaded.preamble, "");
+});
+
+test("MODEL_MAP names one Codex model per tier the workflow scripts use", () => {
+  assert.ok(MODEL_MAP.haiku);
+  assert.ok(MODEL_MAP.sonnet);
+  assert.notEqual(MODEL_MAP.haiku, MODEL_MAP.sonnet);
+});
+
+test("parseArgv reads the workflow name and the repo as an absolute path", () => {
+  const { name, args } = parseArgv(["build", "--repo", "/tmp/repo", "--issue", "123"]);
+  assert.equal(name, "build");
+  assert.equal(args.repo, "/tmp/repo");
+  assert.equal(args.issue, "123");
+});
+
+test("parseArgv rejects a flag it does not define", () => {
+  assert.throws(() => parseArgv(["build", "--repo", "/tmp/repo", "--nope", "1"]), /unknown flag/);
+});
+
+test("parseArgv leaves Object.prototype untouched when --args carries a __proto__ key", () => {
+  const { args } = parseArgv([
+    "build",
+    "--repo",
+    "/tmp/repo",
+    "--args",
+    '{"__proto__":{"polluted":1}}',
+  ]);
+  assert.equal({}.polluted, undefined);
+  assert.equal(args.repo, "/tmp/repo");
+});
+
+// The unit shape build.js requires: files and tests are arrays the script reads .length from,
+// so a null arriving there throws inside the vm instead of taking a degradation branch.
+const UNIT_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  required: ["units"],
+  properties: {
+    units: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "files"],
+        properties: {
+          id: { type: "string" },
+          files: { type: "array", items: { type: "string" } },
+          note: { type: "string" },
+        },
+      },
+    },
+  },
+};
+
+test("findSchemaViolation names a required array that came back null inside an item", () => {
+  const found = findSchemaViolation({ units: [{ id: "T-001", files: null }] }, UNIT_SCHEMA);
+  assert.equal(found, "units[0].files is null");
+});
+
+test("findSchemaViolation names a required key the response omitted", () => {
+  const found = findSchemaViolation({ units: [{ files: [] }] }, UNIT_SCHEMA);
+  assert.equal(found, "units[0].id is missing");
+});
+
+test("findSchemaViolation accepts null under a required property the schema declares nullable", () => {
+  const schema = {
+    type: "object",
+    required: ["reference_module"],
+    properties: {
+      reference_module: { type: ["object", "null"], properties: { kind: { type: "string" } } },
+    },
+  };
+  assert.equal(findSchemaViolation({ reference_module: null }, schema), "");
+});
+
+test("findSchemaViolation passes a response that fills every required field", () => {
+  const value = { units: [{ id: "T-001", files: ["a.js"] }] };
+  assert.equal(findSchemaViolation(value, UNIT_SCHEMA), "");
+});
+
+test("pruneNulls leaves a required null in place for findSchemaViolation to catch", () => {
+  // The two run in sequence inside the agent stage: pruning removes the optional nulls, and
+  // whatever null survives is the one that has to trigger a retry rather than reach the script.
+  const pruned = pruneNulls({ units: [{ id: "T-001", files: null, note: null }] }, UNIT_SCHEMA);
+  assert.deepEqual(pruned, { units: [{ id: "T-001", files: null }] });
+  assert.equal(findSchemaViolation(pruned, UNIT_SCHEMA), "units[0].files is null");
+});
+
+test("stubs.workflow throws the message build.js's sibling() matches on an unresolved name", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "codex-run-test-"));
+  try {
+    const stubs = createStubs({ repo: "/tmp/repo", tmp });
+    await assert.rejects(
+      () => stubs.workflow("does-not-exist", {}),
+      // build.js:159 tests the message for this exact substring before falling back to the
+      // plugin namespace, so a reworded throw silently disables that fallback.
+      (err) => err.message.includes("workflow('does-not-exist'): no workflow with that name"),
+    );
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What & Why

workflow スクリプトを Codex 上で実行する runner を追加する。`agent()` は Claude Code のサブエージェントランタイムが供給しているため、これまで workflow スクリプトは Claude Code の外では動かせなかった。`codex-run.js` は `agent()` 1 回を `codex exec` の子プロセス 1 個へ置き換え、評価形の残り（vm コンテキスト、禁止された `Date`、`Math` グローバル、parallel と pipeline の意味論）は `run-workflow.js` を再利用する。

## Review focus

- `strictify`、`pruneNulls` の schema 変換を重点的に見てほしい。Codex の structured outputs は strict モードで動き、宣言済みプロパティを `required` から落とした schema を拒否する。往路で schema を、復路で response を変換しており、往復して元の形に戻ることがスクリプト側の前提になる
- `run-workflow.js` の `onLog`、`onPhase` は既定が no-op で throw を握るため、既存の呼び出し元から見た挙動は追加前と同一である。ここは流し読みでよい
- `MODEL_MAP` の既定値 `gpt-5.6-luna`、`gpt-5.6-terra`、`gpt-5.6-sol` が実在する Codex のモデル ID かは**未検証**である。テストは階層ごとに 1 エントリあることしか表明していないため、存在しない ID でも通る。マージ前に実際の `codex exec` で確認が要る

## Changes

- `runWorkflow()` に `onLog`、`onPhase` を追加した。実行中の `log()`、`phase()` をその場で呼び出し元へ渡すためで、戻り値の配列を待てない実行中の表示がこれを使う。呼び出し元の表示処理が workflow の継続可否を決めてはならないので、コールバックからの throw はここで握る
- `workflows/_lib/` の用途をテストが import するものに限っていた規約を、別ホストで script を評価する runner まで許すよう広げた。この runner の置き場所が規約上なかったため

## Scope

- Not included: `codex-run.js` を呼ぶ CI ジョブや slash command は追加していない。現時点では手で `node workflows/_lib/codex-run.js <workflow> --repo <abs path>` を叩く経路のみ

## Design Decisions

- 評価形を再実装せず `run-workflow.js` の `runWorkflow()` を再利用した。本番の挙動を 2 か所で再現すると、片方だけが古くなったときに検知できない
- 並列度に `min(16, cpus - 2)` の上限を置いた。Claude はインプロセスのエージェントに同じ上限を持つが、子プロセスにはその上限がないため、`pipeline()` が長い unit 列を受けると unit ごとに codex を同時起動してしまう
- リトライは 1 回（`ATTEMPTS = 2`）とした。再試行して意味のある失敗（接続断、schema を外した応答）が毎回起きるわけではないため
- `workspace-write` サンドボックスのときだけ `sandbox_workspace_write.network_access=true` を渡す。`gh` と `git push` がネットワークへ出るが、このサンドボックスは既定でそれを塞ぐ

## How to Test

1. `node --test "workflows/**/tests/*.test.js"` を実行する
2. テスト 367 本が通り、失敗 0 で終わる。うち `codex-run.test.js` の 23 本が schema 変換の往復、`loadAgent`、`parseArgv` の `__proto__` 混入を覆う
3. `codex` CLI がある環境で `node workflows/_lib/codex-run.js polish --repo "$(pwd)"` を実行する
4. `[codex] codex <model>/<effort> <sandbox> (attempt 1/2)` の形のログがステージごとに流れ、workflow の戻り値が JSON で出力される

手順 3-4 は未実施である。手順 1-2 のみ実行して確認した。
