### PR TITLE
[scribe] verifier 根拠の返り値、relay payload 化、PR タイトル script 決定を候補へ追加

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -66,6 +66,9 @@
 - skills 配下の Python を TypeScript へ移すとき、.github/workflows/test.yml の Node tests step は glob を手動で足さないと拾わない。Python 側は find なので .py を消せば自動で外れるが、.ts を足しても自動では入らない #615
 - exit 0 の hook の stdout print は単独では届かず hook_payload の notify (systemMessage/additionalContext) 経由が要る #618
 - settings.json で matcher 共通 command が if だけ Write/Edit に分かれる複数登録は重複でない #618
+- commitPostcondition 等の返り値は agent の自己申告でなく verifier report の head や実在する PR など検証済みの事実を根拠にする。判定できない commit を落とすと呼び出し元は分岐点以降のコミットを無かった扱いにする #623
+- haiku 等 agent 経由の relay に literal な sha を埋め込んだ shell command (git diff <sha>) を実行させると HEAD へ置き換えて実行されることがあるため、固定値は command 文字列でなく構造化 payload で渡す #623
+- PR タイトルは、取得できた issue タイトルから script が一意に決め、agent の作文に委ねない #623
 
 ## 棄却
 


### PR DESCRIPTION
## 追加/更新したページ

なし。今回抽出したパターンはいずれも根拠 1 件で、2 件の閾値に届かずページ化はゼロ件。

## 候補追加

- commitPostcondition 等の返り値は agent の自己申告でなく verifier report の head や実在する PR など検証済みの事実を根拠にする。判定できない commit を落とすと呼び出し元は分岐点以降のコミットを無かった扱いにする (#623)
- haiku 等 agent 経由の relay に literal な sha を埋め込んだ shell command (git diff <sha>) を実行させると HEAD へ置き換えて実行されることがあるため、固定値は command 文字列でなく構造化 payload で渡す (#623)
- PR タイトルは、取得できた issue タイトルから script が一意に決め、agent の作文に委ねない (#623)

## 参照コード / 由来の修正

なし。既存 49 ページ全件の参照コード（ファイル実在 + シンボル grep 一致）と、由来 リンク先 DR（8 件、いずれも status: accepted）を確認したが、破損・supersede は見つからなかった。`kind: structure` の 2 ページ (`skills-structure.md`, `workflow-structure.md`) の境界/契約/要求の各行も現行コードと突き合わせ、すべて一致を確認した。

## スコープ

- PR: #623（1 件、`merged:>2026-09-02T02:27:47Z`、cursor は前回 scribe PR #619 の mergedAt）
- issue: 0 件（該当なし）
- research file: 0 件（`.claude/workspace/research/*.md` の last-commit-time がカーソル以降のものなし。リポジトリが shallow clone だったため `git fetch --unshallow` で全履歴を復元してから確認した）

PR #623 は build workflow の commit 検証・diff-files relay・PR タイトル決定の 3 箇所を、agent の読みでなく script/verifier の判定に置き換えた変更。Design Decisions 節に挙げられた個別実装判断（relay 追加回避、`git ls-files` 採用、`CONVENTIONAL_PREFIX` の型限定）はスキルの不変条件により対象外とした。

## 検証で落とした項目

なし。

## 持ち越し

なし（`昇格待ち` 0 件）。