### PR TITLE
[scribe] 決定論の判定は script へ出す を追加/更新

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -66,6 +66,11 @@
 - skills 配下の Python を TypeScript へ移すとき、.github/workflows/test.yml の Node tests step は glob を手動で足さないと拾わない。Python 側は find なので .py を消せば自動で外れるが、.ts を足しても自動では入らない #615
 - exit 0 の hook の stdout print は単独では届かず hook_payload の notify (systemMessage/additionalContext) 経由が要る #618
 - settings.json で matcher 共通 command が if だけ Write/Edit に分かれる複数登録は重複でない #618
+- script が決めた値 (比較対象の sha、PR タイトル) は agent に書き写させず、shq で argv 1 要素としてコマンドに直接載せる。relay agent には stdout の逐語中継だけをさせる。git を打たせると比較対象を自分で解決した HEAD に置き換える #623
+- 検証に落ちた成果物も実在すれば数え、verified フラグで区別する。commits から落とすと呼び出し元が unit_commits: 0 と報告し、履歴にあるコミットを無いものとして扱う #623
+- 同じ事実を 2 体の agent に聞かない。verifier の report が持つフィールド (head) を使い、再取得の relay を足さない #623
+- prefix 除去の正規表現は正準の列挙 (verify-commit.py の COMMIT_TYPES) と同じ集合に限定する。任意語だと WIP: や RFC: の先頭語が消える #623
+- 手元の gate (oxlint / oxfmt) は Python を見ないので、push 前に CI と同じ版の ruff (0.16.4) を手元で走らせる。E501 だけで CI が落ちた #623
 
 ## 棄却
 

--- a/docs/wiki/deterministic-script-judgment.md
+++ b/docs/wiki/deterministic-script-judgment.md
@@ -1,5 +1,5 @@
 ---
-globs: ["**/skills/**/*.md", "**/skills/**/scripts/*"]
+globs: ["**/skills/**/*.md", "**/skills/**/scripts/*", "**/workflows/**/*.js"]
 scenes: []
 ---
 
@@ -7,7 +7,7 @@ scenes: []
 
 ## 内容
 
-入力から一意に決まる判定は script に置き、agent には内容の判断だけを残す。閾値、上限、並び順、節の切り出し、必須集合の充足は前者に当たり、何を書くか、どれが同じ共通項かは後者に当たる。skill の散文が閾値を述べていると、実行のたびに解釈が揺れ、テストからも掛けられない。
+入力から一意に決まる判定は script に置き、agent には内容の判断だけを残す。閾値、上限、並び順、節の切り出し、必須集合の充足は前者に当たり、何を書くか、どれが同じ共通項かは後者に当たる。skill の散文が閾値を述べていると、実行のたびに解釈が揺れ、テストからも掛けられない。workflow でも同じで、git の照会や値の書き写しを agent に任せず、payload と argv で verifier に渡し、agent には stdout の逐語中継だけを残す。
 
 ## 定型手順
 
@@ -24,6 +24,9 @@ scenes: []
 - `skills/issue/scripts/validate-issue-body.py` の `FLOOR` (種別ごとの必須節を、骨格が何を求めるかと別に持つ)
 - `skills/scribe/scripts/find_wiki_rule.py` の `find` (該当ページの絞り込みを glob の照合で行う)
 - `skills/dr/scripts/validate-dr.py` の `STATUS_VALUES` (status が lifecycle の値の中にあるかを検査する)
+- `workflows/code.js` の `commitPostcondition` (コミットの実在と検証結果を verifier の report の head と verdict から決め、agent の自己申告に頼らない)
+- `workflows/build.js` の `relayScript` (payload を argv 1 要素で verifier に渡し、stdout を逐語で持ち帰る。解釈は `relayedJson` が script 側で行う)
+- `workflows/build.js` の `prTitle` (PR タイトルを issue タイトルから script が決め、shq で gh コマンドに直接載せる)
 
 ## 根拠
 
@@ -32,3 +35,4 @@ scenes: []
 - #222 同じ形を別の skill へ広げた
 - #230 閾値を skill の散文から外した
 - #389 issue の plan 選定と節の切り出しを pick-plan.py へ出し、種別ごとの必須節を FLOOR として validator に持たせた。移す過程で「slug が issue のタイトルに一致する」という前提が崩れ、実行で確かめられる形にして初めて分かった
+- #623 build の戻り値と PR 本文が agent の読みで git の事実と食い違った。commit の実在は verifier の report で、変更ファイル一覧は diff-files.py で、PR タイトルは script が issue タイトルから決める形にし、relay agent には stdout の逐語中継だけを残した


### PR DESCRIPTION
## 追加 / 昇格 / 更新したページ

### commit 1: docs(wiki): 決定論の判定は script へ出す を追加/更新

- `docs/wiki/deterministic-script-judgment.md` (更新)。globs に `**/workflows/**/*.js` を足し、workflow でも git の照会や値の書き写しを agent に任せず payload と argv で verifier に渡す旨を 内容 に 1 文加えた。参照コード に `workflows/code.js` の `commitPostcondition`、`workflows/build.js` の `relayScript` と `prTitle` を、根拠 に #623 を足した

## 候補の追加 (`_candidates.md` の 単発)

- script が決めた値は agent に書き写させず shq で argv 1 要素として渡す。relay に git を打たせると比較対象を自分で解決した HEAD に置き換える #623
- 検証に落ちた成果物も実在すれば数え、verified フラグで区別する #623
- 同じ事実を 2 体の agent に聞かない。verifier の report が持つフィールドを使う #623
- prefix 除去の正規表現は正準の列挙 (COMMIT_TYPES) と同じ集合に限定する #623
- 手元の gate は Python を見ないので、push 前に CI と同じ版の ruff を手元で走らせる #623

## 参照コード / 由来 の修復

- なし。全 49 ページの 参照コード を掃引し、ファイルの実在とシンボルの grep を確認した。由来 の DR リンクはすべて実在し status は accepted
- 構造ページ 2 枚 (`workflow-structure.md`、`skills-structure.md`) の行を現在のコードと突き合わせた。workflow 7 本、skill 29 個、入れ子 2 経路、参照シンボルはいずれも一致

## 読んだ範囲

- PR: #623 (前回 scribe PR #619 のマージ 2026-09-02T02:27:47Z 以降にマージされた 1 件)
- issue: 0 件
- research ファイル: 0 件

## 検証で落とした項目

- なし

## 持ち越し

- なし (deferred 0 件)

https://claude.ai/code/session_01FkNx3WyjKVB3WThUUsHBF3
