### PR TITLE
[Feature] workflows/_lib/gate.py を TypeScript へ移行する第1スライス

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,10 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 22
+          # .test.ts を node --test で直接読ませる型ストリップは Node 22.18 / 23.6 で
+          # 無フラグ既定化済みだが、stable 化したのは Node 24.12 / 25.2 のみで 22.x の
+          # 系列には来ていない (https://nodejs.org/api/typescript.html)。stable な方を選ぶ。
+          node-version: 24
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
@@ -39,6 +42,11 @@ jobs:
       - name: Install
         run: bun install --frozen-lockfile
 
+      # typescript は devDependency なので、上の Install がそのまま入れる。oxlint と同じ形。
+      # tsconfig.json の include/exclude が検査範囲そのものなので、対象を CLI に別途渡さない。
+      - name: Type check
+        run: npx tsc --noEmit
+
       - name: Node tests
         run: >
           node --test
@@ -47,6 +55,7 @@ jobs:
           "hooks/**/tests/*.test.js"
           "skills/**/tests/*.test.js"
           "workflows/**/tests/*.test.js"
+          "workflows/**/tests/*.test.ts"
 
       # hooks/edit/tests/rumdl_check_test.py runs the real binary. The rumdl step below
       # reaches it through `pipx run`, which puts nothing on PATH for this step.

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "textlint-rule-no-mix-dearu-desumasu": "^6.0.4",
         "textlint-rule-preset-ja-spacing": "^3.0.3",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2",
+        "typescript": "7.0.2",
       },
     },
   },
@@ -178,6 +179,46 @@
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
     "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -774,6 +815,8 @@
     "typed-array-length": ["typed-array-length@1.0.8", "", { "dependencies": { "call-bind": "^1.0.9", "for-each": "^0.3.5", "gopd": "^1.2.0", "is-typed-array": "^1.1.15", "possible-typed-array-names": "^1.1.0", "reflect.getprototypeof": "^1.0.10" } }, "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g=="],
 
     "typedarray.prototype.slice": ["typedarray.prototype.slice@1.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "math-intrinsics": "^1.1.0", "typed-array-buffer": "^1.0.3", "typed-array-byte-offset": "^1.0.4" } }, "sha512-q7QNVDGTdl702bVFiI5eY4l/HkgCM6at9KhcFbgUAzezHFbOVy4+0O/lCjsABEQwbZPravVfBIiBVGo89yzHFg=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "dotclaude",
       "devDependencies": {
         "@textlint-ja/textlint-rule-preset-ai-writing": "^1.7.0",
+        "@types/node": "^26.4.0",
         "hucre": "^1.1.0",
         "oxfmt": "0.63.0",
         "oxlint": "1.78.0",
@@ -175,6 +176,8 @@
     "@textlint/utils": ["@textlint/utils@15.8.0", "", {}, "sha512-waINJCI7sBVs1A3K05UFKe8QoNAsdJFCXr3PJ1QsgAf0BeEgCtyrLVcZUdbOtKxRkF4QB4NuClB0By1Ty4znpQ=="],
 
     "@types/mdast": ["@types/mdast@3.0.15", "", { "dependencies": { "@types/unist": "^2" } }, "sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ=="],
+
+    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
@@ -819,6 +822,8 @@
     "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.1.0", "", {}, "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "textlint-rule-ja-no-weak-phrase": "^2.0.0",
     "textlint-rule-no-mix-dearu-desumasu": "^6.0.4",
     "textlint-rule-preset-ja-spacing": "^3.0.3",
-    "textlint-rule-preset-ja-technical-writing": "^12.0.2"
+    "textlint-rule-preset-ja-technical-writing": "^12.0.2",
+    "typescript": "7.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "devDependencies": {
     "@textlint-ja/textlint-rule-preset-ai-writing": "^1.7.0",
+    "@types/node": "^26.4.0",
     "hucre": "^1.1.0",
     "oxfmt": "0.63.0",
     "oxlint": "1.78.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["plugins/**", "node_modules/**", "skills/*/test/cases/**"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2022"],
+    "types": ["node"],
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,

--- a/workflows/_lib/tests/gate.differential.test.ts
+++ b/workflows/_lib/tests/gate.differential.test.ts
@@ -1,0 +1,291 @@
+// Differential test for the workflows/_lib/gate.py -> gate.ts slice (see
+// docs/decisions/0112-adopt-typescript-for-helper-scripts.md, Success Criteria: "第 1
+// スライスは Python 版と TypeScript 版の出力を突き合わせる差分テストで確認する"). The unit's
+// contract is workflows/_lib/gate.py's CLI contract carried over unchanged, so both sides are
+// driven as CLI processes and compared on stdout JSON + exit code -- never on internal
+// functions, which the CLI contract does not promise to keep identical between the two.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PY_SCRIPT = join(HERE, "..", "gate.py");
+const TS_SCRIPT = join(HERE, "..", "gate.ts");
+
+// gate.ts's own spawnSync call onto the target command is what this unit's contract warns
+// about: Node's spawnSync defaults to a 1MiB maxBuffer and throws ENOBUFS past it, where
+// Python's subprocess.run has no such ceiling. Confirmed in this session: a 2,000,000-byte
+// stdout produced ENOBUFS under Node's default maxBuffer and no error under Python. The outer
+// call here only reads back a gate report bounded by --tail-bytes (12000 bytes by default),
+// well under 1MiB, but the same generous ceiling is set anyway so this harness never becomes
+// the thing that reintroduces the bug it exists to catch.
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+type GateReport = Record<string, unknown>;
+
+interface CliResult {
+  readonly exitCode: number | null;
+  readonly report: GateReport;
+}
+
+function runCli(command: string, script: string, args: readonly string[]): CliResult {
+  const result = spawnSync(command, [script, ...args], { encoding: "utf8", maxBuffer: MAX_BUFFER });
+  let report: GateReport;
+  try {
+    report = JSON.parse(result.stdout) as GateReport;
+  } catch (error) {
+    const stderrTail = (result.stderr || "").slice(0, 500);
+    throw new Error(
+      `${command} ${script} ${args.join(" ")} did not print a JSON report on stdout ` +
+        `(exit ${result.status}, stderr: ${stderrTail}): ${(error as Error).message}`,
+    );
+  }
+  return { exitCode: result.status, report };
+}
+
+// python3 matches the invocation gate_test.py itself uses; process.execPath (rather than a
+// hardcoded "node") runs gate.ts under whatever Node binary is already running this suite, so
+// the two never disagree about which runtime does the type stripping.
+const runPython = (args: readonly string[]): CliResult => runCli("python3", PY_SCRIPT, args);
+const runTypeScript = (args: readonly string[]): CliResult =>
+  runCli(process.execPath, TS_SCRIPT, args);
+
+// duration_ms is wall-clock and never equal between two independent runs. execution_error
+// carries a raw OSError/Node error string whose exact wording this unit's contract excludes
+// from parity -- only whether it is present (non-null) is part of the contract. Everything
+// else in the report is required to match byte-for-byte.
+function normalizeReport(report: GateReport): GateReport {
+  const clone = JSON.parse(JSON.stringify(report)) as GateReport;
+  if ("duration_ms" in clone) clone.duration_ms = null;
+  const evidence = clone.evidence;
+  if (evidence && typeof evidence === "object" && "execution_error" in (evidence as GateReport)) {
+    const record = evidence as GateReport;
+    record.execution_error = record.execution_error === null ? null : "<execution-error-text>";
+  }
+  return clone;
+}
+
+function assertParity(args: readonly string[], label: string): void {
+  const python = runPython(args);
+  const typescript = runTypeScript(args);
+  assert.equal(typescript.exitCode, python.exitCode, `[${label}] exit code diverged`);
+  assert.deepEqual(
+    normalizeReport(typescript.report),
+    normalizeReport(python.report),
+    `[${label}] JSON report diverged (duration_ms and execution_error wording excluded)`,
+  );
+}
+
+const withTmpDir = (fn: (cwd: string) => void): void => {
+  const tmp = mkdtempSync(join(process.env.TMPDIR || tmpdir(), "gate-differential-"));
+  try {
+    fn(tmp);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+};
+
+// ---- T-006 ----------------------------------------------------------------------------
+// One representative call per branch of gate.py's CLI contract (mirrors gate_test.py's own
+// VerdictTest / UsageTest / CalibrationTest / CalibrationCandidateTest coverage). Each entry
+// gets a fresh --cwd unless it overrides it, which the relative-path usage-error entry does.
+interface MatrixEntry {
+  readonly name: string;
+  readonly args: (cwd: string) => readonly string[];
+}
+
+const MATRIX: readonly MatrixEntry[] = [
+  {
+    name: "pass gate: 期待どおりの終了で pass",
+    args: (cwd) => ["--cwd", cwd, "--command", "printf 'done\\n'", "--expect", "pass"],
+  },
+  {
+    name: "pass gate: 想定外の非ゼロ終了で fail し failure_route が渡される",
+    args: (cwd) => [
+      "--cwd",
+      cwd,
+      "--command",
+      "exit 3",
+      "--expect",
+      "pass",
+      "--failure-route",
+      "green:U-001",
+    ],
+  },
+  {
+    name: "fail gate: アンカーなしは usage error として blocked",
+    args: (cwd) => ["--cwd", cwd, "--command", "exit 1", "--expect", "fail"],
+  },
+  {
+    name: "fail gate: 完全な失敗行をアンカーにすると pass",
+    args: (cwd) => [
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'ok 1 - T-001 x\\nnot ok 2 - T-002 y\\n'; exit 1",
+      "--expect",
+      "fail",
+      "--require-output",
+      "not ok 2 - T-002 y",
+    ],
+  },
+  {
+    name: "fail gate: テスト名だけの部分文字列アンカーは missing_required_output",
+    args: (cwd) => [
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'ok 1 - T-001 x\\nnot ok 2 - T-002 y\\n'; exit 1",
+      "--expect",
+      "fail",
+      "--require-output",
+      "T-001 x",
+    ],
+  },
+  {
+    name: "forbid-output: 禁止語が出力に部分一致すると forbidden_output",
+    args: (cwd) => [
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'warning: deprecated call\\n'",
+      "--expect",
+      "pass",
+      "--forbid-output",
+      "deprecated",
+    ],
+  },
+  {
+    name: "usage error: 未知のフラグ",
+    args: (cwd) => ["--cwd", cwd, "--command", "true", "--expect", "pass", "--nope", "x"],
+  },
+  {
+    name: "usage error: 単数フラグの重複指定",
+    args: (cwd) => ["--cwd", cwd, "--command", "true", "--command", "false", "--expect", "pass"],
+  },
+  {
+    name: "usage error: 相対パスの --cwd",
+    args: () => ["--cwd", "relative/dir", "--command", "true", "--expect", "pass"],
+  },
+  {
+    name: "calibrate: アンカー無しで Red コマンドを実行し classification に calibration_ を付ける",
+    args: (cwd) => [
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'not ok 1 - T-001 x\\n'; exit 1",
+      "--calibrate",
+    ],
+  },
+  {
+    name: "calibrate: コマンドが想定外に成功すると calibration_unexpected_pass",
+    args: (cwd) => ["--cwd", cwd, "--command", "printf 'all green\\n'", "--calibrate"],
+  },
+  {
+    name: "calibrate: --require-output の併用は使用エラー",
+    args: (cwd) => ["--cwd", cwd, "--command", "exit 1", "--calibrate", "--require-output", "x"],
+  },
+  {
+    name: "planned-test: 指定した名前を持つ失敗行だけが候補になる",
+    args: (cwd) => [
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'ok 1 - other\\nnot ok 2 - an empty query returns an error\\n'; exit 1",
+      "--calibrate",
+      "--planned-test",
+      "T-001:an empty query returns an error",
+    ],
+  },
+  {
+    name: "planned-test: calibrate の外で指定すると使用エラー",
+    args: (cwd) => [
+      "--cwd",
+      cwd,
+      "--command",
+      "true",
+      "--expect",
+      "pass",
+      "--planned-test",
+      "T-001:x",
+    ],
+  },
+];
+
+test("呼び出し matrix の全件で gate.py と gate.ts の JSON が duration_ms と execution_error の文言を除いて一致する", () => {
+  withTmpDir((tmp) => {
+    for (const entry of MATRIX) {
+      assertParity(entry.args(tmp), entry.name);
+    }
+  });
+});
+
+// ---- T-007 ----------------------------------------------------------------------------
+test("1MiB を超える出力を出すコマンドで両者とも pass を返す", () => {
+  withTmpDir((tmp) => {
+    // Confirmed in this session: `python3 -c "...write('a'*2_000_000)"` makes gate.py return
+    // pass (subprocess.run carries no output ceiling), and the identical command run through
+    // Node's spawnSync with no maxBuffer set throws ENOBUFS -- the exact failure this
+    // scenario exists to catch once gate.ts is implemented.
+    const args = [
+      "--cwd",
+      tmp,
+      "--command",
+      "python3 -c \"import sys; sys.stdout.write('a'*2000000)\"",
+      "--expect",
+      "pass",
+    ];
+    const python = runPython(args);
+    const typescript = runTypeScript(args);
+    assert.equal(python.exitCode, 0, "gate.py did not pass on a >1MiB stdout command");
+    assert.equal(
+      typescript.exitCode,
+      0,
+      "gate.ts did not pass on a >1MiB stdout command (likely ENOBUFS from an unset maxBuffer)",
+    );
+    assert.equal(python.report.verdict, "pass");
+    assert.equal(typescript.report.verdict, "pass");
+    assert.deepEqual(normalizeReport(typescript.report), normalizeReport(python.report));
+  });
+});
+
+// ---- T-008 ----------------------------------------------------------------------------
+test("タイムアウトしたコマンドで両者とも exit 124 と timed_out true を返す", () => {
+  withTmpDir((tmp) => {
+    const args = ["--cwd", tmp, "--command", "sleep 5", "--expect", "pass", "--timeout-ms", "200"];
+    const python = runPython(args);
+    const typescript = runTypeScript(args);
+    assert.equal(python.exitCode, 124);
+    assert.equal(typescript.exitCode, 124);
+    assert.equal(python.report.verdict, "blocked");
+    assert.equal(typescript.report.verdict, "blocked");
+    const pyEvidence = python.report.evidence as GateReport;
+    const tsEvidence = typescript.report.evidence as GateReport;
+    assert.equal(pyEvidence.timed_out, true);
+    assert.equal(tsEvidence.timed_out, true);
+    assert.deepEqual(normalizeReport(typescript.report), normalizeReport(python.report));
+  });
+});
+
+// ---- T-009 ----------------------------------------------------------------------------
+test("シグナルで終了したコマンドで両者の exit_code と signal 名が一致する", () => {
+  withTmpDir((tmp) => {
+    // Confirmed in this session: gate.py reports evidence.exit_code -15 / evidence.signal
+    // "SIGTERM" for `kill -TERM $$`. Node's spawnSync surfaces the same event as
+    // { status: null, signal: "SIGTERM" }; gate.ts is expected to translate that back to the
+    // same -15 / "SIGTERM" pair gate.py reports, not Node's native shape.
+    const args = ["--cwd", tmp, "--command", "kill -TERM $$", "--expect", "pass"];
+    const python = runPython(args);
+    const typescript = runTypeScript(args);
+    const pyEvidence = python.report.evidence as GateReport;
+    const tsEvidence = typescript.report.evidence as GateReport;
+    assert.equal(typescript.exitCode, python.exitCode);
+    assert.equal(tsEvidence.exit_code, pyEvidence.exit_code);
+    assert.equal(tsEvidence.signal, pyEvidence.signal);
+    assert.deepEqual(normalizeReport(typescript.report), normalizeReport(python.report));
+  });
+});

--- a/workflows/_lib/tests/gate.test.ts
+++ b/workflows/_lib/tests/gate.test.ts
@@ -1,0 +1,186 @@
+// Ported subset of workflows/_lib/tests/gate_test.py's own coverage onto gate.ts (see
+// docs/decisions/0112-adopt-typescript-for-helper-scripts.md). gate.differential.test.ts
+// already proves gate.py and gate.ts agree on the CLI contract; this file instead proves
+// gate.ts's own behavior the way gate_test.py proves gate.py's -- some scenarios by driving
+// the CLI (mirroring gate_test.py's VerdictTest / UsageTest / CalibrationTest), one by calling
+// an exported function directly (mirroring gate_test.py's TailTest). Only a subset of
+// gate_test.py's 26 tests is ported in this pass; the rest arrive in later units.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(HERE, "..", "gate.ts");
+
+// Matches gate.differential.test.ts's own MAX_BUFFER: well over the --tail-bytes-bounded
+// report this reads back, kept generous so this harness never becomes the ENOBUFS bug it is
+// not the one guarding against (see gate.differential.test.ts's T-007 for that guard).
+const MAX_BUFFER = 64 * 1024 * 1024;
+
+type GateReport = Record<string, unknown>;
+
+interface CliResult {
+  readonly exitCode: number | null;
+  readonly report: GateReport;
+}
+
+function runCli(args: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    encoding: "utf8",
+    maxBuffer: MAX_BUFFER,
+  });
+  let report: GateReport;
+  try {
+    report = JSON.parse(result.stdout) as GateReport;
+  } catch (error) {
+    const stderrTail = (result.stderr || "").slice(0, 500);
+    throw new Error(
+      `gate.ts ${args.join(" ")} did not print a JSON report on stdout ` +
+        `(exit ${result.status}, stderr: ${stderrTail}): ${(error as Error).message}`,
+    );
+  }
+  return { exitCode: result.status, report };
+}
+
+const withTmpDir = (fn: (cwd: string) => void): void => {
+  const tmp = mkdtempSync(join(process.env.TMPDIR || tmpdir(), "gate-test-"));
+  try {
+    fn(tmp);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+};
+
+// ---- T-010 ------------------------------------------------------------------------------
+test("未知フラグと重複 singleton と相対 cwd とアンカー無しの expect fail が blocked と usage_error になる", () => {
+  withTmpDir((cwd) => {
+    const unknownFlag = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      "true",
+      "--expect",
+      "pass",
+      "--nope",
+      "x",
+    ]);
+    assert.equal(unknownFlag.exitCode, 2);
+    assert.equal(unknownFlag.report.verdict, "blocked");
+    assert.equal(unknownFlag.report.classification, "usage_error");
+    assert.match(String(unknownFlag.report.error), /unknown argument: --nope/);
+
+    const repeatedSingleton = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      "true",
+      "--command",
+      "false",
+      "--expect",
+      "pass",
+    ]);
+    assert.equal(repeatedSingleton.exitCode, 2);
+    assert.equal(repeatedSingleton.report.verdict, "blocked");
+    assert.equal(repeatedSingleton.report.classification, "usage_error");
+    assert.match(String(repeatedSingleton.report.error), /only once/);
+
+    const relativeCwd = runCli(["--cwd", "relative/dir", "--command", "true", "--expect", "pass"]);
+    assert.equal(relativeCwd.exitCode, 2);
+    assert.equal(relativeCwd.report.verdict, "blocked");
+    assert.equal(relativeCwd.report.classification, "usage_error");
+    assert.match(String(relativeCwd.report.error), /--cwd must be absolute/);
+
+    const noAnchor = runCli(["--cwd", cwd, "--command", "exit 1", "--expect", "fail"]);
+    assert.equal(noAnchor.exitCode, 2);
+    assert.equal(noAnchor.report.verdict, "blocked");
+    assert.equal(noAnchor.report.classification, "usage_error");
+    assert.match(String(noAnchor.report.error), /--require-output/);
+  });
+});
+
+// ---- T-011 ------------------------------------------------------------------------------
+// Dynamic import (rather than a static one at file top) so a missing gate.ts fails only this
+// test, not the whole file -- T-010 / T-012 / T-013 drive gate.ts as a CLI process and must
+// keep reporting on their own regardless of this test's outcome.
+test("切り詰めが残した先頭行が tail から落ち、完全な行が無ければ tail が空になる", async () => {
+  const { tail } = await import("../gate.ts");
+  assert.equal(tail(Buffer.from("alpha\nbeta\n"), 8), "beta\n");
+  assert.equal(tail(Buffer.from("alphabeta"), 4), "");
+});
+
+// ---- T-012 ------------------------------------------------------------------------------
+test("完全な 1 行と一致しないアンカーが missing_required_output で落ち、禁止出力が forbidden_output で落ちる", () => {
+  withTmpDir((cwd) => {
+    const partialAnchor = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'ok 1 - T-001 x\\nnot ok 2 - T-002 y\\n'; exit 1",
+      "--expect",
+      "fail",
+      "--require-output",
+      "T-001 x",
+    ]);
+    assert.equal(partialAnchor.exitCode, 1);
+    assert.equal(partialAnchor.report.verdict, "fail");
+    assert.deepEqual(partialAnchor.report.reason_codes, ["missing_required_output"]);
+
+    const forbidden = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'warning: deprecated call\\n'",
+      "--expect",
+      "pass",
+      "--forbid-output",
+      "deprecated",
+    ]);
+    assert.equal(forbidden.exitCode, 1);
+    assert.deepEqual(forbidden.report.reason_codes, ["forbidden_output"]);
+  });
+});
+
+// ---- T-013 ------------------------------------------------------------------------------
+test("calibrate がアンカー無しで走り classification に calibration_ が付き、アンカー指定と expect pass を拒否する", () => {
+  withTmpDir((cwd) => {
+    const calibrated = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      "printf 'not ok 1 - T-001 x\\n'; exit 1",
+      "--calibrate",
+    ]);
+    assert.equal(calibrated.exitCode, 0);
+    assert.equal(calibrated.report.verdict, "pass");
+    assert.equal(calibrated.report.classification, "calibration_expected_failure");
+    assert.equal(calibrated.report.expected, "fail");
+
+    const anchorRejected = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      "exit 1",
+      "--calibrate",
+      "--require-output",
+      "x",
+    ]);
+    assert.equal(anchorRejected.exitCode, 2);
+    assert.match(String(anchorRejected.report.error), /takes no --require-output/);
+
+    const passRejected = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      "exit 1",
+      "--calibrate",
+      "--expect",
+      "pass",
+    ]);
+    assert.equal(passRejected.exitCode, 2);
+    assert.match(String(passRejected.report.error), /--expect must be fail/);
+  });
+});

--- a/workflows/code/tests/code.gate.test.js
+++ b/workflows/code/tests/code.gate.test.js
@@ -3,10 +3,15 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { runWorkflow } from "../../_lib/run-workflow.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const codeJs = join(here, "..", "..", "code.js");
+const jaCodeJs = join(here, "..", "..", "..", ".ja", "workflows", "code.js");
+const gateTs = join(here, "..", "..", "_lib", "gate.ts");
 
 const plan = {
   test_command: "npm test",
@@ -320,4 +325,160 @@ test("the gate scripts are reached through bundled(), not a bare dev-tree path",
       `${label} resolves via bundled()`,
     );
   }
+});
+
+// ---- U-007: runGate switches from `python3 ${gateScript}` (gate.py) to a node launch of the
+// real gate.ts, and the deterministic Red path is proved against that real script rather than a
+// canned report. ----
+
+// relayStdout always appends the literal command as the last thing in its prompt (see
+// code.js's relayStdout), so everything after this marker, to the end of the string, is the
+// exact command line runGate built.
+const COMMAND_MARKER = "return its stdout verbatim in stdout, whatever its exit status.\n";
+const extractCommand = (prompt) => {
+  const idx = prompt.indexOf(COMMAND_MARKER);
+  return idx === -1 ? null : prompt.slice(idx + COMMAND_MARKER.length).trim();
+};
+
+test("T-015 runGate が組み立てるコマンドが gate.ts を node で起動する", async () => {
+  const { calls } = await run();
+  const calibrate = calls.agent.find((c) => c.opts.label === "calibrate:U-1");
+  assert.ok(calibrate, "the calibration gate ran");
+  const command = extractCommand(calibrate.prompt);
+  assert.ok(command, "the relay prompt carries the constructed command line");
+  assert.match(
+    command,
+    /^node\s+/,
+    `runGate should launch the gate script with node, not a python3 interpreter (got: ${command})`,
+  );
+  assert.match(command, /gate\.ts\b/, `the launched script should be gate.ts (got: ${command})`);
+});
+
+// docs/wiki/workflow-const-source-text-check.md: a workflow script cannot export a shared
+// constant, so gateScript is defined independently in each of the EN and .ja copies. Parity is
+// proved by extracting the literal from both sources rather than by copying an expected string
+// into this test.
+const GATE_SCRIPT_RE = /const gateScript = bundled\("([^"]+)"\);/;
+const extractGateScript = (source) => {
+  const m = source.match(GATE_SCRIPT_RE);
+  return m ? m[1] : null;
+};
+
+test("T-016 EN と .ja の code.js が同じ gateScript 定数を持つ", () => {
+  const enValue = extractGateScript(readFileSync(codeJs, "utf8"));
+  const jaValue = extractGateScript(readFileSync(jaCodeJs, "utf8"));
+  assert.ok(enValue, "gateScript is extractable from the EN code.js");
+  assert.ok(jaValue, "gateScript is extractable from the .ja code.js");
+  assert.equal(enValue, jaValue, "EN and .ja code.js resolve gateScript to the same path");
+  assert.match(
+    enValue,
+    /gate\.ts$/,
+    `gateScript should now name gate.ts, not gate.py (got: ${enValue})`,
+  );
+});
+
+// A real fixture repo with one test that fails in a stable, TAP-recognizable way. gate.py /
+// gate.ts's calibration matcher looks for a "not ok" marker line naming the planned test, so the
+// fixture's test name is echoed into the plan's tests[].name verbatim.
+const PLANNED_TEST_NAME = "a red planned test";
+const makeGateFixture = () => {
+  const dir = mkdtempSync(join(tmpdir(), "code-gate-seam-"));
+  writeFileSync(join(dir, "package.json"), JSON.stringify({ type: "module" }));
+  writeFileSync(
+    join(dir, "sample.test.js"),
+    [
+      `import { test } from "node:test";`,
+      `import assert from "node:assert/strict";`,
+      `test(${JSON.stringify(PLANNED_TEST_NAME)}, () => {`,
+      `  assert.equal(1, 2);`,
+      `});`,
+      "",
+    ].join("\n"),
+  );
+  return dir;
+};
+
+const seamPlan = {
+  test_command: "node --test --test-reporter=tap sample.test.js",
+  units: [
+    {
+      id: "U-G1",
+      goal: "seam goal",
+      files: ["sample.js"],
+      contract: "seam contract",
+      tests: [{ id: "T-G01", name: PLANNED_TEST_NAME }],
+      seam: false,
+    },
+  ],
+};
+
+// sealAnchor embeds the candidates as one JSON line between two fence lines (see code.js's
+// sealAnchor); this reads that line back rather than re-deriving what a real calibration found.
+const extractCandidatesPayload = (prompt) => {
+  const m = prompt.match(/---- candidates [^\n]*----\n(\{.*\})\n---- candidates/);
+  return m ? JSON.parse(m[1]) : null;
+};
+
+// Only "calibrate" and "gate-red" run the real gate script (this unit's contract is the Red
+// calibration path specifically); "gate-green" stays a canned pass so a fixture that is never
+// actually fixed does not also fail the Green gate for an unrelated reason.
+const gateSeamStub = (fixtureRepo, capturedCommands) => (prompt, opts) => {
+  const label = opts.label ?? "";
+  const key = label.split(":")[0];
+  if (key === "red") return { red_confirmed: true, test_files: ["sample.test.js"], notes: "" };
+  if (key === "calibrate" || key === "gate-red") {
+    const command = extractCommand(prompt);
+    capturedCommands.push({ label, command });
+    const res = spawnSync("bash", ["-c", command ?? "true"], {
+      encoding: "utf8",
+      maxBuffer: 64 * 1024 * 1024,
+    });
+    return { stdout: res.stdout ?? "" };
+  }
+  if (key === "seal") {
+    const payload = extractCandidatesPayload(prompt);
+    const candidates = (payload && payload.candidates) || [];
+    const picked = candidates.find((c) => c.test_id === "T-G01") || candidates[0];
+    return picked ? { candidate_id: picked.id } : null;
+  }
+  if (["green", "impl", "green2", "impl2"].includes(key)) return { green: true, notes: "" };
+  if (key === "gate-green") return { stdout: JSON.stringify(gateReport()) };
+  if (label === "verify") return { tests_pass: true, gates_pass: true, output_tail: "" };
+  throw new Error(`unexpected label in the gate seam stub: ${label} (repo: ${fixtureRepo})`);
+};
+
+test("T-017 実際の gate.ts を通した Red calibration の report を code.js が解析して unit を先へ進める", async () => {
+  const fixtureRepo = makeGateFixture();
+  try {
+    const capturedCommands = [];
+    const { result } = await runWorkflow(codeJs, {
+      args: { plan: seamPlan, repo: fixtureRepo, verify: true },
+      stubs: { agent: gateSeamStub(fixtureRepo, capturedCommands) },
+    });
+    assert.ok(capturedCommands.length > 0, "the calibration/red gate courier ran at least once");
+    for (const { label, command } of capturedCommands) {
+      assert.match(
+        command ?? "",
+        /^node\s+.*gate\.ts\b/,
+        `${label}: expected a node launch of the real gate.ts (got: ${command})`,
+      );
+    }
+    assert.equal(result.stopped, undefined, `code.js stopped early: ${result.why}`);
+    assert.deepEqual(
+      result.completed,
+      ["U-G1"],
+      "the real gate.ts's calibration report carries the unit through to completion",
+    );
+  } finally {
+    rmSync(fixtureRepo, { recursive: true, force: true });
+  }
+});
+
+// Sanity for the fixture itself, independent of code.js: the real gate.ts this unit's contract
+// requires is reachable at the path every other assertion above assumes.
+test("T-017b the real gate.ts the seam test targets exists on disk", () => {
+  assert.doesNotThrow(
+    () => readFileSync(gateTs, "utf8"),
+    `expected a real gate.ts at ${gateTs} for the seam test to run through`,
+  );
 });

--- a/workflows/tests/ja-ts-parity.test.js
+++ b/workflows/tests/ja-ts-parity.test.js
@@ -1,0 +1,72 @@
+// hooks/_lib/mirror_prose.py's TARGET_SUFFIXES already covers .ts and already checks whether
+// the prose in a mirrored pair carries Japanese. What it does not check is whether the two
+// files agree outside their prose: a translated comment must sit over identical code, and a
+// line count staying equal on both sides is not enough to prove that (see
+// docs/wiki/count-comparison-masks-filtered-set-drift.md) — content has to be compared.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+// Mirrors hooks/_lib/mirror_prose.py's COMMENT_LINE (`^\s*(#|//|\*)`) for the .ts comment
+// markers it already treats as prose. Stripping those lines and comparing the remaining
+// source text — not its line count — is what proves the two files agree outside prose (see
+// docs/wiki/count-comparison-masks-filtered-set-drift.md).
+const TS_COMMENT_LINE = /^\s*(\/\/|\*)/;
+
+const stripTsComments = (src) =>
+  src
+    .split("\n")
+    .filter((line) => !TS_COMMENT_LINE.test(line))
+    .join("\n");
+
+const tsBodyMatches = (en, ja) => stripTsComments(en) === stripTsComments(ja);
+
+test("コメントだけが異なる EN と .ja の .ts ペアが一致と判定される", () => {
+  const en = [
+    "// Adds two numbers.",
+    "export function add(a: number, b: number): number {",
+    "  return a + b;",
+    "}",
+    "",
+  ].join("\n");
+  const ja = [
+    "// 二つの数を足す。",
+    "export function add(a: number, b: number): number {",
+    "  return a + b;",
+    "}",
+    "",
+  ].join("\n");
+  assert.equal(tsBodyMatches(en, ja), true);
+});
+
+test("識別子が 1 つ異なるペアが不一致として落ちる", () => {
+  const en = [
+    "export function add(a: number, b: number): number {",
+    "  return a + b;",
+    "}",
+    "",
+  ].join("\n");
+  const ja = [
+    "export function add(x: number, b: number): number {",
+    "  return x + b;",
+    "}",
+    "",
+  ].join("\n");
+  assert.equal(tsBodyMatches(en, ja), false);
+});
+
+test("EN 側にだけ文が 1 つ多いペアが不一致として落ちる", () => {
+  const en = [
+    "export function add(a: number, b: number): number {",
+    "  const sum = a + b;",
+    "  return sum;",
+    "}",
+    "",
+  ].join("\n");
+  const ja = [
+    "export function add(a: number, b: number): number {",
+    "  return a + b;",
+    "}",
+    "",
+  ].join("\n");
+  assert.equal(tsBodyMatches(en, ja), false);
+});

--- a/workflows/tests/tsconfig-scope.representative.ts
+++ b/workflows/tests/tsconfig-scope.representative.ts
@@ -1,0 +1,4 @@
+// Fixture only: gives tsconfig.json's include set ("**/*.ts") a real file to type-check,
+// since no other workflows/**/*.ts exists yet. tsconfig-scope.test.js checks this path by
+// glob matching alone, not by importing this module.
+export const representative: string = "tsconfig-scope";

--- a/workflows/tests/tsconfig-scope.test.js
+++ b/workflows/tests/tsconfig-scope.test.js
@@ -1,0 +1,50 @@
+// tsconfig.json's exclude mirrors .oxlintrc.json's ignorePatterns for skills/*/test/cases/**
+// (see .oxlintrc.json) instead of inventing a second policy over the same file set.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, globSync } from "node:fs";
+import { dirname, join, matchesGlob } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const readJson = (relative) => JSON.parse(readFileSync(join(root, relative), "utf8"));
+
+// Whether relativePath falls inside the set tsconfig.json actually type-checks: matched by
+// at least one include pattern and matched by no exclude pattern.
+//
+// path.matchesGlob(path, pattern) is stable since Node v24.8.0 / v22.20.0
+// (https://nodejs.org/docs/latest/api/path.html#pathmatchesglobpath-pattern), confirmed in
+// this session against this repo's own paths (e.g. "skills/*/test/cases/**" matches
+// "skills/use-context-reviewer-security/test/cases/safe/env-key.ts").
+const isInTypeCheckScope = (tsconfig, relativePath) => {
+  const include = tsconfig.include ?? [];
+  const exclude = tsconfig.exclude ?? [];
+  const included = include.some((pattern) => matchesGlob(relativePath, pattern));
+  const excluded = exclude.some((pattern) => matchesGlob(relativePath, pattern));
+  return included && !excluded;
+};
+
+test("型検査の対象集合が skills/*/test/cases 配下の .ts を 1 件も含まない", () => {
+  const tsconfig = readJson("tsconfig.json");
+  const candidates = globSync("skills/*/test/cases/**/*.ts", { cwd: root });
+  assert.ok(
+    candidates.length > 0,
+    "no skills/*/test/cases/**/*.ts file exists in this checkout to check the exclusion against",
+  );
+  const offenders = candidates.filter((relativePath) => isInTypeCheckScope(tsconfig, relativePath));
+  assert.deepEqual(
+    offenders,
+    [],
+    `tsconfig.json's type-check target set still contains skills/*/test/cases files: ${offenders.join(", ")}`,
+  );
+});
+
+test("型検査の対象集合が workflows 配下の .ts を含む", () => {
+  const tsconfig = readJson("tsconfig.json");
+  const representative = "workflows/tests/tsconfig-scope.representative.ts";
+  assert.ok(
+    isInTypeCheckScope(tsconfig, representative),
+    "tsconfig.json's type-check target set does not include workflows/**/*.ts",
+  );
+});


### PR DESCRIPTION
## What & Why

workflows/_lib/gate.py を TypeScript へ移す第 1 スライスとして、CI に型検査ゲートと .ja/EN パリティ検査の骨格を追加する。この状態に達すると、helper script が TypeScript として動き、CI が型検査と .ja 構造パリティで守る状態に、残り 142 本を同じ手順で運べる。

## Review focus

- tsconfig.json の include/exclude と CI の型検査ステップが、`.test.ts` を含む検査対象範囲を正しく捉えているか
- gate.differential.test.ts/gate.test.ts/code.gate.test.js は gate.ts 本体の実装より先にコミットされており、現時点では Red のまま残っている

## Changes

- CI の Node を 22 から 24 に上げた。`.test.ts` を `node --test` で無フラグ実行する型ストリップは Node 22.18/23.6 で有効だが、stable 化したのは 24.12/25.2 系列のみのため
- @types/node と typescript 7.0.2 を devDependency に追加し、tsconfig.json の `types` に `node` を明示した

## Design Decisions

- 型検査は CI の専用ステップ (`npx tsc --noEmit`) として独立させ、既存の `node --test` 実行コマンドには混ぜなかった

## How to Test

1. `npx tsc --noEmit -p tsconfig.json`
   期待値: exit 0
2. `node --test --test-reporter=tap "workflows/**/tests/*.test.ts" "workflows/tests/*.test.js" "workflows/code/tests/*.test.js"`
   現状: 97 pass/13 fail (gate.ts 未実装分。詳細は下記の Verify Output を参照)


---

_下は build workflow の自動検証結果。plan との突合までで、コードの欠陥を探すレビューはしていない。PR の本筋からは外れるので任意だが、status 行の逸脱件数が非ゼロなら見る。_

Closes #594

<details>
<summary><code>verify tests=FAIL gates=FAIL</code> · <code>scope-deviations 2</code> · <code>missing-tests 1</code> · <code>untouched-plan-files 7</code> · <code>conformance 6 (5 high)</code></summary>

<details><summary>verify 出力</summary>

```
TEST SUITE: node --test --test-reporter=tap "workflows/**/tests/*.test.ts" "workflows/tests/*.test.js" "workflows/code/tests/*.test.js"
1..110
# tests 110
# pass 97
# fail 13
# cancelled 0
# skipped 0
# duration_ms 662.37

All 13 failures share one root cause: /Users/thkt/.claude/workflows/_lib/gate.ts does not exist on disk (only workflows/_lib/gate.py exists). This is a mid-migration state -- tests were already committed (9f535ae9 "port gate.py test subset to typescript") expecting a TypeScript gate.ts, plus one uncommitted/untracked test workflows/_lib/tests/gate-retirement.test.ts that also asserts zero remaining references to gate.py, but the gate.ts port itself was never written and gate.py/its call sites were never retired.

Failing tests:
1. workflows/_lib/tests/gate-retirement.test.ts:24 -- 4 tracked files still reference gate.py (.ja/workflows/code.js, workflows/_lib/tests/gate.differential.test.ts, workflows/_lib/tests/gate_test.py, workflows/code.js)
2-5. workflows/_lib/tests/gate.differential.test.ts (parity/1MiB-output/timeout/signal cases) -- all fail with "Cannot find module '/Users/thkt/.claude/workflows/_lib/gate.ts'"
6,8,9. workflows/_lib/tests/gate.test.ts (unknown-flag/dup-singleton, missing_required_output/forbidden_output, calibrate-anchor cases) -- same "Cannot find module gate.ts"
7. workflows/_lib/tests/gate.test.ts:109 -- ERR_MODULE_NOT_FOUND importing '../gate.ts' directly
57-59. workflows/code/tests/code.gate.test.js -- runGate still launches gate.py via python3 (the "$(P=...find .../gate.py...)" shell snippet), not gate.ts via node; the .ja/EN code.js gateScript constant is still 'workflows/_lib/gate.py'
60. workflows/code/tests/code.gate.test.js:479 -- asserts gate.ts exists at /Users/thkt/.claude/workflows/_lib/gate.ts; ENOENT

LINT GATE: node_modules/.bin/oxlint . -> exit 0, 0 diagnostics. PASS.

TYPE-CHECK GATE: node_modules/.bin/tsc --noEmit -p tsconfig.json -> exit 1.
workflows/_lib/tests/gate.test.ts(110,33): error TS2307: Cannot find module '../gate.ts' or its corresponding type declarations.
FAIL (same root cause as the test failures: gate.ts is missing).

Per instruction, no fixes were applied -- results reported as-is.
```

</details>

**実機確認 (merge 前に実施)**
- [ ] 型検査を test_command から外した理由の確認: tsconfig.json と typescript 依存はこの plan 自身が U-001 と U-002 で作るため、それ以前の unit では `tsc -p tsconfig.json` が解決しない。型検査は CI ステップと下の falsification が持つ
- [ ] CI の falsification: 型検査対象の .ts へ意図的な型エラーを入れて CI が赤くなることを 1 回確認する
- [ ] CI の falsification: .test.ts へ意図的に失敗するアサーションを入れて CI が赤くなることを 1 回確認する

**Plan スコープ外の変更ファイル**
- `workflows/_lib/tests/gate-retirement.test.ts`
- `workflows/tests/tsconfig-scope.representative.ts`

**一度も変更されていない plan の files**
- `workflows/_lib/gate.ts`
- `workflows/_lib/tests/gate_test.py`
- `.ja/workflows/_lib/gate.ts`
- `workflows/_lib/gate.py`
- `.ja/workflows/_lib/gate.py`
- `workflows/code.js`
- `.ja/workflows/code.js`

**テストとして見つからない plan の言明**
- 追跡ファイルのどれも _lib/gate.py を参照しない

**Issue 適合性 (独立レビュー)**
- `[high] missing` workflows/_lib/gate.ts はツリー内のどこにも存在せず(追跡済み・未追跡とも)、それを検証する差分テストのみがコミットされている。node --test --experimental-strip-types でスイートを実行するとT-006からT-009が『Cannot find module gate.ts』で失敗する。npx tsc --noEmit も同じ欠落モジュールに対してTS2307で失敗し、この差分はリポジトリ自身の型チェック工程を赤のままにする。U-001からU-005までの各コミットはTDDのRed半分(テスト)のみを含み、gate.ts自体に対応するGreenの実装コミットがない。
  `workflows/_lib/ (no gate.ts file present); workflows/_lib/tests/gate.differential.test.ts` · spec: U-004 gate.ts が gate.py と同じ出力を返す — files: workflows/_lib/gate.ts, workflows/_lib/tests/gate.differential.test.ts / contract: workflows/_lib/gate.py の CLI 契約をそのまま移す
- `[high] missing` gate.ts が存在しないため、この基準が対象とするENOBUFS/maxBufferの挙動は未実装であり検証不能である。T-007の差分テストは同等性を確認するのではなく、そのまま失敗する。
  `workflows/_lib/tests/gate.differential.test.ts (T-007, fails as 'not ok 3' in the test run)` · spec: Acceptance Criteria: 1MiB を超える出力を出すコマンドで `gate.ts` が pass を返す
- `[high] wrong` 廃止確認は追跡ファイルに対してリテラル文字列'_lib/gate.py'をgrepするが、テストファイル自身がそのリテラルをREFERENCE定数・テスト名・エラーメッセージ内に含む。gate.pyを両ツリーから完全に削除した後でも、`git grep -F "_lib/gate.py"` はこのテストファイルにマッチし続けるため、T-014は現状の書き方ではグリーンになり得ない。この点は、gate.py、`.ja/workflows/_lib/gate.py`、`workflows/_lib/tests/gate_test.py` が今日時点でなお存在するという事実とは独立して、チェック自体が自己矛盾していることを示す。
  `workflows/_lib/tests/gate-retirement.test.ts:15 (`const REFERENCE = "_lib/gate.py";`)` · spec: Acceptance Criteria: 追跡ファイルのどれも `_lib/gate.py` を参照しない
- `[high] missing` runGate は EN と .ja の両ファイルで、いまだ `python3 ${gateScript}`(`gateScript = bundled("workflows/_lib/gate.py")`)としてコマンドを構築している。gate.ts をnodeで起動する方式への切り替えは行われていない。コミットba18d5d3で追加されたT-015、T-016、T-017、T-017bはまさにこの挙動を検証するテストであり、実行するといずれも失敗する。
  `workflows/code.js:116-128 and .ja/workflows/code.js:117-129` · spec: U-007 contract: `workflows/code.js` `runGate` が組み立てる `python3 ${gateScript}` を node 起動へ替える
- `[high] wrong` 追加されたファイルは、テスト内部でローカルに定義された比較ヘルパー(`stripTsComments`/`tsBodyMatches`)を、3件の合成文字列リテラルに対してユニットテストするのみである。リポジトリのEN/.jaツリー配下にある実ファイルを読み取ったり比較したりすることは一切なく、契約が示す統合先である `hooks/_lib/mirror_prose.py` にも組み込まれておらず、この差分では同ファイルに変更がない。この差分中のどのチェックも実際の`.ts`ファイルの同等性を保証しておらず、テスト自体は通過してもこの受け入れ基準は満たされていない。
  `workflows/tests/ja-ts-parity.test.js:1-72` · spec: U-003 contract / Acceptance Criteria: EN と `.ja` の `.ts` がコメントを除いた本文で一致することを検査が保証する
- `[medium] missing` Testing Decisions セクションは『26 テスト。U-005 で `.ts` へ移す』と繰り返しているが、gate.test.ts自身のヘッダーコメントは『Only a subset of gate_test.py's 26 tests is ported in this pass; the rest arrive in later units,』と述べており、gate_test.py自体は削除も縮小もされていない。コミットされたユニットが移植しているのは、契約行が挙げる26テストではなく、4件の受け入れテストシナリオ(T-010からT-013)である。
  `workflows/_lib/tests/gate.test.ts (added) and workflows/_lib/tests/gate_test.py (untouched, still 26 Python tests)` · spec: U-005 contract: `workflows/_lib/tests/gate_test.py` の 26 テストを移す

**異常 (Red 未確認)**
- U-001 (commit-unverified): ユニットの範囲外のパスがコミットされている: workflows/tests/tsconfig-scope.representative.ts
- U-002 (commit-unverified): コミットメッセージ本文が、宣言されたブロックと文字どおりに一致しない。
- U-003 (scope-cut): tsBodyMatches のロジックを、実際の適用箇所(`hooks/_lib/mirror_prose.py` またはワークフロースクリプト)に組み込み、リポジトリ内の実際のEN/.ja `.ts` ペアがコミット時・CI時に検査されるようにする必要がある。このユニットはインラインのフィクスチャに対して比較アルゴリズムを証明しているに過ぎない。本番コードはまだこれを一切呼び出していない。
- U-003 (commit-unverified): コミットメッセージ本文が、宣言されたブロックと文字どおりに一致しない。
- U-004 (no-red): calibration_missing_calibration_evidence: Redキャリブレーションゲートの下でスイートが失敗しなかった。
  <details><summary>根拠 10 件</summary>

  - node --test --test-reporter=tap "workflows/_lib/tests/gate.differential.test.ts" → 4/4 new tests 'not ok', each stderr showing "Error: Cannot find module '/Users/thkt/.claude/workflows/_lib/gate.ts'"
  - node --test --test-reporter=tap "workflows/**/tests/*.test.ts" "workflows/tests/*.test.js" "workflows/code/tests/*.test.js" → '# tests 101 / # pass 97 / # fail 4', the 4 failures being exactly T-006..T-009 by name
  - npx tsc --noEmit -p tsconfig.json → exit 0 (after adding @types/node + tsconfig `types` field; failed with TS2591 'Cannot find name node:child_process' etc. before the fix)
  - /Users/thkt/.config/bun/bin/tsgo --noEmit -p tsconfig.json → exit 0 (the same binary the PostToolUse write-gate hook invoked and initially blocked on)
  - npx oxlint workflows/_lib/tests/gate.differential.test.ts → no output (no findings)
  - git diff --stat: package.json +1 line (@types/node devDependency), tsconfig.json +1 line (types: ["node"]), bun.lock +5 lines; workflows/_lib/tests/gate.differential.test.ts is new/untracked
  - python3 workflows/_lib/gate.py --cwd /tmp --command "python3 -c ...write('a'*2_000_000)" --expect pass → verdict pass, confirming the >1MiB baseline behavior the T-007 test targets
  - node -e spawnSync('/bin/zsh',['-c', same 2MB-output command]) → {error: 'ENOBUFS', stdout length: 1114112}, confirming the maxBuffer pitfall the contract names
  - python3 workflows/_lib/gate.py --cwd /tmp --command 'kill -TERM $$' --expect pass → evidence.exit_code -15, evidence.signal 'SIGTERM', exit 2 (basis for the T-009 assertions)
  - node -e spawnSync('/bin/zsh',['-c','kill -TERM $$']) → {status: null, signal: 'SIGTERM'} (confirms Node's native shape gate.ts must translate to match Python's -15/SIGTERM)

  </details>
- U-004 (commit-unverified): ユニットの範囲外のパスがコミットされている: bun.lock, package.json, tsconfig.json
- U-005 (no-red): calibration_missing_calibration_evidence: Redキャリブレーションゲートの下でスイートが失敗しなかった。
  <details><summary>根拠 6 件</summary>

  - node --test --test-reporter=tap workflows/_lib/tests/gate.test.ts -> 4/4 tests fail, each with 'Cannot find module .../gate.ts' (T-011 via ERR_MODULE_NOT_FOUND on the dynamic import; T-010/T-012/T-013 via the same error surfacing in the spawned CLI's stderr, caught by runCli's JSON-parse guard)
  - workflows/_lib/gate.ts does not exist: `find workflows/_lib -maxdepth 2 -type f` lists no gate.ts (only gate.py)
  - git log --all --oneline -- workflows/_lib/gate.ts returns nothing: gate.ts was never committed, so U-004's own gate.differential.test.ts is also currently Red for the identical reason
  - npx tsc --noEmit fails only on workflows/_lib/tests/gate.test.ts(110,33): Cannot find name/module '../gate.ts' -- and the same tsc failure already existed at HEAD from gate.differential.test.ts referencing '../gate.ts' before this change (confirmed by reading that committed file's own TS_SCRIPT line)
  - node --test ... full command: 97 pass / 8 fail (was 97 pass / 4 fail before this change) -- the 4 new failures are exactly this unit's 4 tests, no regression among the previously passing 97
  - python3 workflows/_lib/tests/gate_test.py -v: all 32 tests still pass unchanged (file not modified)

  </details>
- U-005 (commit-unverified): 件名が `<type>(<scope>): <description>` の形式になっていない。
- U-006 (no-red): calibration_missing_calibration_evidence: Redキャリブレーションゲートの下でスイートが失敗しなかった。
  <details><summary>根拠 3 件</summary>

  - node --test --test-reporter=tap workflows/_lib/tests/gate-retirement.test.ts -> 'not ok 1 - 追跡ファイルのどれも _lib/gate.py を参照しない' listing offenders: .ja/workflows/code.js, workflows/_lib/tests/gate.differential.test.ts, workflows/_lib/tests/gate_test.py, workflows/code.js
  - git ls-files | xargs grep -l '_lib/gate\.py' -> .ja/workflows/code.js, docs/decisions/0112-adopt-typescript-for-helper-scripts.md, workflows/_lib/tests/gate.differential.test.ts, workflows/_lib/tests/gate_test.py, workflows/code.js
  - full test command run (node --test --test-reporter=tap workflows/**/tests/*.test.ts workflows/tests/*.test.js workflows/code/tests/*.test.js) -> 106 tests, 9 failing; failure #1 is this new T-014 test, failures #2-9 are pre-existing gate.test.ts / gate.differential.test.ts failures from earlier units because workflows/_lib/gate.ts does not exist yet in this repo state (find . -iname 'gate*' shows no gate.ts anywhere), which is outside this unit's target files and not introduced by this change

  </details>
- U-006 (uncommitted): ユニットU-006の作業が未完了である: gate.py ファイルが workflows/_lib/ と .ja/workflows/_lib/ の両方になお存在しており(削除されるべき)、.ja/workflows/_lib/gate.ts は存在しない(作成されるべき)。ステージされているのはテストファイル workflows/_lib/tests/gate-retirement.test.ts のみであり、ユニットの計画が指定する対象ファイルは廃止に向けて準備されていない。
- U-007 (no-red): calibration_missing_calibration_evidence: Redキャリブレーションゲートの下でスイートが失敗しなかった。
  <details><summary>根拠 8 件</summary>

  - workflows/code.js:116 `const gateScript = bundled("workflows/_lib/gate.py");` and :128 `const command = [`python3 ${gateScript}`, ...args.map(shq)].join(" ");` — the current runtime/script pair T-015/T-016/T-017 target
  - workflows/_lib/gate.ts does not exist: `ls workflows/_lib/` shows only gate.py, codex-run.js, run-workflow.js, tests/ (no gate.ts); same absence confirmed under .ja/workflows/_lib/
  - `node --test --test-reporter=tap workflows/code/tests/code.gate.test.js` run in this session: 19 pass, 4 fail — T-015 error 'runGate should launch the gate script with node, not a python3 interpreter (got: python3 "$(...gate.py...)" ...)'
  - same run, T-016 error: "gateScript should now name gate.ts, not gate.py (got: workflows/_lib/gate.py)"
  - same run, T-017 error: 'calibrate:U-G1: expected a node launch of the real gate.ts (got: python3 "$(...gate.py...)" ...)' — fails before ever needing gate.ts to exist, because code.js still emits the python3/gate.py command
  - same run, T-017b error: "ENOENT: no such file or directory, open '/Users/thkt/.claude/workflows/_lib/gate.ts'" — documents the missing-preceding-unit gap explicitly
  - full required test command `node --test --test-reporter=tap "workflows/**/tests/*.test.ts" "workflows/tests/*.test.js" "workflows/code/tests/*.test.js"` run in this session: 97 pass, 13 fail (13 = 9 pre-existing gate.ts-related failures already present before this change [gate-retirement.test.ts x1, gate.test.ts x6, gate.differential.test.ts x2] + the 4 new T-015/T-016/T-017/T-017b failures; verified via `grep '^not ok'` on the tap output)
  - `git status --short` / `git diff --stat` after the edit: only workflows/code/tests/code.gate.test.js changed (161 insertions), no changes to workflows/code.js or .ja/workflows/code.js

  </details>

</details>
