### PR TITLE
fix(workflows): let the red gate seal a respaced name and a trailing verdict

### DIFF
--- a/.ja/workflows/_lib/gate.ts
+++ b/.ja/workflows/_lib/gate.ts
@@ -66,7 +66,7 @@ const LINE_SPLIT = /\r\n|\r|\n/;
 export const MAX_CALIBRATION_CANDIDATES = 128;
 export const MAX_CALIBRATION_LINE_LENGTH = 2000;
 const FAILURE_MARKER =
-  /(?:^\s*not ok\b|^\s*(?:FAIL(?:ED|URE)?\b|ERROR\b|\(fail\)|[✖✕×✗❌●])|^\s*\d+\)\s+|\bFAILED\b|\bFAILURE\b)/i;
+  /(?:^\s*not ok\b|^\s*(?:FAIL(?:ED|URE)?\b|ERROR\b|\(fail\)|[✖✕×✗❌●])|^\s*\d+\)\s+|\bFAILED\b|\bFAILURE\b|\.{3}\s*(?:FAIL|ERROR)\s*$)/i;
 const LF = 0x0a;
 const CR = 0x0d;
 
@@ -194,16 +194,37 @@ export function outputLines(stream: "stdout" | "stderr", text: string): Candidat
   return lines;
 }
 
+const REGEX_META = /[.*+?^${}()|[\]\\]/g;
+
+// 行のどこに計画テスト名が座っているか。名前の中の空白の連なりは、行側で消えていてもよい。
+//
+// 完全一致で引かないのは、計画の文が repository の Markdown formatter を通ってここへ届くため。
+// formatter は日本語の中の ASCII 数字の前後を空けるが、同じ文をテスト名として書いた側にその
+// 空白は無い。完全一致だと候補が 1 件も出ず、seal する行が無いまま run が止まってしまう。
+function locateName(line: string, name: string): { at: number; length: number } | null {
+  const at = line.indexOf(name);
+  if (at >= 0) {
+    return { at, length: name.length };
+  }
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length < 2) {
+    return null;
+  }
+  const pattern = parts.map((part) => part.replace(REGEX_META, "\\$&")).join("\\s*");
+  const match = new RegExp(pattern).exec(line);
+  return match === null ? null : { at: match.index, length: match[0].length };
+}
+
 // 計画テスト名を含み、その名前を除いた残りに失敗マーカーがある行。
 //
 // マーカーを探す前に名前を切り落とす。そうしないと、名前自体に "error" を含むテストが
 // 名前の力だけでマーカーを満たしてしまう。
 export function namesPlannedFailure(line: string, name: string): boolean {
-  const at = line.indexOf(name);
-  if (at < 0) {
+  const found = locateName(line, name);
+  if (found === null) {
     return false;
   }
-  const context = line.slice(0, at) + line.slice(at + name.length);
+  const context = line.slice(0, found.at) + line.slice(found.at + found.length);
   return FAILURE_MARKER.test(context);
 }
 

--- a/workflows/_lib/gate.ts
+++ b/workflows/_lib/gate.ts
@@ -67,7 +67,7 @@ const LINE_SPLIT = /\r\n|\r|\n/;
 export const MAX_CALIBRATION_CANDIDATES = 128;
 export const MAX_CALIBRATION_LINE_LENGTH = 2000;
 const FAILURE_MARKER =
-  /(?:^\s*not ok\b|^\s*(?:FAIL(?:ED|URE)?\b|ERROR\b|\(fail\)|[✖✕×✗❌●])|^\s*\d+\)\s+|\bFAILED\b|\bFAILURE\b)/i;
+  /(?:^\s*not ok\b|^\s*(?:FAIL(?:ED|URE)?\b|ERROR\b|\(fail\)|[✖✕×✗❌●])|^\s*\d+\)\s+|\bFAILED\b|\bFAILURE\b|\.{3}\s*(?:FAIL|ERROR)\s*$)/i;
 const LF = 0x0a;
 const CR = 0x0d;
 
@@ -195,16 +195,39 @@ export function outputLines(stream: "stdout" | "stderr", text: string): Candidat
   return lines;
 }
 
+const REGEX_META = /[.*+?^${}()|[\]\\]/g;
+
+// Where the planned name sits in the line, with each run of whitespace inside the name
+// allowed to be absent from the line.
+//
+// Not an exact comparison: the plan's sentence reaches here through the repository's
+// Markdown formatter, which spaces an ASCII digit run apart from the Japanese around it,
+// while the same sentence written into a test name carries no such space. An exact
+// comparison then offers no candidate at all and the run stops with nothing to seal.
+function locateName(line: string, name: string): { at: number; length: number } | null {
+  const at = line.indexOf(name);
+  if (at >= 0) {
+    return { at, length: name.length };
+  }
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length < 2) {
+    return null;
+  }
+  const pattern = parts.map((part) => part.replace(REGEX_META, "\\$&")).join("\\s*");
+  const match = new RegExp(pattern).exec(line);
+  return match === null ? null : { at: match.index, length: match[0].length };
+}
+
 // A line naming the planned test and, outside that name, carrying a failure marker.
 //
 // The name is cut out before the marker is looked for. A test whose own name contains
 // "error" would otherwise satisfy the marker on the strength of its name alone.
 export function namesPlannedFailure(line: string, name: string): boolean {
-  const at = line.indexOf(name);
-  if (at < 0) {
+  const found = locateName(line, name);
+  if (found === null) {
     return false;
   }
-  const context = line.slice(0, at) + line.slice(at + name.length);
+  const context = line.slice(0, found.at) + line.slice(found.at + found.length);
   return FAILURE_MARKER.test(context);
 }
 

--- a/workflows/_lib/tests/gate.test.ts
+++ b/workflows/_lib/tests/gate.test.ts
@@ -460,3 +460,31 @@ test("T-032 every verdict branch is reachable from an observation alone", () => 
   assert.equal(calCode, 1);
   assert.equal(calReport.classification, "calibration_unexpected_pass");
 });
+
+// The plan's sentence reaches the gate through the repository's Markdown formatter, which puts
+// spaces around an ASCII digit run in Japanese prose. The same sentence written into a test name
+// carries none, and an exact comparison then leaves the run with no candidate to seal at all.
+test("T-033 a planned name the formatter respaced still names its failure, and an absent one does not", () => {
+  const name = "追跡 `.py` すべてが 1 行目に持つ";
+  const line =
+    "test_T_001 (__main__.Shebang.test_T_001)\nT-001 追跡 `.py` すべてが1行目に持つ ... FAIL";
+  const [first, second] = line.split("\n");
+  assert.deepEqual(
+    calibrationCandidates("", `${first}\n${second}\n`, [["T-001", name]]).map((c) => c.text),
+    [second],
+  );
+  assert.deepEqual(calibrationCandidates("", `${second}\n`, [["T-002", "別の名前"]]), []);
+});
+
+// unittest's verbose reporter puts its verdict at the end of the line, so a marker set that only
+// looks for FAIL at the head of a line reads a failing Python suite as offering nothing.
+test("T-034 a trailing unittest verdict counts as a failure marker and a passing one does not", () => {
+  const planned: [string, string][] = [["T-001", "シェバンを持つ"]];
+  const fail = "T-001 シェバンを持つ ... FAIL";
+  const error = "T-001 シェバンを持つ ... ERROR";
+  const ok = "T-001 シェバンを持つ ... ok";
+  assert.deepEqual(
+    calibrationCandidates("", `${fail}\n${error}\n${ok}\n`, planned).map((c) => c.text),
+    [fail, error],
+  );
+});


### PR DESCRIPTION
## Summary

#607 の build が Red ゲートで止まり、`calibration_missing_calibration_evidence` と空の候補リストを返した。Red テストだけがコミットされ、Green の書き換えには一度も到達していない。原因は独立した 2 つの欠陥だった。

## 欠陥 1: 計画テスト名の完全一致

`namesPlannedFailure` は plan の文を `indexOf` で行に照合していた。plan の文は repository の Markdown formatter を通り、日本語の中の ASCII 数字の前後が空く。同じ文をテスト名として書いた側にその空白は無い。

| plan 側 | テスト名側 |
| --- | --- |
| `...すべてが 1 行目に...` | `...すべてが1行目に...` |

失敗中の 3 テストがすべて候補から外れ、seal する行が 1 本も残らなかった。名前の中の空白の連なりを、行側で消えていてもよい形に緩めた。それ以外の照合は完全一致のまま。

## 欠陥 2: 行末の判定を拾わない失敗マーカー

`FAILURE_MARKER` は行頭の `FAIL` しか見ていなかった。unittest の verbose reporter は判定を行末に置く。

```
T-001 <docstring> ... FAIL
```

このリポジトリの Python テストは全て `unittest.main(verbosity=2)` で終わるので、Python スイートは常に「失敗マーカーを持つ行が 1 本も無い」出力として読まれていた。

## Test plan

- `node --test workflows/_lib/tests/gate.test.ts` — 20 passed（T-033 と T-034 を追加）
- 追加した 2 テストが修正前のロジックで落ちることを確認した。旧マーカーは `... FAIL` を `false` と判定し、旧 `indexOf` は再スペース版を見つけない
- `npx tsc --noEmit` — exit 0
- `npx oxlint` — 指摘なし
- `node --test "workflows/**/tests/*.test.{js,ts}" "workflows/tests/*.test.js"` — 431 passed
- `.ja` ミラーを同じコミットで更新。`ja-ts-parity` の全域走査が通っている

## Design Decisions

- 14 件の計画テスト名を書き換えて回避する道を採らなかった。同じ形が今後の plan でも出るため、照合側を直した
- 名前の中の空白を `\s*` に緩めるにとどめ、文字単位の緩和はしていない。名前が行に無い場合はこれまでどおり候補にならない
- 行末判定に加えたのは `FAIL` と `ERROR` のみ。`ok` と `skipped` は拾わない

https://claude.ai/code/session_01VP6XCc8KUQDEhfcVoiZz2b
