### PR TITLE
fix(hooks): start rumdl_check and let what it finds reach the writer

### DIFF
--- a/hooks/edit/rumdl_check.py
+++ b/hooks/edit/rumdl_check.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "_lib"))
 
-from hook_payload import edited_file
+from hook_payload import edited_file, notify
 
 path = edited_file(sys.stdin.read())
 if path is None or not path.endswith(".md"):
@@ -35,4 +35,4 @@ except FileNotFoundError:
 # signal that separates the two.
 output = result.stdout.strip()
 if result.returncode != 0 and output:
-    print(output)
+    notify(output)

--- a/hooks/edit/tests/rumdl_check_test.py
+++ b/hooks/edit/tests/rumdl_check_test.py
@@ -7,6 +7,7 @@
 Run: python3 hooks/edit/tests/rumdl_check_test.py
 """
 
+import json
 import os
 import subprocess
 import sys
@@ -53,11 +54,20 @@ class TestRumdlCheck(unittest.TestCase):
         payload = {"tool_name": tool, "tool_input": {"file_path": str(path)}}
         return hook_harness.checked(HOOK, payload, env)
 
-    def test_violation_is_printed(self) -> None:
-        """T-001 a markdown file carrying a rule violation makes the hook print the violation"""
+    def test_violation_reaches_both_channels(self) -> None:
+        """T-001 a markdown file carrying a rule violation makes the hook name it on both channels
+
+        Stdout from a hook that exits 0 reaches no one on its own, so the violation goes out in
+        the envelope hooks/_lib/hook_payload.py's notify writes: systemMessage for the human,
+        additionalContext for whoever wrote the file.
+        """
         path = self.write("violation.md", VIOLATING_MD)
         result = self.run_hook("Write", path)
-        self.assertIn("MD022", result.stdout)
+        emitted = json.loads(result.stdout)
+        self.assertIn("MD022", emitted["systemMessage"])
+        specific = emitted["hookSpecificOutput"]
+        self.assertEqual(specific["hookEventName"], "PostToolUse")
+        self.assertIn("MD022", specific["additionalContext"])
 
     def test_file_unchanged(self) -> None:
         """T-002 the hook leaves the edited file byte-identical to what it received"""

--- a/settings.json
+++ b/settings.json
@@ -158,6 +158,18 @@
           },
           {
             "type": "command",
+            "command": "~/.claude/hooks/edit/rumdl_check.py",
+            "if": "Write(**/*.md)",
+            "timeout": 30
+          },
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/edit/rumdl_check.py",
+            "if": "Edit(**/*.md)",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "~/.claude/hooks/edit/mirror_prose_guard.py",
             "if": "Write(**/.ja/**)",
             "timeout": 10


### PR DESCRIPTION
## Summary

`hooks/edit/rumdl_check.py` は **一度も動いたことがない。** `git log -S'rumdl_check' -- settings.json` が空で、追加されて以来ツリーに座ったまま、自分のテストに駆動された修正を 2 回受けている。

この hook が見るのは、.md を書いた瞬間の markdown 違反である。CI の rumdl step は push のあとに同じことを言う。

## 起動を塞いでいた 3 つ

| | 内容 |
| --- | --- |
| 配線が無い | `settings.json` のどこにも登録されていなかった |
| 実行ビットが無い | `settings.json` は素のパスを起動するので、登録しても起動しないファイルを指すだけだった。しかも**何も言わない**。`docs/wiki/silent-hook-failure.md` が #534 で記録している条件で、これが 3 例目 |
| 報告が素の print | exit 0 の hook の stdout は単独では誰にも届かない（`hooks/_lib/mirror_prose.py` の `emit` がそう書いている） |

## 変更

- `settings.json` の `PostToolUse` / `Write|Edit` グループに、兄弟の `textlint_fix.py` の隣へ 2 エントリ追加。`if` は `Write(**/*.md)` と `Edit(**/*.md)`
- `hooks/edit/rumdl_check.py` に実行ビットを付与
- 報告を `hook_payload` の `notify` 経由へ。systemMessage が人間に、additionalContext が書いた側に届く

## Test plan

- `python3 hooks/edit/tests/rumdl_check_test.py` — 5 passed。T-001 を封筒の検査へ書き換え、`hookEventName` と両チャネルに違反が載ることを固定した
- 陽性対照: `notify(output)` を元の `print(output)` へ戻すと T-001 が落ちることを確認
- **live で確認した。** MD022 を含む .md を書くと、3 件の違反が `additionalContext` 経由で返ってくる。テストの緑だけでは配線の生存を確かめられない（`docs/wiki/silent-hook-failure.md` の定型手順 2）
- `python3 hooks/_lib/tests/shebang_test.py` — 4 passed。T-003 が「`settings.json` が名指す `.py` はすべて実行ビットとシェバンを持つ」を検査するので、実行ビットを落としたままなら落ちる
- `hooks/` の Python テスト一括 — exit 0
- `ruff check hooks` / `ruff format --check hooks` / `rumdl check .` — いずれも指摘なし

## 併せて撤回する所見

同じ調査で「`settings.json` に重複登録が 4 件ある」と 2 度報告したが、**誤りだったので撤回する。** `command` だけを見て `if` を無視していた。

```json
{ "command": ".../rust_post_edit.py", "if": "Write(**/*.rs)" }
{ "command": ".../rust_post_edit.py", "if": "Edit(**/*.rs)" }
```

`matcher` が `Write|Edit` で、`if` が Write と Edit に振り分けている。1 回のツール呼び出しで発火するのは片方だけで、余分なプロセスは起きない。この PR で追加する 2 エントリも同じ形をしている。

https://claude.ai/code/session_01VP6XCc8KUQDEhfcVoiZz2b
