### PR TITLE
[scribe] gate 中継 tail サイズ、TS 移行 CI glob を候補へ追加

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -62,6 +62,8 @@
 - tests を持つ unit は plan の files に、そのテストが動かすモジュールを含める。Red が触れるのは files にあるものだけなので、files 外を import するテストは Red を確立できない #600
 - plan 文の Markdown 整形は日本語中の ASCII 数字前後に空白を入れるため、テスト名照合は空白の連なりの有無を許容しないと候補を取りこぼす #609
 - unittest.main(verbosity=2) の verbose reporter は判定 (FAIL/ERROR) を行末に置くため、行頭マーカーのみを見る失敗検出は Python スイートの失敗を常に取りこぼす #609
+- gate レポートの中継はシェル→agent 経由で確率的に途中で切れるため、呼び出し側が読まない stdout_tail 等のフィールドは既定サイズを呼び出し元で絞る #614
+- skills 配下の Python を TypeScript へ移すとき、.github/workflows/test.yml の Node tests step は glob を手動で足さないと拾わない。Python 側は find なので .py を消せば自動で外れるが、.ts を足しても自動では入らない #615
 
 ## 棄却
 


### PR DESCRIPTION
## 追加した候補 (単発)

- gate レポートの中継はシェル→agent 経由で確率的に途中で切れるため、呼び出し側が読まない stdout_tail 等のフィールドは既定サイズを呼び出し元で絞る #614
- skills 配下の Python を TypeScript へ移すとき、.github/workflows/test.yml の Node tests step は glob を手動で足さないと拾わない。Python 側は find なので .py を消せば自動で外れるが、.ts を足しても自動では入らない #615

いずれも根拠 1 件のため、ページへは昇格していない (`docs/wiki/_candidates.md` の閾値は 2 件)。

## 対象範囲

前回 scribe PR (#614 が merge された 2026-08-31T15:27:09Z) 以降に merge/close された PR/issue のうち、scribe ラベル以外の全件。

- PR: #614, #615
- issue: #605
- research file: 0 件 (該当ファイル無し)

## Phase 4/5 の検査

- `docs/wiki/*.md` の参照コードを機械的に全件 sweep (39 ページ、全参照): 壊れているものなし
- 構造ページ (`skills-structure.md` / `workflow-structure.md`) の境界・契約・要求を現行コードと突き合わせ: drift なし
- 由来リンクを持つ 5 ページ (`external-origin-labeling.md` / `ja-mirror-drift.md` / `skills-structure.md` / `untracked-output-manual-close.md` / `workflow-structure.md`) の DR 参照 8 件: いずれも `status: accepted`、張り替え不要

## 見送った候補

- #615/#605 の「機構コストはファイル数に比例しない」「.ja パリティ検査への配線」は、PR/issue 自身が明記する Design Decision の一部、または `docs/wiki/ja-mirror-drift.md` が既に持つ規約の一事例のため、新規候補にしなかった

## Deferred

`昇格待ち` は 0 件のまま。今回追加した 2 件は次の run で 2 件目の根拠が付けばページへ昇格する。