### PR TITLE
fix(workflows): keep the gate report short enough to relay whole

### DIFF
--- a/.ja/workflows/code.js
+++ b/.ja/workflows/code.js
@@ -132,10 +132,19 @@ const parsedReport = (stdout) => {
   }
 };
 
+// レポートは agent を経由して戻るので、長いものは途中で切れて戻る。ある run では 1.5 KB から
+// 8.7 KB のレポートが中継され、解析できない形で届いたものは 5.7 KB だった。その長さの大半は
+// 2 つの出力 tail で、ここはそれを一度も読まない。読むのは verdict と classification と
+// candidates である。gate.ts の既定は tail 1 つあたり 12 KB。
+const GATE_TAIL_BYTES = "800";
+
 // gate.ts は Node の TypeScript 型ストリップの上で動く。それより古い node のシェルでは最初の
 // 型注釈でコマンドが死に、stdout には何も出ない。中継した stderr だけが原因を名指す場所になる。
 const runGate = async (unit, label, args) => {
-  const command = [`node ${gateScript}`, ...args.map(shq)].join(" ");
+  const command = [
+    `node ${gateScript}`,
+    ...[...args, "--tail-bytes", GATE_TAIL_BYTES].map(shq),
+  ].join(" ");
   const relayed = await relayStdout(unit, label, command);
   if (relayed === null) return null;
   const report = parsedReport(relayed.stdout);

--- a/workflows/code.js
+++ b/workflows/code.js
@@ -131,11 +131,20 @@ const parsedReport = (stdout) => {
   }
 };
 
+// The report crosses back through an agent, and a long one comes back truncated: a run of
+// gate calls relayed reports of 1.5 KB to 8.7 KB and the one that arrived unparseable was
+// 5.7 KB. Most of that length is the two output tails, which nothing here reads -- the script
+// reads verdict, classification, and candidates. gate.ts defaults the tails to 12 KB each.
+const GATE_TAIL_BYTES = "800";
+
 // gate.ts runs on Node's TypeScript type stripping. A shell whose node predates it kills the
 // command at the first type annotation and writes nothing to stdout, so the relayed stderr is
 // the only place the cause is named.
 const runGate = async (unit, label, args) => {
-  const command = [`node ${gateScript}`, ...args.map(shq)].join(" ");
+  const command = [
+    `node ${gateScript}`,
+    ...[...args, "--tail-bytes", GATE_TAIL_BYTES].map(shq),
+  ].join(" ");
   const relayed = await relayStdout(unit, label, command);
   if (relayed === null) return null;
   const report = parsedReport(relayed.stdout);


### PR DESCRIPTION
## Summary

gate のレポートはシェルから agent を経由して戻る。**長いものは途中で切れて戻る。** #605 の build で 1 unit がそこで止まった。

同じ run で中継されたレポートの実測。

| 位置 | サイズ | 解析 |
| --- | --- | --- |
| U-001 calibrate | 5132 B | OK |
| U-002 calibrate | 6456 B | OK |
| U-003 calibrate | 8635 B | OK |
| U-003 red | 8699 B | OK |
| U-004 calibrate | 5949 B | OK |
| **U-004 red** | **5691 B** | **FAIL** |

サイズに固い閾値は無く、確率的に切れる。落ちた 1 本は出力 tail の文字列の途中で切断されていた。**gate 自体は `verdict: pass` を返し、封印した行も `output_includes` で一致していた。** unit は `gate_did_not_report` として止まった。

## 原因と修正

長さの大半は 2 つの出力 tail で、`gate.ts` の既定は 1 つあたり 12 KB である。**呼び出し側はそれを一度も読まない。**

```
ugrep -c 'stdout_tail|stderr_tail' workflows/code.js workflows/build.js
workflows/code.js:0
workflows/build.js:0
```

読むのは `verdict` と `classification` と `candidates` だけ。`runGate` が毎回 `--tail-bytes 800` を渡すようにした。同じレポートで 5691 B → 1753 B。

## Test plan

- 落ちた U-004 の公式 Red gate を `--tail-bytes 800` 付きで手で再現し、レポートが 1753 B になることを確認
- `node --test "workflows/**/tests/*.test.{js,ts}" "workflows/tests/*.test.js" "tests/*.test.js"` — 466 passed
- `npx oxlint` — exit 0
- `.ja` ミラーを同じコミットで更新

## Design Decisions

- courier の model は haiku のまま。原因は入力の長さで、短くすれば足りる。model を上げても長さの上限は消えない
- tail を 0 にせず 800 にした。gate が `blocked` を返したとき、run log を読む人間に最後の数行が要る
- `runGate` の 1 箇所に置いた。calibrate と公式 Red の両方が同じ経路を通る

https://claude.ai/code/session_01VP6XCc8KUQDEhfcVoiZz2b
