### PR TITLE
[Feature] hooks 配下の Python を TypeScript へ移行する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
           "tests/*.test.js"
           "agents/**/tests/*.test.js"
           "hooks/**/tests/*.test.js"
+          "hooks/**/tests/*.test.ts"
           "skills/**/tests/*.test.js"
           "skills/**/tests/*.test.ts"
           "workflows/**/tests/*.test.js"

--- a/docs/decisions/0112-adopt-typescript-for-helper-scripts.md
+++ b/docs/decisions/0112-adopt-typescript-for-helper-scripts.md
@@ -30,7 +30,7 @@ Chosen option: "helper script を TypeScript へ段階移行する", because 起
 ### Consequences
 
 - Good, because helper 同士が型を共有でき、契約が手書きガードから型へ移る
-- Good, because hook 1 本あたりの起動が 34ms から 23ms へ下がる。`PreToolUse` の Bash matcher は 8 本あるので Bash 1 回あたり約 90ms 縮む
+- Good, because hook 1 本あたりの起動は実測で下がる。ただし当初見積もった 34ms から 23ms への下がり幅は #606 の実測と食い違い、正しくは python3 24.6ms、node 30.4ms（`node -e ''` の空プロセスのみ）、bun 14.7ms である。下がるのは bun を採った場合に限られ、node は python3 より遅いため hooks 層の runtime から外れる。`PreToolUse` の Bash matcher は 8 本あるので、bun 採用時は Bash 1 回あたり約 79ms 縮む。runtime の選び直しは DR-0114 に記録する
 - Bad, because 移行中は Python と TypeScript が同居し、CI が ruff と型検査の両方を持つ
 - Bad, because 実行に必要なランタイムの床が `python3` から Node 24 以上へ上がる
 

--- a/docs/decisions/0114-justify-the-hooks-typescript-migration-by-the-type-contract.md
+++ b/docs/decisions/0114-justify-the-hooks-typescript-migration-by-the-type-contract.md
@@ -1,0 +1,96 @@
+---
+status: "proposed"
+date: "2026-09-01"
+decision-makers: "thkt"
+---
+
+# Justify the hooks TypeScript migration by the type contract
+
+## Context and Problem Statement
+
+DR-0112 は helper script 全体の TypeScript 段階移行を、型契約の共有と起動コストの両方を根拠に決めた。起動コストの根拠は「stdin JSON + ローカル import を持つ現実的な hook 形が python3 で 34ms、TypeScript ファイルで 23ms」という当時の見積もりだった。
+
+#606 の設計中に実測すると値が違った。python3 は 24.6ms、`node -e ''` の空プロセスだけで 30.4ms、bun は 14.7ms である（DR-0113 に記録済み）。node は python3 より遅く、hooks 層に node をそのまま採ると `PreToolUse` の Bash matcher 8 本の合計起動時間は移行前を下回るどころか悪化する。DR-0112 の Success Criteria が要求する「移行前を下回る」を node だけでは満たせない。
+
+一方で settings.json は hook を絶対パスのシェバン経由で直接起動し、PATH は truncated である（`hooks/_lib/tests/shebang_test.py`、#534）。ランタイムを切り替えるなら、そのシェバンが指す先も同じ制約を満たす必要がある。
+
+hooks 層の移行を続けるなら、根拠を起動コストから型契約へ置き直すか、起動コストを満たす別のランタイムを採るかを決める必要がある。
+
+## Decision Drivers
+
+- 契約を型として共有できるかどうか（DR-0112 が最初に挙げた観点で、実測結果と無関係に成立する）
+- hooks 層の起動コスト実測。DR-0112 の Success Criteria は「移行前を下回る」であり、node 単体では満たせない
+- settings.json が hook をシェバン経由で直接起動する制約。PATH が truncated なので、mise shim のような PATH 依存の解決は使えない（shebang_test.py と同じ理由）
+- CI は node で走り、`npx tsc --noEmit` と `node --test` が型検査とテストの実行環境である（DR-0112 の Confirmation、DR-0113 の Context）
+
+## Considered Options
+
+- hooks 層も node で実行する（DR-0112 の当初想定のまま）
+- hooks 層は bun で実行し、CI の型検査とテストは node で行う
+- hooks 層の TypeScript 移行を見送り、Python のまま据え置く
+
+## Decision Outcome
+
+Chosen option: "hooks 層は bun で実行し、CI の型検査とテストは node で行う", because 型契約の共有という主目的は runtime の選択と無関係に成立し、起動コストという副次目的は bun を採ってはじめて満たせるため。node は起動コストの点で hooks 層の runtime として失格 (disqualified) であり、この記録がその判断そのものと、bun を採る場合にシェバンがどの形になるかを残す。
+
+### Consequences
+
+- Good, because 型契約の共有は runtime に関わらず得られ、DR-0112 の主目的が保たれる
+- Good, because 起動コストは bun 採用時に実際に下がる。python3 の 24.6ms から bun の 14.7ms へ、Bash matcher 8 本で約 79ms 縮む
+- Bad, because node は起動コストの点で hooks 層の runtime から外れる。node の空プロセスは 30.4ms で python3 の 24.6ms より遅く、node 単体の採用は DR-0112 の Success Criteria を悪化させる方向に働く
+- Bad, because 配布ランタイムの前提が hooks 層だけ bun を追加で要求する。DR-0112 が書いた「Node 24 以上」という床は workflows/skills 層には残るが、hooks 層はそれだけでは足りない
+- Bad, because bun のインストール経路が環境ごとに揺れうる。mise shim (`~/.local/share/mise/shims/bun`) は settings.json の truncated PATH では解決できないため、シェバンは絶対パスを直接書く必要がある。Homebrew 経由で入れた場合は `#!/opt/homebrew/bin/bun` が `#!/opt/homebrew/bin/python3` と同じ形の固定パスになるが、bun.sh のインストーラーが既定で使う `~/.bun/bin/bun` はユーザーのホームディレクトリに依存し、同じ固定パスにならない
+
+### Confirmation
+
+`hooks/_lib/tests/shebang_test.py` と同じ形のテストを hooks 層の `.ts` に用意し、実行ビットを持つ追跡 `.ts` の 1 行目が固定のシェバン（bun の絶対パス、Homebrew 経由なら `#!/opt/homebrew/bin/bun`）と一致することを検査する。移行が始まるまでは対象 0 件で green になる。CI 側の型検査とテストは `npx tsc --noEmit -p tsconfig.json` と `node --test` のまま変わらない。
+
+## Pros and Cons of the Options
+
+### hooks 層も node で実行する
+
+DR-0112 の当初想定通り、workflows/skills 層と同じ runtime を hooks 層にも使う。
+
+- Good, because runtime が 1 つで済み、DR-0113 の「node と bun のどちらでも動く」規律を hooks 層で守る必要がない
+- Bad, because 起動コストが python3 より悪化し（30.4ms > 24.6ms）、DR-0112 の Success Criteria を満たせない
+
+### hooks 層は bun で実行し、CI は node で行う
+
+hooks 層の実行だけ bun のシェバンに切り替え、型検査とテストは既存の node のまま保つ。
+
+- Good, because 型契約の共有と起動コストの改善を両立できる
+- Bad, because DR-0113 の「bun 印の識別子を書かない」規律が、この層で実際に踏まれる条件になる。node で動かない bun 専用 API を書けば CI だけが落ち、hooks 実行では気づけない
+
+### hooks 層の TypeScript 移行を見送る
+
+Python のまま据え置き、workflows/skills 層だけ TypeScript に留める。
+
+- Good, because シェバンの絶対パス問題も runtime 追加の配布前提も発生しない
+- Bad, because DR-0112 が挙げた「helper 同士で型を共有する」目的が hooks 層には届かない。`hooks/_lib` は fan-in 16 の塊で、DR-0112 の Migration Strategy が最後のスライスに位置づけている
+
+## More Information
+
+### Migration Strategy
+
+hooks 層のスライスが始まる時点で、各 hook の shebang 行を `#!/opt/homebrew/bin/python3` から bun の絶対パスへ書き換える。`hooks/_lib/tests/shebang_test.py` が担う 4 つの検査（実行ビット付き `.py` のシェバン、stale シェバンの不在、settings.json 由来スクリプトのシェバン、`_lib` 配下のシェバン不在）を `.ts` 向けに複製し、python3 版はそのスライスが完了するまで両方が green であることを確認する。
+
+### Rollback Plan
+
+シェバンの書き換えは各 hook ファイル単位で独立しており、DR-0112 の Rollback Plan（スライス単位の PR revert）がそのまま適用できる。bun のインストールが得られない環境が判明した場合は、この記録だけを revert し hooks 層の移行を node runtime の選択肢へ戻すか、Python のまま据え置く選択肢へ戻す。
+
+### Success Criteria
+
+- hooks 層の移行後、`PreToolUse` の Bash matcher 8 本の合計起動時間が移行前（python3 24.6ms × 8）を下回る。node 単体ではこの基準を満たせないことが実測済みなので、bun のシェバンで起動した状態で計測する
+- hooks 層の `.ts` が bun 専用 API を書かずに `node --test` の下でも green である（DR-0113 の discipline を hooks 層で実際に満たす）
+- 追跡された hooks 層の `.ts` すべてのシェバンが絶対パスで固定され、PATH 解決に依存しない
+
+### Reassessment Triggers
+
+- node の起動コストが bun と同等になり、hooks 層だけ runtime を分ける理由が消える（DR-0113 の Reassessment Triggers と同じ条件）
+- bun の Homebrew 経由インストールが配布対象の環境で保証できなくなり、固定パスのシェバンが書けなくなる
+- hooks 層の移行後、実測した起動時間の改善が DR-0112 の Reassessment Triggers が定める 1 本あたり 5ms を下回る
+
+### 関連する記録
+
+- DR-0112 Adopt TypeScript for helper scripts。段階移行そのものと、当初の起動コスト見積もりを決めた記録。この記録はその見積もりが実測と食い違った後の、hooks 層に限った runtime の選び直しであり、supersede ではない
+- DR-0113 Ban bun-branded identifiers in TypeScript sources。node と bun の両方で動く discipline を lint で執行する記録で、この記録が hooks 層の runtime として bun を選ぶ理由を裏付ける実測値（python3 24.6ms、node 30.4ms、bun 14.7ms）の出どころでもある

--- a/docs/decisions/0114-justify-the-hooks-typescript-migration-by-the-type-contract.md
+++ b/docs/decisions/0114-justify-the-hooks-typescript-migration-by-the-type-contract.md
@@ -10,7 +10,7 @@ decision-makers: "thkt"
 
 DR-0112 は helper script 全体の TypeScript 段階移行を、型契約の共有と起動コストの両方を根拠に決めた。起動コストの根拠は「stdin JSON + ローカル import を持つ現実的な hook 形が python3 で 34ms、TypeScript ファイルで 23ms」という当時の見積もりだった。
 
-#606 の設計中に実測すると値が違った。python3 は 24.6ms、`node -e ''` の空プロセスだけで 30.4ms、bun は 14.7ms である（DR-0113 に記録済み）。node は python3 より遅く、hooks 層に node をそのまま採ると `PreToolUse` の Bash matcher 8 本の合計起動時間は移行前を下回るどころか悪化する。DR-0112 の Success Criteria が要求する「移行前を下回る」を node だけでは満たせない。
+issue #606 の設計中に実測すると値が違った。python3 は 24.6ms、`node -e ''` の空プロセスだけで 30.4ms、bun は 14.7ms である（DR-0113 に記録済み）。node は python3 より遅く、hooks 層に node をそのまま採ると `PreToolUse` の Bash matcher 8 本の合計起動時間は移行前を下回るどころか悪化する。DR-0112 の Success Criteria が要求する「移行前を下回る」を node だけでは満たせない。
 
 一方で settings.json は hook を絶対パスのシェバン経由で直接起動し、PATH は truncated である（`hooks/_lib/tests/shebang_test.py`、#534）。ランタイムを切り替えるなら、そのシェバンが指す先も同じ制約を満たす必要がある。
 

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -119,6 +119,7 @@ This directory contains important decisions about the project.
 | [0111](0111-adopt-apple-container-for-agent-sandbox.md) | Adopt Apple container for agent sandbox | accepted | 2026-08-28 |
 | [0112](0112-adopt-typescript-for-helper-scripts.md) | Adopt TypeScript for helper scripts | proposed | 2026-08-29 |
 | [0113](0113-ban-bun-branded-identifiers-in-typescript-sources.md) | Ban bun-branded identifiers in TypeScript sources | accepted | 2026-09-01 |
+| [0114](0114-justify-the-hooks-typescript-migration-by-the-type-contract.md) | Justify the hooks TypeScript migration by the type contract | proposed | 2026-09-01 |
 
 ## By Status
 
@@ -144,6 +145,7 @@ This directory contains important decisions about the project.
 - **0101**: embedding + storage ユーティリティの共有クレート化 (rurico)
 - **0109**: Keep the scope tag and retire the cluster-promotion rule
 - **0112**: Adopt TypeScript for helper scripts
+- **0114**: Justify the hooks TypeScript migration by the type contract
 
 ### Accepted
 

--- a/hooks/_lib/hook_payload.ts
+++ b/hooks/_lib/hook_payload.ts
@@ -1,36 +1,101 @@
 /// <reference types="node" />
-// Scaffold only. The parity implementation is a later unit; every export here returns a fixed
-// sentinel instead of reading the payload, so hooks/_lib/tests/hook-payload-parity.test.ts can
-// import this module in process and diff its result against hook_payload.py's without a
-// module-resolution or parse failure hiding the mismatch each test is meant to show.
+// Typed reads of a hook payload, and the one write a PreToolUse hook makes. The TypeScript
+// side of hooks/_lib/hook_payload.py; both stay in the tree while the consumers move over one
+// at a time, and hooks/_lib/tests/hook-payload-parity.test.ts holds the two to the same answers.
 //
-// Contract: hooks/_lib/hook_payload.py's own docstring -- "json.loads returns Any, and
-// isinstance narrows a dict only to dict[Unknown, Unknown], so a field read straight from the
-// payload spreads Unknown through every caller a type checker follows. This module is the one
-// place that admits it." TypeScript's json.parse return type is `any` for the same reason;
-// values leave this module as `unknown`, which a caller has to narrow before use.
+// JSON.parse returns `any`, and a `typeof x === "object"` check narrows only to `object`, so a
+// field read straight from the payload spreads that looseness through every caller a type
+// checker follows. This module is the one place that admits it. Values leave here as
+// `unknown`, which a caller has to narrow before using -- the same contract hook_payload.py's
+// docstring states for `object`.
 
-const NOT_IMPLEMENTED = "__NOT_IMPLEMENTED__";
-
-/** The payload as a mapping, empty for anything that is not one. */
-export function parse(_text: string): Record<string, unknown> {
-  return {};
+/** A JSON object, or null for an array, a scalar, or null itself. */
+function mapping(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  return value as Record<string, unknown>;
 }
 
-/** One key out of a nested mapping, null when the container is not one. */
-export function field(_container: unknown, _key: string): unknown {
-  return NOT_IMPLEMENTED;
+/** The payload as a mapping, empty for anything that is not one. */
+export function parse(text: string): Record<string, unknown> {
+  let loaded: unknown;
+  try {
+    loaded = JSON.parse(text || "{}");
+  } catch {
+    return {};
+  }
+  return mapping(loaded) ?? {};
+}
+
+/** One key out of a nested mapping, null when the container is not one.
+ *
+ * Null rather than undefined for an absent key: the Python side returns None there, and a
+ * differential test comparing the two under strict equality separates the two values. */
+export function field(container: unknown, key: string): unknown {
+  const found = mapping(container);
+  if (found === null) {
+    return null;
+  }
+  return Object.hasOwn(found, key) ? found[key] : null;
+}
+
+/** The envelope notify writes. Split from the write so a test reads the shape without
+ * capturing stdout, the way gate.ts keeps classifyObservation apart from the stdout write. */
+export function notification(message: string, hookEventName: string): Record<string, unknown> {
+  return {
+    systemMessage: message,
+    hookSpecificOutput: { hookEventName, additionalContext: message },
+  };
 }
 
 /** Report on both channels: systemMessage reaches the human and additionalContext reaches the
- * agent. Mirrors hook_payload.py's notify. */
-export function notify(_message: string, _hookEventName: string = "PostToolUse"): void {}
+ * agent, so a hook that only picks one leaves the other side unable to act on what it found.
+ *
+ * hookEventName defaults to PostToolUse, this module's first caller. The hooks reference
+ * requires hookSpecificOutput.hookEventName to name the event actually firing
+ * (https://code.claude.com/docs/en/hooks#json-output, "It requires a hookEventName field set
+ * to the event name."), so a hook of a different kind, such as a PreToolUse advisory, passes
+ * its own. */
+export function notify(message: string, hookEventName: string = "PostToolUse"): void {
+  process.stdout.write(`${JSON.stringify(notification(message, hookEventName))}\n`);
+}
 
-/** Refuse the call, naming what has to change before it can run. Mirrors hook_payload.py's
- * deny. */
-export function deny(_reason: string): void {}
+/** The envelope deny writes. Split from the write for the same reason notification is. */
+export function denial(reason: string): Record<string, unknown> {
+  return {
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: reason,
+    },
+  };
+}
+
+/** Refuse the call, naming what has to change before it can run.
+ *
+ * The envelope is the PreToolUse contract, so every hook that stops a call emits the same
+ * shape. What differs between them is the reason, which the caller writes.
+ *
+ * Not a top-level `decision`: PreToolUse accepts only "block" there, so an "approve" written
+ * at that level asserts a permission the harness never grants.
+ *
+ * permissionDecision takes exactly these: allow, deny, ask, defer. Any other value fails
+ * schema validation, which Claude Code reports as a non-blocking hook error before the tool
+ * call runs, so a gate written with an invalid value stops nothing and says nothing. */
+export function deny(reason: string): void {
+  process.stdout.write(`${JSON.stringify(denial(reason))}\n`);
+}
+
+const EDITING_TOOLS = new Set(["Write", "Edit"]);
 
 /** The path a Write or Edit call touched, or null for anything else. */
-export function editedFile(_text: string): string | null {
-  return NOT_IMPLEMENTED;
+export function editedFile(text: string): string | null {
+  const payload = parse(text);
+  const toolName = payload.tool_name;
+  if (typeof toolName !== "string" || !EDITING_TOOLS.has(toolName)) {
+    return null;
+  }
+  const path = field(payload.tool_input, "file_path");
+  return typeof path === "string" && path ? path : null;
 }

--- a/hooks/_lib/hook_payload.ts
+++ b/hooks/_lib/hook_payload.ts
@@ -1,0 +1,36 @@
+/// <reference types="node" />
+// Scaffold only. The parity implementation is a later unit; every export here returns a fixed
+// sentinel instead of reading the payload, so hooks/_lib/tests/hook-payload-parity.test.ts can
+// import this module in process and diff its result against hook_payload.py's without a
+// module-resolution or parse failure hiding the mismatch each test is meant to show.
+//
+// Contract: hooks/_lib/hook_payload.py's own docstring -- "json.loads returns Any, and
+// isinstance narrows a dict only to dict[Unknown, Unknown], so a field read straight from the
+// payload spreads Unknown through every caller a type checker follows. This module is the one
+// place that admits it." TypeScript's json.parse return type is `any` for the same reason;
+// values leave this module as `unknown`, which a caller has to narrow before use.
+
+const NOT_IMPLEMENTED = "__NOT_IMPLEMENTED__";
+
+/** The payload as a mapping, empty for anything that is not one. */
+export function parse(_text: string): Record<string, unknown> {
+  return {};
+}
+
+/** One key out of a nested mapping, null when the container is not one. */
+export function field(_container: unknown, _key: string): unknown {
+  return NOT_IMPLEMENTED;
+}
+
+/** Report on both channels: systemMessage reaches the human and additionalContext reaches the
+ * agent. Mirrors hook_payload.py's notify. */
+export function notify(_message: string, _hookEventName: string = "PostToolUse"): void {}
+
+/** Refuse the call, naming what has to change before it can run. Mirrors hook_payload.py's
+ * deny. */
+export function deny(_reason: string): void {}
+
+/** The path a Write or Edit call touched, or null for anything else. */
+export function editedFile(_text: string): string | null {
+  return NOT_IMPLEMENTED;
+}

--- a/hooks/_lib/tests/fixtures/hook-payloads.json
+++ b/hooks/_lib/tests/fixtures/hook-payloads.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": "T-001-pretooluse-bash",
+    "payload": {
+      "hook_event_name": "PreToolUse",
+      "tool_name": "Bash",
+      "tool_input": {
+        "command": "echo hello world"
+      }
+    }
+  },
+  {
+    "id": "T-002-posttooluse-write",
+    "payload": {
+      "hook_event_name": "PostToolUse",
+      "tool_name": "Write",
+      "tool_input": {
+        "file_path": "/tmp/hook-payload-parity-example.txt",
+        "content": "hello"
+      }
+    }
+  },
+  {
+    "id": "T-003-missing-key",
+    "payload": {
+      "hook_event_name": "PreToolUse",
+      "tool_name": "Bash",
+      "tool_input": {}
+    }
+  },
+  {
+    "id": "T-003-type-mismatch",
+    "payload": {
+      "hook_event_name": "PreToolUse",
+      "tool_name": "Bash",
+      "tool_input": "not-a-mapping"
+    }
+  }
+]

--- a/hooks/_lib/tests/hook-payload-parity.test.ts
+++ b/hooks/_lib/tests/hook-payload-parity.test.ts
@@ -1,0 +1,131 @@
+/// <reference types="node" />
+// Differential tests for hooks/_lib/hook_payload.ts against hooks/_lib/hook_payload.py: for the
+// same payload the two must read out the same value (contract: docs/decisions/0112-adopt-
+// typescript-for-helper-scripts.md's Success Criteria, "the CLI contract does not change across
+// the migration; the first slice confirms it with a differential test diffing the Python and
+// TypeScript outputs"). hook_payload.ts is a Red-step scaffold, so every test here is expected
+// to fail against it until a later unit fills in the real parity implementation. No consumer
+// switches to hook_payload.ts in this unit -- hook_payload.py stays the one every hook imports.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { editedFile, field } from "../hook_payload.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const HOOKS_LIB_DIR = join(HERE, "..");
+const FIXTURES_PATH = join(HERE, "fixtures", "hook-payloads.json");
+
+interface Fixture {
+  id: string;
+  payload: Record<string, unknown>;
+}
+
+function loadFixtures(): Fixture[] {
+  return JSON.parse(readFileSync(FIXTURES_PATH, "utf8")) as Fixture[];
+}
+
+function fixture(id: string): Fixture {
+  const found = loadFixtures().find((entry) => entry.id === id);
+  if (!found) {
+    throw new Error(`no fixture named ${id}`);
+  }
+  return found;
+}
+
+// A one-shot driver rather than a CLI: hook_payload.py has no __main__, so this is the smallest
+// way to call its named exports from outside the process. It mirrors exactly the three
+// functions hook_payload.ts exposes for reading a payload value.
+const PY_DRIVER = `
+import json
+import sys
+
+sys.path.insert(0, sys.argv[1])
+import hook_payload as hp
+
+spec = json.loads(sys.stdin.read())
+fn = spec["fn"]
+if fn == "field":
+    result = hp.field(spec["container"], spec["key"])
+elif fn == "edited_file":
+    result = hp.edited_file(spec["text"])
+else:
+    raise SystemExit(f"unknown fn: {fn}")
+print(json.dumps({"result": result}))
+`;
+
+type PythonSpec =
+  | { fn: "field"; container: unknown; key: string }
+  | { fn: "edited_file"; text: string };
+
+function runPython(spec: PythonSpec): unknown {
+  const result = spawnSync("python3", ["-c", PY_DRIVER, HOOKS_LIB_DIR], {
+    input: JSON.stringify(spec),
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    throw new Error(`python3 driver failed (exit ${result.status}): ${result.stderr}`);
+  }
+  return (JSON.parse(result.stdout) as { result: unknown }).result;
+}
+
+test("T-001 both implementations return the same command string for a PreToolUse Bash payload", () => {
+  const { payload } = fixture("T-001-pretooluse-bash");
+  const container = payload.tool_input;
+  const key = "command";
+  const expected = "echo hello world";
+
+  const tsResult = field(container, key);
+  const pyResult = runPython({ fn: "field", container, key });
+
+  assert.equal(tsResult, expected, "hook_payload.ts");
+  assert.equal(pyResult, expected, "hook_payload.py");
+  assert.equal(tsResult, pyResult, "hook_payload.ts and hook_payload.py must agree");
+});
+
+test("T-002 both implementations return the same edited path for a PostToolUse Write payload", () => {
+  const { payload } = fixture("T-002-posttooluse-write");
+  const text = JSON.stringify(payload);
+  const expected = "/tmp/hook-payload-parity-example.txt";
+
+  const tsResult = editedFile(text);
+  const pyResult = runPython({ fn: "edited_file", text });
+
+  assert.equal(tsResult, expected, "hook_payload.ts");
+  assert.equal(pyResult, expected, "hook_payload.py");
+  assert.equal(tsResult, pyResult, "hook_payload.ts and hook_payload.py must agree");
+});
+
+test("T-003 both implementations return the same default for a payload missing a key and for one whose type differs", () => {
+  const missingKey = fixture("T-003-missing-key");
+  const typeMismatch = fixture("T-003-type-mismatch");
+  const key = "file_path";
+
+  const tsMissing = field(missingKey.payload.tool_input, key);
+  const pyMissing = runPython({ fn: "field", container: missingKey.payload.tool_input, key });
+  assert.equal(tsMissing, null, "hook_payload.ts: missing key");
+  assert.equal(pyMissing, null, "hook_payload.py: missing key");
+  assert.equal(tsMissing, pyMissing, "missing key: both implementations must agree");
+
+  const tsMismatch = field(typeMismatch.payload.tool_input, key);
+  const pyMismatch = runPython({ fn: "field", container: typeMismatch.payload.tool_input, key });
+  assert.equal(tsMismatch, null, "hook_payload.ts: type mismatch");
+  assert.equal(pyMismatch, null, "hook_payload.py: type mismatch");
+  assert.equal(tsMismatch, pyMismatch, "type mismatch: both implementations must agree");
+});
+
+test("T-004 the comparison runs over at least one payload and both implementations return a non-empty value for every one", () => {
+  const fixtures = loadFixtures();
+  assert.ok(fixtures.length > 0, "the fixture file must carry at least one payload");
+
+  for (const { id, payload } of fixtures) {
+    const tsResult = field(payload, "tool_name");
+    const pyResult = runPython({ fn: "field", container: payload, key: "tool_name" });
+
+    assert.ok(typeof tsResult === "string" && tsResult.length > 0, `${id}: hook_payload.ts`);
+    assert.ok(typeof pyResult === "string" && pyResult.length > 0, `${id}: hook_payload.py`);
+    assert.equal(tsResult, pyResult, `${id}: both implementations must agree`);
+  }
+});

--- a/hooks/_lib/tests/hook-payload-parity.test.ts
+++ b/hooks/_lib/tests/hook-payload-parity.test.ts
@@ -3,9 +3,10 @@
 // same payload the two must read out the same value (contract: docs/decisions/0112-adopt-
 // typescript-for-helper-scripts.md's Success Criteria, "the CLI contract does not change across
 // the migration; the first slice confirms it with a differential test diffing the Python and
-// TypeScript outputs"). hook_payload.ts is a Red-step scaffold, so every test here is expected
-// to fail against it until a later unit fills in the real parity implementation. No consumer
-// switches to hook_payload.ts in this unit -- hook_payload.py stays the one every hook imports.
+// TypeScript outputs"). The read path is what this slice diffs: field and editedFile, the two
+// every consumer reaches for. notify and deny write to stdout rather than returning, so their
+// parity moves with the first consumer that switches. No consumer switches here -- every hook
+// still imports hook_payload.py.
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";

--- a/hooks/_lib/tests/hooks-toolchain.test.ts
+++ b/hooks/_lib/tests/hooks-toolchain.test.ts
@@ -1,0 +1,110 @@
+/// <reference types="node" />
+// Whether hooks/**'s .ts files sit inside the repository's type-check set and CI's Node tests
+// step, and outside both oxlint's ignorePatterns and tsconfig's exclude. Each check runs the
+// real tool (tsc, oxlint) and reads its own output, following workflows/tests/tsconfig-
+// scope.test.js's listTypeCheckedFiles rather than reimplementing include/exclude/ignore
+// resolution here.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(TEST_DIR, "..", "..", "..");
+const TSC_BIN = path.join(ROOT, "node_modules", ".bin", "tsc");
+const TSCONFIG = path.join(ROOT, "tsconfig.json");
+const OXLINT_BIN = path.join(ROOT, "node_modules", ".bin", "oxlint");
+
+function toPosix(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+// tsc compiles the whole project to answer this, so it runs once for the file rather than once
+// per test. Mirrors workflows/tests/tsconfig-scope.test.js's listTypeCheckedFiles.
+let typeCheckedFiles: string[] | undefined;
+function listTypeCheckedFiles(): string[] {
+  if (typeCheckedFiles) return typeCheckedFiles;
+  assert.ok(
+    existsSync(TSC_BIN),
+    `${TSC_BIN} is missing: run the repository's install step (bun install) before this suite`,
+  );
+  const output = execFileSync(TSC_BIN, ["-p", TSCONFIG, "--listFilesOnly"], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  typeCheckedFiles = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(toPosix)
+    .filter((file) => !file.includes("/node_modules/"));
+  return typeCheckedFiles;
+}
+
+// oxlint's own file discovery, spawned once and cached the same way: reading its output is the
+// real ignorePatterns resolution rather than a reimplementation of oxlint's globbing.
+// --debug=files is oxlint's own option for printing the files a run would lint and then exiting
+// (confirmed via `npx oxlint --help`).
+let oxlintFiles: string[] | undefined;
+function listOxlintFiles(): string[] {
+  if (oxlintFiles) return oxlintFiles;
+  assert.ok(
+    existsSync(OXLINT_BIN),
+    `${OXLINT_BIN} is missing: run the repository's install step (bun install) before this suite`,
+  );
+  const output = execFileSync(OXLINT_BIN, ["--debug=files", "."], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  oxlintFiles = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map(toPosix);
+  return oxlintFiles;
+}
+
+test("T-005 the tsc --listFilesOnly output carries hooks/_lib/hook_payload.ts", () => {
+  const files = listTypeCheckedFiles();
+  assert.ok(
+    files.some((file) => file.endsWith("hooks/_lib/hook_payload.ts")),
+    "hooks/_lib/hook_payload.ts is not in the type-check set",
+  );
+});
+
+// The Python step is a find over the tree, so retiring a *_test.py drops it from CI on its own.
+// Adding a .test.ts does not: the Node step names its globs one by one, and a ported test that
+// no glob reaches leaves CI green having run nothing.
+test("T-006 the Node tests step in .github/workflows/test.yml carries hooks/**/tests/*.test.ts", () => {
+  const workflow = readFileSync(path.join(ROOT, ".github", "workflows", "test.yml"), "utf8");
+  const step = workflow.slice(workflow.indexOf("- name: Node tests"));
+  assert.ok(step.startsWith("- name: Node tests"), "the Node tests step is missing from test.yml");
+  assert.match(step.slice(0, step.indexOf("- name:", 1)), /"hooks\/\*\*\/tests\/\*\.test\.ts"/);
+});
+
+// hooks/_lib/hook_payload.ts and its differential test already clear oxlint's ignorePatterns
+// today (oxlint has no hooks/ entry to drop them with); the gap is tsconfig's include, which the
+// tsc half below exercises through the real compiler instead of a re-implemented glob match.
+// Kept as one assertion pair per file so a future ignorePatterns/exclude entry that reintroduces
+// a hooks/ drop fails here rather than silently narrowing coverage again.
+const HOOKS_TS_FILES = [
+  "hooks/_lib/hook_payload.ts",
+  "hooks/_lib/tests/hook-payload-parity.test.ts",
+];
+
+test("T-007 neither .oxlintrc.json's ignorePatterns nor tsconfig.json's exclude drops hooks/", () => {
+  const oxlintSet = listOxlintFiles();
+  const tscSet = listTypeCheckedFiles();
+  for (const file of HOOKS_TS_FILES) {
+    assert.ok(
+      oxlintSet.some((entry) => entry.endsWith(file)),
+      `oxlint's ignorePatterns dropped ${file}`,
+    );
+    assert.ok(
+      tscSet.some((entry) => entry.endsWith(file)),
+      `tsconfig's exclude (or a missing include) dropped ${file}`,
+    );
+  }
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "allowImportingTsExtensions": true,
     "skipLibCheck": true
   },
-  "include": ["skills/**/*.ts", "workflows/**/*.ts"],
+  "include": ["hooks/**/*.ts", "skills/**/*.ts", "workflows/**/*.ts"],
   // exclude はここが正本ではなく .oxlintrc.json の ignorePatterns 内
   // "skills/*/test/cases/**" の写し。正本を編集したらここも合わせて直す。
   "exclude": ["skills/*/test/cases/**"]


### PR DESCRIPTION
Closes #606

## What & Why

`hooks/_lib/hook_payload.ts` を `hook_payload.py` と並置し、両者の出力を突き合わせる差分テストで一致を固定する。**consumer は 1 本も切り替えない。** `hooks/**` を `tsc` の型検査対象と CI の Node tests step に含める。

DR-0112 の段階移行で最後に残る `hooks/**` 層について、根拠を起動速度から型契約へ置き直した。`hook_payload.py` の docstring は `json.loads` が `Any` を返し `isinstance` が dict を `dict[Unknown, Unknown]` にしか絞れないと認めており、payload から直接読んだフィールドが型検査器の辿るすべての呼び出し側へ Unknown を撒く。この伝播を型で止めることが移行の主張であり、`hook_payload` は非テスト 15 本が import する塊なので第 1 スライスに選んだ。

## 差分テストが固定している 2 点

`field` は mapping が持たないキーに対して `undefined` でなく `null` を返す。Python 側は `None` を返し、テストは厳密等価で突き合わせるので、この 2 つは別の値になる。

`parse` は配列を「mapping ではない」として扱う。`_mapping` の `isinstance(value, dict)` に対応する。素の `typeof` 検査は配列を object と呼ぶので、そのままでは通してしまう。

## Design Decisions

- **hooks 層のランタイムは bun、CI の型検査とテストは従来どおり node**（DR-0114）。実測で `node -e ''` の空プロセスが 30.4ms、python3 が 24.6ms、bun が 14.7ms。node は python3 より遅いので hooks 層の runtime として不採用で、起動コストの改善は bun を採ってはじめて成立する
- **DR-0112 の Consequences を訂正した。** `34ms から 23ms` の見積もりが実測と食い違う。supersede ではなく、hooks 層に限った runtime の選び直しを DR-0114 に置いた
- **`settings.json` を 1 エントリも触らない。** 移行を行うセッション自身の生きた設定で、サンドボックスの write-deny 対象でもある。`.ts` の起動時エラーで `PreToolUse` の Bash matcher が落ちると移行自体を続けられなくなる
- **`notify` / `deny` を `notification` / `denial` と分けた。** 書き出す封筒を純関数として返し、stdout を捕まえずに形を検査できるようにする。`workflows/_lib/gate.ts` が `classifyObservation` と `main` の書き出しを分けているのと同じ形。両者の parity はこのスライスでは突き合わせていない。どちらも返さず書くので、最初に切り替える consumer と一緒に動かす

## Test plan

- `node --test --test-reporter=tap "hooks/_lib/tests/*.test.ts"` — 7 passed（T-001 から T-007）
- CI 相当の全 glob — 712 passed
- `npx tsc --noEmit` — exit 0
- `npx oxlint` — exit 0
- Python テストの一括実行 — exit 0
- `ruff check .` — All checks passed / `ruff format --check .` — 647 files already formatted
- `python3 skills/dr/scripts/validate-dr.py docs/decisions/0114-*.md` — errors なし

## build の途中経過について

build は 3 unit のうち U-001（決定記録）を通したあと、`hook_payload.ts` をスタブのままコミットして PR を作った。差分テスト 4 本が Red のまま、CI の glob も配線されていたので、そのままでは push のたびに CI が落ちる状態だった。build 自身の conformance レビューがこれを high 3 件として検出している。

実装はこのブランチで手で入れた。上の Test plan がその後の状態。
