### PR TITLE
workflow の旧形式互換とコメントを整理し、参照の無い関数を消す

### DIFF
--- a/.ja/skills/ablate/scripts/arms.py
+++ b/.ja/skills/ablate/scripts/arms.py
@@ -29,8 +29,7 @@ RUN_COUNT = 5
 
 # 1 アームが合格と判定されるために、harness ありの挙動を再現しなければならない実行の割合。
 # docs/wiki/deterministic-script-judgment.md に倣い、この数値を SKILL.md の散文でなくここに
-# 1 箇所だけ持つ。合否判定へ配線する処理は、このモジュールがまだ持たない比較を必要とするため、
-# 実行結果を採点するユニットへ持ち越す (このユニットの deferred を参照)。
+# 1 箇所だけ持つ。
 PASS_THRESHOLD = 0.8
 
 UNMEASURED = "unmeasured"

--- a/.ja/skills/ablate/scripts/report.py
+++ b/.ja/skills/ablate/scripts/report.py
@@ -29,8 +29,7 @@ TRANSCRIPTS_ROOT = Path.home() / ".claude" / "projects"
 # ablation apparatus 自身の script tree。ここ配下のパスは観測を生成したコードそのものであり
 # 検査対象の harness 要素ではないため、delete_candidates に決して現れてはならない —
 # 観測を続ける apparatus 自身を削除してしまうと、harness 要素を測り続ける能力そのものが
-# 失われる (このユニットの T-015 契約「ablation apparatus 自身が delete candidates から
-# 除かれている」)。
+# 失われる。
 APPARATUS_DIR = "skills/ablate/"
 
 REPORT_NAME = "ablate"

--- a/.ja/skills/scribe/scripts/verify_run.py
+++ b/.ja/skills/scribe/scripts/verify_run.py
@@ -18,8 +18,6 @@ from typing import TypedDict, cast
 # 1 回の run を背後の履歴から切り分けられない。
 COMMIT_PREFIX = "docs(wiki):"
 
-NOT_A_PAGE = {"_candidates.md", "README.md"}
-
 WIKI_DIR = "docs/wiki"
 
 WAITING = "## 昇格待ち"
@@ -77,21 +75,6 @@ def run_commits(repo: Path, base: str) -> list[str]:
         if subject.startswith(COMMIT_PREFIX):
             hashes.append(commit_hash)
     return hashes
-
-
-def pages_added(repo: Path, commit_hash: str) -> int:
-    out = _git(
-        repo, "diff-tree", "--no-commit-id", "--name-status", "-r", commit_hash, "--", WIKI_DIR
-    )
-    count = 0
-    for line in out.splitlines():
-        if not line:
-            continue
-        status, path = line.split("\t", 1)
-        name = Path(path).name
-        if status == "A" and name.endswith(".md") and name not in NOT_A_PAGE:
-            count += 1
-    return count
 
 
 def section_rows(text: str, heading: str) -> int:

--- a/.ja/workflows/assert.js
+++ b/.ja/workflows/assert.js
@@ -14,22 +14,16 @@ export const meta = {
   ],
 };
 
-// 設計上の要点は 4 つ。
-// 1. 静的 reviewer fan-out は routing 表を複製せず workflow("audit") の入れ子で再利用する
-//    (routing 表の変更が assert に直接伝播する性質を保つため)。audit 内で
-//    critic-audit / critic-evidence を通過済みのため、assert 側の Challenge は Codex findings
-//    のみに掛け、同一 agent による二重 challenge を避ける。
-// 2. gate 判定は schema + script で計算する。gate を enhancer の散文から decode するのではなく、
-//    (build, tests, issues) から script が規則で計算するため、re-spawn / fail-close の機構自体が
-//    不要になる。
-// 3. worktree.py / bootstrap.py は決定論 script なので agent にそのまま実行させる。
-//    session id は agent 環境の $CLAUDE_SESSION_ID で解決し、生成と cleanup が同じ id から
-//    branch / path を導出するため drift しない。
-// 4. adversarial (codex 600s) は Evidence と同時に始め、Challenge / Triage の裏で走らせる
-//    (barrier に入れると最長 stage が全体を塞ぐ)。
-//
-// OUTCOME.md 不在時に /outcome で stub 生成しない。assert は検証であり、対象 repo への
-// 書き込み副作用を持たない。不在は report に記録して前進する。
+// 1. 静的 reviewer fan-out は workflow("audit") の入れ子で、routing 表を複製しない。audit 内で
+//    critic-audit / critic-evidence を通過済みなので、assert の Challenge は Codex findings のみ。
+// 2. gate は (build, tests, issues) から schema + script の規則で計算し、enhancer の散文から
+//    decode しない。
+// 3. worktree.py / bootstrap.py は決定論 script で、生成と cleanup は $CLAUDE_SESSION_ID から
+//    同じ branch / path を導く。
+// 4. adversarial (codex 600s) は Evidence と同時に始め、Challenge / Triage の裏で走らせる。
+//    barrier に入れると最長 stage が全体を塞ぐ。
+// OUTCOME.md 不在時に stub は生成しない。assert は対象 repo への書き込み副作用を持たない。不在は
+// report に記録する。
 
 const parseArgs = () => {
   if (typeof args === "object" && args) return args;
@@ -59,9 +53,8 @@ if (!repo) {
 const anchor = (p) =>
   `git / ファイル / ビルドのコマンドはすべて ${repo} の repository から実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`;
 
-// plugin 配布を考慮した資産解決。この script が plugin として配られると、同梱資産は
-// ~/.claude ではなく ~/.claude/plugins 配下に置かれる。shell 片は dev tree のパスを先に
-// 試すので、dev tree はそのまま動く。-e 判定はディレクトリも通し、下の SCRIPTS が要る。
+// plugin 配布では同梱資産は ~/.claude/plugins 配下に置かれる。shell 片は dev tree のパスを先に
+// 試す。-e 判定はディレクトリも通し、下の SCRIPTS が要る。
 const bundled = (rel) =>
   `"$(P="$HOME/.claude/${rel}"; [ -e "$P" ] || P="$(find "$HOME/.claude/plugins" -path "*/${rel}" -not -path "*/.ja/*" 2>/dev/null | sort -V | tail -1)"; printf %s "$P")"`;
 // この workflow の付属 script。loader は workflows/ 直下の .js しか読まないため、
@@ -71,10 +64,9 @@ const SCRIPTS = bundled("workflows/assert");
 // その判定結果を読む。
 const OUTCOME_VALIDATOR = bundled("skills/outcome/scripts/validate-outcome.py");
 
-// merge-findings.py の 2 規則を JS に inline する。P1 -> high、P2 -> medium、P3 -> 落とす。
-// critical / high / medium / low は素通し。認識できない severity は順位付け不能なので落とす。
-// dedup key は file:line のみ (source ごとに category schema が違う)。衝突時は高い severity を
-// 残し、source を和集合にする。
+// merge-findings.py の 2 規則を inline する。P1 -> high、P2 -> medium、P3 -> 落とす。critical /
+// high / medium / low は素通し、認識できない severity は落とす。dedup key は file:line のみ
+// (source ごとに category schema が違う)。衝突時は高い severity を残し、source を和集合にする。
 const SEVERITY_MAP = {
   P1: "high",
   P2: "medium",
@@ -290,8 +282,8 @@ if (boot.mode === "none") {
 }
 
 // env fail (worktree 不可 / install fail) と build smoke fail (対象がビルドできない) を区別する。
-// 動的 evidence の欠落のうち caveat 落としを許すのは env fail のみ。build smoke fail を caveat に
-// 落とすと壊れたビルドが merge に届く false-Ready を生む。
+// caveat 落としを許すのは env fail のみ。build smoke fail まで落とすと壊れたビルドが Ready で merge
+// に届く。
 const envFail = !boot.worktree_ok || boot.install === "fail";
 const buildCol = envFail ? "skipped" : boot.build;
 const dynamicOk = !envFail && buildCol !== "fail";

--- a/.ja/workflows/audit.js
+++ b/.ja/workflows/audit.js
@@ -15,13 +15,11 @@ export const meta = {
   ],
 };
 
-// routing は agent ではなく script に置く。agent に glob 表を再導出させると、この workflow が
-// なくすはずの drift を持ち込み直すことになる。reviewer に sonnet を使うのは、opus で深い解析を
-// させると stream watchdog が stall するため。
+// routing は script に置く。agent に glob 表を再導出させると、この workflow がなくすはずの drift
+// を持ち込み直す。reviewer は sonnet。opus では stream watchdog が stall する。
 
-// args は object でも、呼び出し側で stringify された JSON 文字列でも渡ってくる。object に
-// parse できる文字列は parse 結果を、それ以外の文字列は scope の短縮記法とみなして、
-// ここで一度だけ正規化する。
+// args は object でも、呼び出し側で stringify された JSON 文字列でも渡ってくる。object に parse
+// できる文字列は parse 結果、それ以外の文字列は scope の短縮記法。
 const parseArgs = () => {
   if (typeof args === "object" && args) return args;
   if (typeof args !== "string") return {};
@@ -53,21 +51,15 @@ const noLimit = opts.noLimit === true;
 const skipPreflight = opts.skipPreflight === true;
 const anchor = (p) =>
   `git コマンドはすべて repo ${repo} で実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`;
-// finding の summary は LLM が生成した自由文で、次段の prompt へそのまま埋め込まれる。
-// そこに紛れ込んだ指示が命令として読まれてはならない。fenced が build.js の fencedBody と
-// 違うのはこの点にある。固定 marker は、JSON.stringify がハイフンをエスケープしないため
-// payload 内の同じ文字列から閉じられる。乱数源はサンドボックスに無く、あっても resume を
-// またいで値が変わる。
-// base の中身に意味は無い。payload に現れにくければよい。base と詰め物はどちらも下の
-// regex に埋め込むので、メタ文字を含まない文字から選ぶ。
+// finding の summary は LLM が生成した自由文で、次段の prompt へそのまま埋め込まれるので、
+// fence marker は payload 内の同じ文字列から閉じられてはならない。サンドボックスに乱数源が無い
+// ため、marker は FENCE_BASE を payload 内の最長連鎖より 1 つ長く詰めたもの。どちらも下の regex
+// に埋め込むので、メタ文字を含まない。
 const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
 const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
-// marker を 1 文字ずつ伸ばすと、1 歩ごとに payload 全体を走査し直すことになる。その payload
-// こそ攻撃者が書く場所で、`base`、`base0`、`base00` と種を蒔けば歩数が payload の長さに
-// 応じて増える。最長連鎖より 1 つ長い marker が payload に出現しないのは、出現するなら
-// それが最長連鎖になるため。marker を予測されても早期クローズが成立しないのも同じ理由に
-// よる。longest の初期値が -1 なのは、衝突しない payload を別の分岐にせずに済ませるため。
+// 最長連鎖を 1 回の走査で求め、コストを payload の長さに比例させる。marker を 1 文字ずつ伸ばすと
+// `base`、`base0`、`base00` と種を蒔いた payload が歩数を増やせる。
 const fenceMarker = (value) => {
   let longest = -1;
   for (const [hit] of value.matchAll(FENCE_RUNS)) {
@@ -82,20 +74,16 @@ const fenced = (value) => {
     `----- BEGIN UNTRUSTED FINDINGS ${marker} -----\n${value}\n----- END UNTRUSTED FINDINGS ${marker} -----`
   );
 };
-// plugin 対応の asset 解決。plugin として配布されたとき bundled asset は ~/.claude では
-// なく ~/.claude/plugins 配下に置かれる。shell 断片は dev-tree のパスを先に試すので、
-// dev tree での動作は変わらない。
+// plugin 配布では bundled asset は ~/.claude/plugins 配下に置かれる。shell 断片は dev-tree の
+// パスを先に試す。
 const bundled = (rel) =>
   `"$(P="$HOME/.claude/${rel}"; [ -e "$P" ] || P="$(find "$HOME/.claude/plugins" -path "*/${rel}" -not -path "*/.ja/*" 2>/dev/null | sort -V | tail -1)"; printf %s "$P")"`;
 
-// timestamp・branch の解決は audit/snapshot.py が行う。agent は payload を一時ファイルに
-// 書いてそのスクリプトを 1 回叩くだけで、disk への副作用が目的、戻り値は使わない。
-// payload のキーは snapshot.py の build_record がそのまま record の項目にする。返り値に
-// しか無い項目は record から読めないので、record で読ませたいものはここへ渡す。
-//
-// payload は prompt に埋め込む形でしか agent に渡せず、書き写す途中で要約されると record
-// だけが痩せる。件数を agent に自己申告させると切り詰めた当人が報告することになるので、
-// stdin を受けた snapshot.py が数えた値を持ち帰らせる。
+// timestamp・branch の解決は audit/snapshot.py が行い、agent は payload を一時ファイルに書いて
+// 1 回叩くだけ。disk への副作用が目的。build_record は payload のキーをそのまま record の項目に
+// するので、record で読ませたいものはここへ渡す。
+// 件数は stdin を受けた snapshot.py が数える。prompt 経由で payload を書き写す agent は途中で
+// 要約しうるので、切り詰めた当人に報告させない。
 const SNAPSHOT_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -193,10 +181,9 @@ const writeSnapshot = async ({
   return { written: true, path: written.path, truncated: lost.length > 0, lost, expected, actual };
 };
 
-// /audit の routing 表。react-pattern は JSX を含む拡張子 (jsx / tsx) にだけ付け、素の js の
-// audit で空振りしないようにする。JSX を使わない React には react-pattern が付かない、という
-// heuristic を含む。ファイルは classify() で最初にマッチした行に決まる。型の機械的チェック
-// (any / アサーション / strict モード) は gates のリンタが担い、reviewer は持たない。
+// /audit の routing 表。ファイルは classify() で最初にマッチした行に決まる。react-pattern は
+// jsx / tsx にだけ付けるので、JSX を使わない React には付かない。型の機械的チェック (any /
+// アサーション / strict モード) は gates のリンタが担う。
 const ROUTING = {
   "*.sh": ["security", "silence", "duplication", "reuse", "efficiency", "operations", "resilience"],
   "*.js": [
@@ -328,8 +315,8 @@ const classify = (p) => {
   return ROUTING.default;
 };
 // source_ids を返すのは Integrate だけ。共有 schema に optional で置くと Integrate が省いても
-// validation を通り、R-N の追跡が run ごとに切れる。reviewer 用は property ごと持たないので、
-// reviewer が id を捏造して返せば additionalProperties: false が弾く。
+// validation を通り、R-N の追跡が切れる。reviewer 用は property ごと持たないので、id を捏造した
+// reviewer は additionalProperties: false が弾く。
 const findingsSchema = ({ withSourceIds = false } = {}) => ({
   type: "object",
   additionalProperties: false,
@@ -457,8 +444,7 @@ const SCOPE_STATUS_SCHEMA = {
 
 // ---- Scope 解決 ----
 // git は revision と path を同じ位置で受けるため、path を渡すとその配下の未コミット変更へ潰れる。
-// 分岐表とコマンド組み立てはこの script が持ち、agent 段には git の実行だけを残す。判断を
-// prompt へ移すと、routing を script 側に置く冒頭コメントの理由が崩れる。
+// 分岐表とコマンド組み立ては script が持ち、agent は git を実行するだけ。
 const base = typeof opts.base === "string" && opts.base.trim() ? opts.base.trim() : "main";
 // rev-parse は revision を解決すると 40 桁の SHA 行だけを返し、範囲指定では除外側に ^ が付く。
 // path を渡したときはその path をそのまま返す。
@@ -661,9 +647,8 @@ const raw = await parallel(
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
 // severity から導かず固定する (agents/_lib/finding-schema.md § Disposition)。assert の gate は
 // severity を見ないので、導出するとマージを止める finding に nits が付く。
-// 手で並べず schema から導く。schema にあるのにこの写しに無いフィールドは黙って落ちる。
-// #425 が塞いだのがその穴。file / line / severity / summary は名前を変えて写し、disposition は
-// dispositionOf を通すので、この 6 つは除く。
+// schema から導き、この写しに無いフィールドが黙って落ちないようにする。file / line / severity /
+// summary は名前を変えて写し、disposition は dispositionOf を通す。
 const MAPPED_FIELDS = new Set([
   "file",
   "line",
@@ -752,9 +737,8 @@ if (!findings.length) {
 // 同じ findings に独立した 2 pass を並行で当てる。membership を決めるのは Challenge の
 // verdict だけで、Verify の evidence は Integrate に届かない。
 const findingsJson = JSON.stringify(findings);
-// workflows/polish.js の VERDICTS_SCHEMA (id/verdict/severity/why) の形を踏襲する。
-// severity の enum はこのファイル自身の FINDINGS_SCHEMA (critical/high/medium/low) に
-// 合わせ、polish の P1/P2/P3 は使わない。2 つの workflow は severity の物差しが異なるため。
+// workflows/polish.js の VERDICTS_SCHEMA (id/verdict/severity/why) と同じ形。severity の enum は
+// このファイルの FINDINGS_SCHEMA に合わせる。polish は P1/P2/P3 で測る。
 const VERDICTS_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -829,9 +813,8 @@ const [challenged, verified] = await parallel([
 ]);
 
 // ---- Triage: survivor 判定はスクリプトが持ち、critic は verdict を返すだけ ----
-// verdict 側でなく finding 側を回す。verdict を付け忘れた finding が黙って消えず、
-// confirmed 扱いで no_verdict に計上される。challenge が丸ごと失敗した run も全件が
-// 同じ経路を通るので、劣化が件数として残る。
+// verdict 側でなく finding 側を回す。verdict の無い finding は confirmed 扱いで no_verdict に
+// 計上され、challenge が丸ごと失敗した run も同じ経路を通るので、劣化が件数として残る。
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
@@ -875,13 +858,10 @@ const info = {
   disputed: { count: disputedIds.length, ids: disputedIds },
   downgraded: { count: downgradedIds.length, ids: downgradedIds },
 };
-// challenge_ran は「verdicts を返した run」と fail-open した run (verdictById が空になり、
-// 全 finding が no_verdict 経由で confirmed に落ちる) を区別する。verify は自由記述の
-// テキストを返すため、schema の形ではなく中身の有無で判定する。
+// challenge_ran は「verdicts を返した run」と、全 finding が no_verdict 経由で confirmed に落ちる
+// fail-open の run を区別する。verify は自由記述を返すため、中身の有無で判定する。
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
-// assert.js の challengeStalled と同じく劣化側を指す boolean。challengeRan だけでは空の
-// verdicts 配列も走ったと数えてしまう (challengeRan 自身の定義はここでは変えない) が、その run
-// では verdict が 1 件も出ていないので、challengeRan には無い件数チェックをここに足す。
+// challengeRan は空の verdicts 配列も走ったと数えるので、劣化フラグには件数チェックを足す。
 const challengeDegraded = !challengeRan || challenged.verdicts.length === 0;
 const verifyRan = !!String(verified || "").trim();
 const tally = {
@@ -917,9 +897,8 @@ const integrated = await agent(
 // フォールバック先を triage 前の findings にすると、id が付く前の配列に落ちるので、
 // challenge が disputed と判定した finding を黙って呼び戻すことになる。
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// toCriticRef は Integrate に渡す前に disposition を落とすので、Integrate が返す値は
-// survivors 由来ではなく信用しない。順位は DECLARABLE_DISPOSITIONS から導き、
-// agents/_lib/finding-schema.md が持つ全順序をここへ書き写さない。
+// toCriticRef は Integrate に渡す前に disposition を落とすので、Integrate が返す値は信用しない。
+// 順位は DECLARABLE_DISPOSITIONS から導き、agents/_lib/finding-schema.md の全順序を書き写さない。
 const DISPOSITION_RANK = Object.fromEntries(
   [...DECLARABLE_DISPOSITIONS].map((d, i) => [d, DECLARABLE_DISPOSITIONS.size - i]),
 );
@@ -930,11 +909,9 @@ const consolidatedDisposition = (sourceIds) =>
     if (!d) return strongest;
     return !strongest || DISPOSITION_RANK[d] > DISPOSITION_RANK[strongest] ? d : strongest;
   }, null) || DEFAULT_DISPOSITION;
-// ソートは workflows/assert.js の mergeIssues をそのまま踏襲する。SEVERITY_RANK 降順、
-// 次に file 昇順(localeCompare)、次に line 昇順。ここ 1 箇所で適用するので、返り値の
-// findings と下の snapshot の findings は同じ並びになる。severity を持たない finding は
-// SEVERITY_RANK に該当キーが無く引き算が NaN になる。比較関数は NaN を 0(等しい)として
-// 扱うため、drop されず全ての severity 付き finding の後ろに並ぶ。
+// ソートはここ 1 箇所で適用し、返り値と snapshot を assert.js の mergeIssues と同じ順にする:
+// SEVERITY_RANK 降順、次に file、次に line。`?? 0` で rank の無い severity を最後に置く。素の
+// 参照では引き算が NaN になり file 比較へ抜ける。
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
 const severityRank = (f) => SEVERITY_RANK[f.severity] ?? 0;
 const finalFindings = integratedFindings

--- a/.ja/workflows/build.js
+++ b/.ja/workflows/build.js
@@ -15,9 +15,8 @@ export const meta = {
   ],
 };
 
-// build は人間の ## Plan 節を再計画しない。Plan 節なし issue は no-plan で
-// 停止し、issue の精緻化に差し戻す。抽出は LLM に委ね、検証は script が持つ。
-// fan-out を持つ stage は入れ子 workflow (code) に委譲する。
+// build は人間の ## Plan 節を再計画せず、Plan 節なし issue は no-plan で止める。抽出は LLM、
+// 検証は script、fan-out を持つ stage は入れ子の code workflow が持つ。
 
 phase("Load");
 
@@ -44,9 +43,8 @@ const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue 
 const issueNumber =
   (issueRef.match(/^#?(\d+)$/) || issueRef.match(/\/issues\/(\d+)(?:[/?#]|$)/) || [])[1] || "";
 // ---- run の記録: build の 1 実行につき jsonl 1 行 ----
-// PLAN_QUALITY は、その停止を issue の ## Plan 節の側で防げたかどうかを持つ。true の件数が
-// /qualify を build の前段で必須にするか (DR-0084 の再評価条件) を決める。どのファイルにも
-// 届かない返り値のままでは、その問いに答えられない。
+// PLAN_QUALITY は issue の ## Plan 節の側で防げた停止を印す。その件数が /qualify を build の
+// 前段で必須にするか (DR-0084 の再評価条件) を決める。
 const PLAN_QUALITY = {
   "no-issue": false,
   "no-repo": false,
@@ -63,9 +61,8 @@ const PLAN_QUALITY = {
   "plan-drift": true,
   "code-failed": false,
 };
-// record.py の stdout が path/run_id と並べて持つ window tally の key。型をここで 1 度だけ
-// 名付け、下の RECORD_SCHEMA の properties をそこから導くことで、key の追加・改名・型変更で
-// 両者がずれるのを防ぐ。
+// record.py が path/run_id の横に出す window tally の key。RECORD_SCHEMA の properties はここから
+// 導くので、key の追加・改名・型変更は 1 箇所で済む。
 const RECORD_COUNT_TYPES = {
   started: "number",
   stops: "number",
@@ -157,9 +154,8 @@ if (!issueRef || !issueNumber) {
   });
 }
 
-// repo が無いと agent は自身の cwd から「リポジトリ」を解決し、別の checkout で
-// step を実行しうる。anchor が全 step を対象リポジトリへ固定し、guard が取り消し
-// にくい git 変更 (branch / commit / push / PR) の前に repo ルートを確認させる。
+// repo が無いと agent は自身の cwd から「リポジトリ」を解決する。anchor が全 step を対象
+// リポジトリへ固定し、guard が branch / commit / push / PR の前に repo ルートを確認させる。
 const repo = typeof input.repo === "string" ? input.repo : "";
 // base は epic ブランチへスライス PR を集約するフローで、新規 checkout の起点と
 // PR の base の両方に使う。
@@ -180,10 +176,9 @@ if (baseBranch && !BRANCH_NAME_SHAPE.test(baseBranch)) {
 const anchor = (p) =>
   `すべての git / ファイル / ビルドコマンドを ${repo} のリポジトリから実行する (各シェルコマンドを \`cd ${repo} && \` で始める)。\n\n${p}`;
 const guard = ` この step で最初の commit / push / ブランチ変更を行う前に \`cd ${repo} && git rev-parse --show-toplevel\` を実行し、出力が ${repo} であることを確認する。異なる場合は git を変更せず中断し、不一致を報告する。`;
-// plugin 配布では sibling が build: 名前空間、bundled が ~/.claude/plugins を解決する。
-// どちらも素の dev tree 形を先に試すので、dev tree はそのまま動く。名前解決の失敗以外で
-// 退避すると、入れ子が投げた真の失敗を捨てて退避先の名前解決エラーだけが残る。入れ子の
-// 失敗は子の stack を message に運ぶので、文言でなく呼んだ名前ごと照合する。
+// plugin 配布では sibling が build: 名前空間、bundled が ~/.claude/plugins を解決し、どちらも
+// dev tree 形を先に試す。退避は名前解決の失敗に限り、文言でなく名前で照合する。それ以外で
+// 退避すると入れ子が投げた真の失敗が名前解決エラーに置き換わる。
 const sibling = async (name, a) => {
   try {
     return await workflow(name, a);
@@ -225,9 +220,8 @@ recordable = true;
 await recordRun("started");
 
 // ---- Load: 逐語 fetch → Plan 見出し確認 → 決定論 id 収集 → 抽出 → validate + クロスチェック ----
-// 渡すのは抽出した番号で、受け取った参照そのものではない。URL は /issues/N がどこかに
-// あれば一致するので、そのまま渡すと後続の文字列ごとシェルへ入る。番号なら anchor が
-// 既に cd している対象リポジトリで gh が解決する。
+// gh に渡すのは抽出した番号で、受け取った参照そのものではない。URL は /issues/N がどこかに
+// あれば一致するので、そのまま渡すと後続の文字列ごとシェルへ入る。
 const fetched = await agent(
   anchor(
     `\`gh issue view ${issueNumber} --json title,body\` を正確に実行し、その title フィールドを title として、body フィールドを body として、いずれも逐語で返す。` +
@@ -249,10 +243,9 @@ if (!fetched || !fetched.found || !String(fetched.body || "").trim()) {
 }
 const body = fetched.body;
 
-// schema 層が表せない検証。tests の空配列は合法 (その unit は code が直接実装で扱う) で、
-// 以下が見るのは unit どうしの関係。seam 規則があるのは、unit ごとのテストが自分の境界を stub するため、各 unit
-// が緑のまま層と層が結線されていない実装を ship しうるから。テストを持つ unit が
-// 2 つ以上あれば両者の間に継ぎ目があり、そこを横断するテストだけが結線漏れで落ちる。
+// schema 層が表せない、unit どうしの関係の検証。unit ごとのテストは自分の境界を stub するので、
+// 各 unit が緑のまま層が結線されていない実装を ship しうる。テストを持つ unit が 2 つあれば、
+// その継ぎ目を横断するテストだけが結線漏れで落ちる。
 const validate = (plan, isBug) => {
   const errors = [];
   // root_cause を書かない Bug plan は症状だけを code で回避しがち。schema の required には
@@ -274,8 +267,7 @@ const validate = (plan, isBug) => {
   // reference_module は複製する既存モジュールか、複製しない理由のいずれかを運ぶ。素の
   // null もフィールドごとの欠落もその理由を運べないので blocker にする。schema の
   // required には入れない。extract が key を落としたとき blockers 文言を持たない
-  // extraction-failed で止まり、書き直す手がかりが残らないため。extract は既存の
-  // `null (理由)` 書式を null のまま残さず kind 付き object へ変換する想定。
+  // extraction-failed で止まり、書き直す手がかりが残らないため。
   const refModule = plan.reference_module;
   if (refModule === undefined) {
     errors.push(
@@ -287,10 +279,10 @@ const validate = (plan, isBug) => {
       "reference_module が理由の無い null。素の null ではなく " +
         "{ kind, reason } (kind: module/no-module/new-shape) の object として記録する",
     );
-  } else if (refModule && typeof refModule === "object" && "kind" in refModule) {
-    // kind フィールドの無い旧形式の object (path/files だけ) は後方互換のため
-    // 検査しない。
-    if (refModule.kind === "module") {
+  } else if (typeof refModule === "object") {
+    if (!String(refModule.kind || "").trim()) {
+      errors.push("reference_module.kind が無い (module/no-module/new-shape)");
+    } else if (refModule.kind === "module") {
       if (!String(refModule.path || "").trim())
         errors.push("kind が module なのに reference_module.path が空");
     } else if (!String(refModule.reason || "").trim()) {
@@ -444,12 +436,10 @@ const PLAN_SCHEMA = obj(
   },
 );
 
-// /think Phase 3 の unit サイズ指針と結合しているので、片方だけを変えない。seam unit
-// のテストは unit 間の境界を跨いで実モジュールを動かすため files が正当に増える。
-// 検査対象は非 seam unit に限る。
-// この数値の正はここ。skills/think/SKILL.md が散文で述べ直し、ずれたら unit-caps-ssot.test.js が
-// 落ちる。3 つ目の複製 .agents/skills/build/scripts/validate-plan.ts はここのテストから届かず、
-// 手で合わせるしかない。
+// /think Phase 3 の unit サイズ指針と結合しているので、両側を一緒に変える。seam unit のテストは
+// unit 間の境界を跨ぐため、検査対象は非 seam unit に限る。
+// 正はここ。skills/think/SKILL.md が述べ直し、ずれたら unit-caps-ssot.test.js が落ちる。
+// .agents/skills/build/scripts/validate-plan.ts はテストから届かず、手で合わせる。
 const UNIT_CAPS = { files: 3, tests: 4 };
 const oversizedUnits = (p) =>
   p.units.filter((u) => {
@@ -473,9 +463,8 @@ if (!planHeading) {
 const afterHeading = body.slice(planHeading.index + planHeading[0].length);
 const nextSection = afterHeading.search(/^##[^#]/m);
 const planSection = nextSection === -1 ? afterHeading : afterHeading.slice(0, nextSection);
-// id は定義位置のみ照合し、prose 中の参照は数えない (think templates/plan.md 参照)。
-// テスト id の接頭辞は任意。doc に [T-SK077] のような接頭辞つき id を書く規約の
-// repo で plan が接頭辞なししか書けないと、実装時の改番に頼ることになる。
+// id は定義位置のみ照合し、prose 中の参照は数えない (think templates/plan.md)。テスト id の
+// 接頭辞は任意。doc に `[T-SK077]` と書く規約の repo で、実装時の改番に頼らずに済ませる。
 const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[1]));
 const bodyUnitIds = idSet(/^###\s+(U-\d{3})\b/gm);
 const bodyTestIds = idSet(/^[ \t]*[-*+][ \t]+(T-[A-Z]*\d{3})\b/gm);
@@ -487,7 +476,7 @@ const plan = await agent(
       `preconditions は plan が前提にする既存コードの {path, pattern} の一覧、backlog_candidates は issue に書かれたスコープ外候補。本文に無ければ空配列。\n` +
       `rules は ### 決まりごと (### Rules) 節を {source, quote} の組にしたもの。source は行に書かれた文書のパス、quote はコロンより後ろの文を逐語で。節が無ければ空配列。\n` +
       `seam は本文が \`seam: true\` と記した unit だけ true、他はすべて false。unit の内容から推測しない。\n` +
-      `reference_module: 本文は object \`{kind, reason}\` (kind: module/no-module/new-shape) で書く。path/files/instances/conventions は kind が module のときだけ加わる。kind と reason は原文のまま写し、kind が module のときは path/files/instances/conventions も本文から写す。旧来の本文は今も \`null (理由)\` の散文で書くことがあり、その場合も素の null に潰さず同じ object 形に変換する。本文の reference_module に理由が一切無いときだけ素の null を出す。本文に reference_module の行が無ければフィールドを省く。\n` +
+      `reference_module: 本文は object \`{kind, reason}\` (kind: module/no-module/new-shape) で書く。path/files/instances/conventions は kind が module のときだけ加わる。kind と reason は原文のまま写し、kind が module のときは path/files/instances/conventions も本文から写す。本文の reference_module に理由が一切無いときだけ素の null を出す。本文に reference_module の行が無ければフィールドを省く。\n` +
       `root_cause: 本文が記載していれば (Root Cause / 原因の行など) 原文のまま写す。本文に記載が無ければフィールドを省く。\n\n${fencedBody}`,
   ),
   {
@@ -503,52 +492,33 @@ if (!plan) {
   return await stop("extraction-failed", { why: "extract agent が plan を返さなかった。" });
 }
 
-// reference_module.kind/reason の決定的フォールバック: 上の extract prompt はまだ
-// skills/think に遅れている。think は DR-0093 により object 形式で書くようになったので、
-// 追いついていない抽出は本文が明記する kind や reason を今も落としうる。上の
-// bodyUnitIds/bodyTestIds と同じ手段で回収する: fencedBody 全体ではなく planSection に
-// 絞った行頭アンカー付き正規表現で、本文中の他所にあるテンプレート引用を一致に数えない。
-// planSection に reference_module 行がちょうど1件あるときだけ補完し、補完するのは
-// kind/reason だけで path は作らない。
-// クォートの有無どちらも取る。`/think` はこの行を `{ kind: no-module, reason: ... }` と
-// クォート無しで書くので、クォート前提の式ではこの補完が存在する理由である本文で何も埋まらない。
-// reason は散文でコンマを含むため、閉じ波括弧まで取る。
+// extract agent は本文が明記する kind や reason を落とすことがあるので、planSection 内の
+// reference_module 行 1 件で両方を上書きする。本文の他所にあるテンプレート引用は一致に数えず、
+// path は作らない。/think はこの行をクォート無しで書くので両形を取り、reason はコンマを含むため
+// 閉じ波括弧まで取る。
 const REFERENCE_MODULE_KIND_RE = /kind:\s*"?([A-Za-z][\w-]*)"?/;
 const REFERENCE_MODULE_REASON_RE = /reason:\s*"?([\s\S]*?)"?\s*\}?\s*$/;
 const REFERENCE_MODULE_LINE_RE = /^reference_module:[ \t]*(.+)$/gm;
 const refModuleLines = [...planSection.matchAll(REFERENCE_MODULE_LINE_RE)];
 if (refModuleLines.length === 1) {
   const refModuleLine = refModuleLines[0][1].trim();
-  const kindMatch = refModuleLine.match(REFERENCE_MODULE_KIND_RE);
-  const reasonMatch = refModuleLine.match(REFERENCE_MODULE_REASON_RE);
-  // 旧形式との互換 (DR-0093): 分割前の本文は kind を持たない `null (理由)` の散文で書く。
-  // reason しか記録していなかった plan の読み替えとして "no-module" が最も近い。
-  const legacyMatch = kindMatch ? null : refModuleLine.match(/^null\s*\(([\s\S]*)\)$/);
-  const filledKind = kindMatch ? kindMatch[1] : legacyMatch ? "no-module" : undefined;
-  const filledReason = reasonMatch ? reasonMatch[1] : legacyMatch ? legacyMatch[1] : undefined;
-  if (filledKind !== undefined || filledReason !== undefined) {
-    const existingRefModule =
-      plan.reference_module &&
-      typeof plan.reference_module === "object" &&
-      !Array.isArray(plan.reference_module)
+  const kind = refModuleLine.match(REFERENCE_MODULE_KIND_RE)?.[1];
+  const reason = refModuleLine.match(REFERENCE_MODULE_REASON_RE)?.[1];
+  if (kind !== undefined || reason !== undefined) {
+    const extracted =
+      plan.reference_module && typeof plan.reference_module === "object" && !Array.isArray(plan.reference_module)
         ? plan.reference_module
         : {};
-    const hasKind = typeof existingRefModule.kind === "string" && existingRefModule.kind.trim();
-    const hasReason =
-      typeof existingRefModule.reason === "string" && existingRefModule.reason.trim();
-    if (!hasKind || !hasReason) {
-      plan.reference_module = {
-        ...existingRefModule,
-        ...(!hasKind && filledKind !== undefined ? { kind: filledKind } : {}),
-        ...(!hasReason && filledReason !== undefined ? { reason: filledReason } : {}),
-      };
-    }
+    plan.reference_module = {
+      ...extracted,
+      ...(kind !== undefined ? { kind } : {}),
+      ...(reason !== undefined ? { reason } : {}),
+    };
   }
 }
 
-// Bug issue はタイトルに `[Bug]` prefix を持つ。fetch が title を取得できなかったときは
-// 分類不能なので、空 fallback の startsWith は Bug ではない側に倒れる (どちらかへの
-// 当て推量はしない)。
+// Bug issue はタイトルに `[Bug]` prefix を持つ。fetch が title を取得できなかったときは空の
+// fallback が Bug ではない側に倒れ、どちらかへの当て推量はしない。
 const blockers = validate(plan, String(fetched.title || "").startsWith("[Bug]"));
 if (blockers.length) {
   return await stop("invalid-plan", { blockers, why: "抽出した plan が構造 validation に失敗。" });
@@ -590,8 +560,8 @@ const relayVerifier = ({ what, script, payload, count }) =>
   `(3) verifier の stdout の "results" 配列を、全 ${count} 件そのまま返す。追加 / 削除 / 編集をしない。\n` +
   `入力 JSON は以下。\n${JSON.stringify(payload)}`;
 
-// payload を argv 1 要素で渡し、stdout を逐語で持ち帰らせる relay。agent には JSON の中身を
-// 読ませず、解釈は relayedJson で script 側が行う。壊れた中継は null であって空の結果ではない。
+// payload を argv 1 要素で渡し、stdout を逐語で持ち帰らせる relay。解釈は relayedJson で script
+// 側が行う。壊れた中継は null であって空の結果ではない。
 const STDOUT_RELAY_SCHEMA = obj(["stdout"], {
   stdout: { type: "string", description: "コマンドの stdout を逐語で" },
 });
@@ -622,17 +592,14 @@ const REVALIDATE_SCHEMA = obj(["results"], {
 });
 
 // ---- Revalidate: 前提を現在のコードベースに対して再検証する ----
-// 起票から build までに前提コードが動いた可能性を fail-close で捕まえる。Branch と並列
-// (両者は plan のみに依存)。drift 停止時は作成済みブランチを stopped に載せて surface する。
+// 起票から build までに動いた前提コードを fail-close で捕まえる。Branch と並列に走り、drift
+// 停止時は作成済みブランチを stopped に載せる。
 phase("Revalidate");
 const preconditions = plan.preconditions || [];
-// reference_module も preconditions と同じくらい plan が前提にする既存コードを名指しする。
-// path と files を revalidate.py が受ける同じ {path} 形に畳み込み、参照モジュールが
-// 移動・削除されていたときも drift として検出する。kind は見ない。no-module でも
-// 引用した形の path を書けるので、path があれば実在検査の対象にする。
-// preconditions と異なり、reference_module の結果が欠落しても fail-open のまま進める
-// (unreported-retry / revalidate-incomplete の対象にしない)。参照モジュールは後続 unit
-// 向けの構造ドキュメントであり、precondition のように build をゲートする前提ではない。
+// reference_module の path と files も preconditions と同じ {path} 形に畳み込み、参照モジュールの
+// 移動を drift として検出する。kind は見ない。no-module でも path を書けるためである。
+// preconditions と異なり、結果が欠落しても fail-open で進める。後続 unit 向けの構造ドキュメント
+// であり、build をゲートする前提ではない。
 const refModule = plan.reference_module;
 const refModuleEntries =
   refModule && typeof refModule === "object" && String(refModule.path || "").trim()
@@ -640,13 +607,11 @@ const refModuleEntries =
         path,
       }))
     : [];
-// 1 回の relay payload にまとめて送り、下の resultByKey が単一の relay 呼び出しから
-// 両方を突き合わせられるようにする。unreported-retry / revalidate-incomplete のゲートは
-// 引き続き preconditions だけで判定する。
+// 1 回の relay payload にまとめ、下の resultByKey が単一の relay 呼び出しから両方を突き合わせる。
+// unreported-retry / revalidate-incomplete のゲートは preconditions だけで判定する。
 const revalidationTargets = [...preconditions, ...refModuleEntries];
-// Code が unit ごとに commit するため run の途中で HEAD は分岐点でなくなり、下流の
-// `git diff HEAD` はすべて空を返す。可視の失敗でなく無言の pass になるので、基準を
-// 分岐点の sha で持つ。
+// Code が unit ごとに commit するため run の途中で HEAD は分岐点でなくなり、`git diff HEAD` は
+// 空を返す。基準は分岐点の sha で持つ。
 const BRANCH_SCHEMA = obj(["branch", "head", "ahead_of_base"], {
   branch: { type: "string", description: "checkout 済みブランチ名のみ" },
   head: {
@@ -727,9 +692,8 @@ const [reval, branchRes, baseline] = await parallel([
 ]);
 const branch = (branchRes && branchRes.branch) || "";
 recordedBranch = branch;
-// build 以前から作業ツリーにある私物を Verify の scope 逸脱から差し引き、同じ一覧を
-// build 以前から作業ツリーにある私物を Verify の scope 逸脱から差し引き、commit agent の
-// never-stage 集合にも渡す。
+// build 以前から作業ツリーにある私物を Verify の scope 逸脱から差し引き、同じ一覧を commit
+// agent の never-stage 集合にも渡す。
 const baselineUntracked = baseline && Array.isArray(baseline.untracked) ? baseline.untracked : [];
 // sha が使えないまま commit を有効にすると、HEAD が動いた後に比較対象が消え、scope /
 // conformance を未検証のまま出荷する。従来の末尾 1 コミットへ退避する。
@@ -737,9 +701,8 @@ const startPoint = String((branchRes && branchRes.head) || "").trim();
 const perUnitCommits = /^[0-9a-f]{7,40}$/.test(startPoint);
 const diffBase = perUnitCommits ? startPoint : "HEAD";
 if (!perUnitCommits) log("分岐点 sha を取得できず、Ship で 1 回 commit し HEAD 基準で diff する。");
-// base 起点の呼び出しで分岐点が base より進んでいれば、その差分は今回の実装ではない。
-// 破棄したブランチや前タスクのブランチの上に積むと、Verify も PR もそれを今回の成果として
-// 扱う。scope 逸脱にも conformance にも現れないので、ここで止める。
+// base 起点で分岐点が base より進んでいれば、その差分は今回の実装ではない。前のブランチの上に
+// 積むと Verify も PR もそれを今回の成果として扱い、scope 逸脱にも conformance にも現れない。
 if (baseBranch && Number(branchRes && branchRes.ahead_of_base) > 0) {
   return await stop("dirty-branch-point", {
     branch,
@@ -877,8 +840,8 @@ log(
 );
 
 // ---- Cleanup: simplify skill + test 検証 ----
-// review lens は build に置かない。/polish は人間が PR に起動する。cleanup
-// を Verify の前に走らせ、検証の対象を出荷する tree にする。
+// Verify の前に走らせ、検証の対象を出荷する tree にする。review lens は人間が PR に起動する
+// /polish のもの。
 const CLEANUP_SCHEMA = obj(["edits", "tests_pass", "stashed"], {
   edits: {
     type: "array",
@@ -909,10 +872,9 @@ const cleanup = (await agent(
 log(`Cleanup: 編集 ${cleanup.edits.length} 件、tests_pass=${cleanup.tests_pass}。`);
 
 // ---- Verify: 決定論の選択チェック (diff スコープ + T-NNN 照合) ∥ conformance ----
-// 正しさの確認は欠陥探索でなく plan のアンカーとの比較で行う。静的解析は
-// edit 時の gates hooks、重い担保は人間の /audit が受け持つ。2 チェックは fail-open で
-// PR に surface する。conformance は唯一の LLM レビューで、findings は専用の PR 節に
-// 出して他へ混ぜない。
+// 欠陥探索でなく plan のアンカーとの比較。静的解析は gates hooks、重い担保は人間が起動する
+// /audit が受け持つ。2 チェックは fail-open で PR に surface し、conformance だけが LLM レビューで
+// 専用の PR 節に出す。
 
 const TEST_PRESENCE_SCHEMA = obj(["results"], {
   results: {
@@ -924,9 +886,8 @@ const TEST_PRESENCE_SCHEMA = obj(["results"], {
   },
 });
 
-// plan の参照モジュールからの構造 drift。conformance は「spec の求めを満たすか」に、
-// こちらは「隣人と同じ形か」に答える。contract が引用するのは 1 つの振る舞いなので、
-// 周辺構造はどのアンカーにも捕まらず手組みされうる。
+// plan の参照モジュールからの構造 drift。conformance は「spec の求めを満たすか」、こちらは
+// 「隣人と同じ形か」に答える。周辺構造は振る舞いの contract には捕まらない。
 const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
   reference_checked: {
     type: "boolean",
@@ -1079,15 +1040,14 @@ const [diff, testPresence, conformance, structure] = await parallel([
 const planFiles = new Set(plan.units.flatMap((u) => u.files));
 // ディレクトリは "dir/" の 1 行で届くことがある。porcelain も、--untracked-files=all を
 // 守らなかった diff agent も同じなので、末尾が "/" の行は配下すべてを指す。
-const dirCovers = (line, path) => line.endsWith("/") && path.startsWith(line);
-// baseline の項目は末尾の "/" が無くてもディレクトリとして読む。畳まれうる列挙から来るので、
-// ファイルとしてだけ扱うと配下が scope 逸脱へ戻ってしまう。
-const preexisting = (f) =>
-  baselineUntracked.some((b) => b && (f === b || f.startsWith(b.endsWith("/") ? b : `${b}/`)));
+const under = (dir, path) => path.startsWith(dir.endsWith("/") ? dir : `${dir}/`);
+const dirCovers = (line, path) => line.endsWith("/") && under(line, path);
+// baseline の項目は末尾の "/" が無くてもディレクトリとして読む。列挙は "/" を畳みうるので、
+// ファイルとして扱うと配下が scope 逸脱に数えられる。
+const preexisting = (f) => baselineUntracked.some((b) => b && (f === b || under(b, f)));
 const coveredByPlan = (f) => planFiles.has(f) || [...planFiles].some((p) => dirCovers(f, p));
-// 各チェックは findings の横に status を持つ。件数だけでは死んだ agent の 0 と綺麗な結果の 0 が
-// 同じ数字になるので、配列は findings を、status は実行されたかどうかを持つ。
-// files が null なのは git が失敗したときで、diff-files.py はその stderr を error に載せる。
+// status を findings の横に持つのは、死んだ agent の 0 と綺麗な結果の 0 が同じ数字になるため。
+// files が null なのは git が失敗したときで、diff-files.py の stderr は error に載る。
 const diffReport = relayedJson(diff);
 if (diffReport && diffReport.files === null) log(`diff-files: git が失敗 (${diffReport.error})。`);
 const diffFiles = diffReport && Array.isArray(diffReport.files) ? diffReport.files : null;
@@ -1109,10 +1069,9 @@ if (!allTestNames.length) {
 } else {
   testPresenceStatus = "agent-failed";
 }
-// plan が files に挙げたのに一度も変更されていないファイル。scope 逸脱が「plan に無い
-// ファイルを触った」を見るのに対し、こちらは「plan にあるファイルを触っていない」を見る。
-// unit が丸ごと実装されないまま green で通ることがあり、conformance が
-// 落ちていると誰も気づかない。LLM 判断が要らないので落ちようがない。
+// plan の files にあるのに一度も変更されていないファイル。scope 逸脱は「plan に無いファイルを
+// 触った」を、こちらは「plan にあるファイルを触っていない」を見る。unit が丸ごと未実装でも
+// green で通るので必要になる。LLM 判断が要らないので落ちようがない。
 const untouchedPlanFiles = diffListed
   ? [...planFiles].filter((p) => !diffFiles.some((f) => f && (f === p || dirCovers(f, p))))
   : [];
@@ -1152,8 +1111,8 @@ if (backlogCandidates.length) {
 }
 
 // ---- Ship: commit + draft PR (外向きの操作なので draft = 可逆) ----
-// fact tail は pr-body.py が決定論で描画し、fact 節を黙って落とさせない。追記と
-// gh pr create を && で連結し、レンダラー失敗時は PR 作成前に中断させる。
+// fact tail は pr-body.py が決定論で描画し、fact 節を黙って落とさせない。追記と gh pr create は
+// && で連結し、レンダラー失敗時は PR 作成前に中断する。
 phase("Ship");
 
 // 情報系セクションの自由記述だけを対象言語へ翻訳 + 圧縮する。安全系の事実と構造化
@@ -1164,10 +1123,8 @@ const shipConformance = conf.spec_found ? conf.findings.map((f) => ({ ...f })) :
 // 書き戻しは set() 経由に限り、構造化フィールドへ触れない。kind は圧縮の強さを
 // 分ける。finding の detail は根拠を location / spec_line が別に持つので削れる。
 const shipStructure = struct.reference_checked ? struct.findings.map((f) => ({ ...f })) : [];
-// anomaly の evidence は slot に入れない。finding の location / spec_line と同じ扱い。
-// prompt が中身を逐語で残す以上、翻訳で変わるのは末尾の説明句だけ。一方で slot を 1 つ
-// 増やすたびに全か無かの書き戻しが突合する id が増え、1 つでも欠けると tail 全体が英語の
-// まま ship される。
+// anomaly の evidence は finding の location / spec_line と同じく slot に入れない。prompt が中身を
+// 逐語で残すうえ、slot は 1 つ増えるごとに全か無かの書き戻しが突合する id を増やす。
 const slots = [];
 for (const [items, field, kind] of [
   [shipConformance, "detail", "finding"],
@@ -1255,18 +1212,15 @@ const shipPayload = {
   manual_checks: manualChecks,
 };
 
-// agent が選んだファイル名は run をまたいで再利用されうるうえ、fact tail は追記されるので、古い
-// 本文の上に今回の tail が積まれた状態で ship してしまう。agent が決めるタイトルをファイル経由
-// にするのは別の理由で、展開すると shell の構文として届くためである。script が決めたタイトルは
-// shq で argv 1 要素にしてコマンドに直接載せる。
+// 本文をファイル経由にするのは、agent が選ぶファイル名が run をまたいで再利用されうるうえ fact
+// tail が追記されるため。agent が決めるタイトルは展開すると shell の構文として届くのでファイル
+// 経由にし、script が決めたタイトルは shq で argv 1 要素にして直接載せる。
 const runSlug = `${issueNumber || "no-issue"}-${String(branch).replace(/[^\w.-]+/g, "-")}`;
 
-// pr-writing.md のタイトル規則 (issue 参照があれば issue タイトルをそのまま使い、feat: / fix: の
-// prefix は外す) を script 側で適用する。Ship agent に任せると、issue を引かずに自作した
-// 英語のタイトルで PR を開くことがある。Load が title を取得できなかった run では空のまま
-// で、従来どおり agent が決める。
-// type の一覧は verify-commit.py の COMMIT_TYPES と同じ。任意の単語を外すと "WIP:" や "RFC:" が
-// 消える。
+// pr-writing.md のタイトル規則 (issue タイトルから feat: / fix: の prefix を外す) は script が
+// 適用する。Ship agent は issue を引かずに自作のタイトルで PR を開くことがある。Load が title を
+// 取得できなかった run では空。type の一覧は verify-commit.py の COMMIT_TYPES と同じで、任意の
+// 単語を外すと "WIP:" や "RFC:" が消える。
 const CONVENTIONAL_PREFIX =
   /^(?:feat|fix|refactor|docs|test|chore|perf|style|ci)(?:\([^()]*\))?!?:\s*/i;
 const prTitle = String(fetched.title || "")

--- a/.ja/workflows/code.js
+++ b/.ja/workflows/code.js
@@ -132,10 +132,9 @@ const parsedReport = (stdout) => {
   }
 };
 
-// レポートは agent を経由して戻るので、長いものは途中で切れて戻る。ある run では 1.5 KB から
-// 8.7 KB のレポートが中継され、解析できない形で届いたものは 5.7 KB だった。その長さの大半は
-// 2 つの出力 tail で、ここはそれを一度も読まない。読むのは verdict と classification と
-// candidates である。gate.ts の既定は tail 1 つあたり 12 KB。
+// レポートは agent を経由して戻るので、長いものは途中で切れる (5.7 KB のものが解析できない形で
+// 届いた)。長さの大半は 2 つの出力 tail で、ここは読まない。読むのは verdict と classification と
+// candidates。gate.ts の既定は tail 1 つあたり 12 KB。
 const GATE_TAIL_BYTES = "800";
 
 // gate.ts は Node の TypeScript 型ストリップの上で動く。それより古い node のシェルでは最初の
@@ -300,6 +299,14 @@ const completed = [];
 const skipped = [];
 const anomalies = [];
 const commits = [];
+// codex-herdr の pane 状態。panes は claude の run では null のままで、close 後も id を保つので
+// どの return path でも報告できる。closed は stopUnit と loop 終端からの二重 close を防ぐ。
+const herdrState = { panes: null, closed: false, opens: 0, closes: 0 };
+const herdrReport = () => ({
+  herdr_panes: herdrState.panes,
+  pane_opens: herdrState.opens,
+  pane_closes: herdrState.closes,
+});
 // run 級の配列を閉じ込めるので、途中終了でも呼び出し元は部分進捗を受け取る。
 const stopUnit = async (stopped, unit, why) => {
   await closeHerdrPanes();
@@ -311,16 +318,13 @@ const stopUnit = async (stopped, unit, why) => {
     skipped,
     anomalies,
     commits,
-    herdr_panes: herdrPanesResolved,
-    pane_opens: paneOpens,
-    pane_closes: paneCloses,
+    ...herdrReport(),
   };
 };
-// 経路と呼び先をこの 1 関数だけで決める。herdrPanes は下で let 宣言されるが、この関数の
-// 呼び出しはすべて for loop の中、その代入より後に起きる。
+// 経路と呼び先をこの 1 関数だけで決める。
 const implementDestination = (role) =>
   implementer === "codex-herdr"
-    ? { opts: {}, paneId: herdrPanes ? herdrPanes[role] : undefined }
+    ? { opts: {}, paneId: herdrState.panes ? herdrState.panes[role] : undefined }
     : { opts: { model: input.model || "sonnet", effort: "high" }, paneId: undefined };
 
 const RED_SCHEMA = {
@@ -383,9 +387,8 @@ const COMMIT_SCHEMA = {
   },
 };
 
-// agent の prompt 文をそのまま載せない。prompt には issue 由来 (untrusted) の文が混ざり、
-// コミットメッセージは改変不能な記録になる。trailer 形式は plan のアンカーを機械可読に保つ
-// (git interpret-trailers / git log --format)。
+// agent の prompt 文はメッセージに載せない。issue 由来 (untrusted) の文が混ざり、コミット
+// メッセージは改変不能な記録になる。trailer 形式は plan のアンカーを機械可読に保つ。
 const commitBody = (unit, tests) =>
   [
     flatten(unit.goal),
@@ -398,9 +401,9 @@ const commitBody = (unit, tests) =>
     ...(issueRef ? [`Issue: #${issueRef}`] : []),
   ].join("\n");
 
-// working tree がその unit の作業だけを持っている間に取る。混ざった後の分割は hunk の帰属
-// を LLM に推測させることになる。コミット失敗 (pre-commit gate のブロック) で
-// stop しないのは、作業がツリーに残り呼び出し元の最終コミットが拾うため。
+// working tree がその unit の作業だけを持っている間に取る。混ざった後の分割は hunk の帰属を LLM
+// に推測させる。コミット失敗 (pre-commit gate のブロック) で止めないのは、作業がツリーに残り
+// 呼び出し元の最終コミットが拾うため。
 const commitUnit = async (unit, tests, testFiles) => {
   if (!commitPerUnit) return;
   // commit agent の後に読むと、着地先の head はもう残っていない。
@@ -464,10 +467,8 @@ const commitUnit = async (unit, tests, testFiles) => {
   log(`${unit.id}: 未コミット (${why})。作業ツリーに残す。`);
 };
 
-// agent tool の schema は形しか保証しない: courier が読んだ codex のファイルが
-// `{"red_confirmed": "false"}` のように文字列で書かれていても RED_SCHEMA の宣言する
-// プロパティ自体は満たしてしまう。呼び出し側が truthy 判定でそれを信頼する直前、ここで実際の
-// 型を検査する。
+// agent tool の schema は形しか保証しない: courier が `{"red_confirmed": "false"}` と文字列で
+// 返しても RED_SCHEMA は満たす。呼び出し側が truthy 判定で信頼する直前、ここで型を検査する。
 const boolMismatch = (result, field) => !!result && typeof result[field] !== "boolean";
 
 const courierTypeStop = (unit, result, field) =>
@@ -490,9 +491,9 @@ const recordDeferred = (unit, result) => {
 // realm に fs が無い)、unit と role が決まれば同じ 1 ファイルを初回・retry で使い回す。
 const responsePath = (unit, role) => `.codex-response/${unit.id}-${role}.json`;
 
-// role は Red step が "tester"、Green / 直接実装が "coder"。まだ失敗している結果をどう
-// 扱うかは呼び出し元が持つ。Red 未確認は anomaly に記録し、impl / Green の失敗は run を止める。
-// 1 回目が null なら retry しないので、死んだ agent を 2 度叩かない。
+// role は Red が "tester"、Green / 直接実装が "coder"。まだ失敗している結果の扱いは呼び出し元が
+// 持つ。Red 未確認は anomaly、impl / Green の失敗は run 停止。1 回目が null なら retry せず、死んだ
+// agent を 2 度叩かない。
 const stepWithRetry = async (unit, label, role, schema, ok, prompt, retryPrompt) => {
   const dest = implementDestination(role);
   // 初回と retry の両方の prompt へ前置くので、codex-herdr の retry も初回と同じ pane・同じ
@@ -550,11 +551,10 @@ const PANE_CLOSE_SCHEMA = {
   },
 };
 
-// herdr CLI リファレンス (https://herdr.dev/ja/docs/cli-reference/, 2026-08-27 取得) より:
-// `pane split` の応答は新しい pane id を `.result.pane.pane_id` に持つ。`agent start <name>
-// --kind KIND --pane ID` は既存のシェル pane を起動対象にし、name は `[a-z][a-z0-9_-]{0,31}` に
-// 一致する必要がある。検出状態が blocked だと即座に `agent_not_ready` を返す。`pane close
-// <pane_id>` は pane split で読んだ id をそのまま渡す。
+// herdr CLI リファレンス (https://herdr.dev/ja/docs/cli-reference/) より: `pane split` の応答は
+// 新しい pane id を `.result.pane.pane_id` に持つ。`agent start <name> --kind KIND --pane ID` は
+// 既存のシェル pane を対象にし、name は `[a-z][a-z0-9_-]{0,31}` に一致させる。検出状態が blocked
+// だと即座に `agent_not_ready` を返す。`pane close <pane_id>` は split で読んだ id を渡す。
 const startPane = (role) =>
   agent(
     anchor(
@@ -589,32 +589,19 @@ const closePane = (role, paneId) =>
     },
   );
 
-// codex-herdr でない run では null のままで、closeHerdrPanes は何もしない。
-let herdrPanes = null;
-// run-workflow.js の calls.agent は各 agent の {prompt, opts} しか記録しないので、pane split
-// から解決した pane id や開閉回数がこの workflow 自身の返り値 (build.js がさらに自分の返り値へ
-// 転送する値) に実際に届いたことをそこからは示せない。herdrPanesResolved は closeHerdrPanes が
-// herdrPanes を null に戻したあとも id を保つので、後片付けの前後どちらの返り値にも id が残る。
-let herdrPanesResolved = null;
-let paneOpens = 0;
-let paneCloses = 0;
-
-// 後片付け (loop 終端の closeHerdrPanes と、下の起動失敗時に開いた tester pane 1 つだけを閉じる
-// 分岐の両方) の close は必ずここを通すので、paneCloses は実際に閉じた pane 数の唯一の集計になる。
+// close は必ずここを通すので、herdrState.closes は実際に閉じた pane 数の唯一の集計になる。
 const closePaneCounted = async (role, paneId) => {
   const res = await closePane(role, paneId);
-  if (res && res.closed) paneCloses++;
+  if (res && res.closed) herdrState.closes++;
   return res;
 };
 
-// stopUnit 経由の早期 return と loop 終端後の正常終了のどちらからも呼ぶので、呼び出しの都度
-// null に戻して二重 close を防ぐ。close が失敗しても run 自体は止めず、anomaly に記録する。
+// close が失敗しても run 自体は止めず、anomaly に記録する。
 const closeHerdrPanes = async () => {
-  if (!herdrPanes) return;
-  const panes = herdrPanes;
-  herdrPanes = null;
-  for (const role of ["tester", "coder"]) {
-    const res = await closePaneCounted(role, panes[role]);
+  if (!herdrState.panes || herdrState.closed) return;
+  herdrState.closed = true;
+  for (const [role, paneId] of Object.entries(herdrState.panes)) {
+    const res = await closePaneCounted(role, paneId);
     if (res && res.closed) continue;
     const why = res
       ? res.notes || `${role} pane の close が closed: false を返した`
@@ -624,9 +611,8 @@ const closeHerdrPanes = async () => {
   }
 };
 
-// herdr は Unix socket 越しに話すので sandboxed Bash からは届かず、agent 側で
-// dangerouslyDisableSandbox が要る。assert.js の codex_available と同じ形で、command の
-// 有無と実疎通の両方を確認してから実装に入る。
+// herdr は Unix socket 越しに話すので、agent 側で dangerouslyDisableSandbox が要る。assert.js の
+// codex_available と同じく、command の有無と実疎通の両方を確認してから実装に入る。
 if (implementer === "codex-herdr") {
   const herdr = await agent(
     anchor(
@@ -650,9 +636,7 @@ if (implementer === "codex-herdr") {
       why: herdr
         ? herdr.notes || "herdr に到達できなかった。"
         : "herdr の到達性確認 agent が結果を返さなかった。",
-      herdr_panes: herdrPanesResolved,
-      pane_opens: paneOpens,
-      pane_closes: paneCloses,
+      ...herdrReport(),
     };
   }
 
@@ -666,35 +650,29 @@ if (implementer === "codex-herdr") {
       why: testerStart
         ? testerStart.notes || "tester pane の起動に失敗した。"
         : "tester pane-start agent が結果を返さなかった。",
-      herdr_panes: herdrPanesResolved,
-      pane_opens: paneOpens,
-      pane_closes: paneCloses,
+      ...herdrReport(),
     };
   }
-  paneOpens++;
+  herdrState.opens++;
   // 2 つ揃ってからではなく pane ごとに記録する。coder の起動失敗は 2 つの間で止まるので、
-  // 残った pane を追う呼び出し側には、その停止が既に解決している tester の id が要る。
-  herdrPanesResolved = { tester: testerStart.pane_id };
+  // 残った pane を追う呼び出し側には tester の id が要る。
+  herdrState.panes = { tester: testerStart.pane_id };
 
   // coder pane の起動に失敗したら、先に開いた tester pane を閉じてから止まる。
   const coderStart = await startPane("coder");
   if (!coderStart || !coderStart.started) {
-    await closePaneCounted("tester", testerStart.pane_id);
+    await closeHerdrPanes();
     return {
       stopped: "pane-start-failed",
       why: coderStart
         ? coderStart.notes || "coder pane の起動に失敗した。"
         : "coder pane-start agent が結果を返さなかった。",
-      herdr_panes: herdrPanesResolved,
-      pane_opens: paneOpens,
-      pane_closes: paneCloses,
+      ...herdrReport(),
     };
   }
-  paneOpens++;
-
+  herdrState.opens++;
   // 全 unit を通してこの 2 pane を使い回す。close は loop 終端 (closeHerdrPanes) が担う。
-  herdrPanes = { tester: testerStart.pane_id, coder: coderStart.pane_id };
-  herdrPanesResolved = herdrPanes;
+  herdrState.panes.coder = coderStart.pane_id;
 }
 
 // contract が引用するのは 1 つの振る舞いなので、plan の参照モジュールが無いと周辺構造が
@@ -709,11 +687,10 @@ const referenceModuleCtx = ref?.path
     `参照モジュールからの逸脱は plan が明記したときのみ許され、逸脱は結果に記す。\n`
   : "";
 
-// リファレンスの発見を LLM の自発探索に任せると探索スキップという脱落点が増え、読了の検証も
-// できないため、読む行為を明示の agent 呼び出しにし、units[].files との glob 照合は script が
-// 握って決定的にする。
-// plan が運ぶ決まりごとを、実装の prompt へそのまま流す。実装の時点で索引や wiki を
-// 引きに行かないので、agent へ何が届いたかは issue 本文の ### 決まりごと だけで読める。
+// リファレンスの読了は明示の agent 呼び出しにし、units[].files との glob 照合は script が持つ。
+// LLM の自発探索に任せると探索がスキップされうるうえ、読了を検証できない。plan の決まりごとは
+// prompt へそのまま流す。実装の時点で何も引きに行かないので、agent へ何が届いたかは issue の
+// ### 決まりごと だけで読める。
 const RULES_START = "---- rules start ----";
 const RULES_END = "---- rules end ----";
 
@@ -966,8 +943,7 @@ for (const [index, unit] of units.entries()) {
   await commitUnit(unit, tests, red.test_files || []);
 }
 
-// 全 unit の実装が終わったので、codex-herdr で開いた pane を閉じる。implementer が claude の
-// run では herdrPanes が null のままで、ここは何もしない。
+// 全 unit の実装が終わったので、codex-herdr で開いた pane を閉じる。
 await closeHerdrPanes();
 
 const VERIFY_SCHEMA = {
@@ -1023,9 +999,6 @@ return {
   tests_pass: verify.tests_pass,
   gates_pass: verify.gates_pass,
   verify_output: verify.output_tail,
-  // claude の run では herdrPanesResolved / paneOpens / paneCloses に一切触れないので null の
-  // まま。build.js はこの 3 つをそのまま自分の返り値へ転送する。
-  herdr_panes: herdrPanesResolved,
-  pane_opens: paneOpens,
-  pane_closes: paneCloses,
+  // build.js はこの 3 つをそのまま自分の返り値へ転送する。
+  ...herdrReport(),
 };

--- a/sandbox/hako/agents.sh
+++ b/sandbox/hako/agents.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# sandbox/hako/agents.sh: single source of truth for the per-agent CLI shape (U-001).
+# sandbox/hako/agents.sh: single source of truth for the per-agent CLI shape.
 #
 # One row per agent: name | guest 内の exec コマンド | 認証ディレクトリ | agent 固有の allowlist ドメイン (space 区切り)。
 # entrypoint.sh と init-firewall.sh はそれぞれ別プロセスからこの表を読むため、source では

--- a/sandbox/hako/entrypoint.sh
+++ b/sandbox/hako/entrypoint.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
 # sandbox/hako/entrypoint.sh: apply the firewall as root, demote to the unprivileged node
-# user, and exec the agent's command (U-003).
+# user, and exec the agent's command.
 #
 # Runs as root inside the guest container. Order matters for the security guarantee:
-#   1. Apply the firewall (init-firewall.sh, U-002) while still root; a non-zero exit means
+#   1. Apply the firewall (init-firewall.sh) while still root; a non-zero exit means
 #      the guest network is not locked down, so the agent must never run.
 #   2. Probe, via gosu, that the demoted node user cannot run iptables. Node has neither
 #      NET_ADMIN nor sudo, so the probe should fail; if it instead succeeds, demotion did
 #      not shed the privilege it claims to, so abort rather than exec the agent under it.
-#   3. exec the agent's command (read from agents.sh, U-001; never hardcoded here) as node.
+#   3. exec the agent's command (read from agents.sh, never hardcoded here) as node.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/sandbox/hako/hako.sh
+++ b/sandbox/hako/hako.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # sandbox/hako/hako.sh: host 側 CLI that assembles the `container run` invocation for one
-# agent (U-005), plus the `login` subcommand that opens an interactive session for that
-# agent's own auth flow (U-006).
+# agent, plus the `login` subcommand that opens an interactive session for that
+# agent's own auth flow.
 #
 # Usage: hako.sh <agent-name> [--live]
 #        hako.sh login <agent-name>
@@ -14,7 +14,7 @@
 # Auth directory: a named volume, `container volume create` (docs/command-reference.md),
 # scoped per agent so agent A's credentials are never mounted into agent B's container.
 # Both forms take the agent name as their first positional argument (after `login`, for the
-# login form) and validate it against agents.sh (U-001) before assembling any run argument.
+# login form) and validate it against agents.sh before assembling any run argument.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -66,8 +66,7 @@ run_container() {
     "$IMAGE" "$agent_name"
 }
 
-# Assembles and runs the ordinary (non-interactive) container invocation for a known agent
-# name (U-005).
+# Assembles and runs the ordinary (non-interactive) container invocation for a known agent name.
 run_agent() {
   local agent_name="$1" live_flag="${2:-}"
   local auth_dir workspace_src
@@ -78,11 +77,11 @@ run_agent() {
   run_container "$agent_name" "$auth_dir" "$workspace_src"
 }
 
-# U-006: `hako.sh login <agent-name>` opens an interactive session so the agent's own login
+# `hako.sh login <agent-name>` opens an interactive session so the agent's own login
 # flow (browser auth, device code, etc.) can run to completion and persist into the
 # per-agent auth volume mounted at auth_dir. The permission-skipping flag lives in
 # agents.sh's per-agent exec command, applied inside the container by entrypoint.sh for the
-# ordinary run path (U-003); this invocation never reads that field, so it carries no such
+# ordinary run path; this invocation never reads that field, so it carries no such
 # flag.
 run_login() {
   local agent_name="$1"

--- a/sandbox/hako/init-firewall.sh
+++ b/sandbox/hako/init-firewall.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# sandbox/hako/init-firewall.sh: apply the guest firewall for one agent and verify it (U-002).
+# sandbox/hako/init-firewall.sh: apply the guest firewall for one agent and verify it.
 #
 # Structure follows anthropics/claude-code's own .devcontainer/init-firewall.sh: flush ->
 # allowlist construction -> default DROP -> post-check. Two deltas from that script:
-#   - The allowed domain set is not a constant here; it comes from agents.sh (U-001), read
+#   - The allowed domain set is not a constant here; it comes from agents.sh, read
 #     as a sibling CLI call the same way sandbox/hako/tests/agents.test.sh resolves AGENTS.
 #   - This guest has no Docker-managed embedded resolver to special-case, so there is no
 #     DNS-rule extract/restore step. DNS is allowed as a single udp/53 rule to whichever

--- a/skills/ablate/scripts/arms.py
+++ b/skills/ablate/scripts/arms.py
@@ -30,9 +30,7 @@ RUN_COUNT = 5
 
 # The share of an arm's runs that must reproduce the harness-present behavior for the arm to
 # be judged passed. Held here per docs/wiki/deterministic-script-judgment.md so the number
-# lives in one script constant rather than in SKILL.md prose; wiring it into a pass/fail
-# verdict is deferred to the unit that scores run output, since that judgment needs a
-# comparison this module does not yet have (see this unit's reported deferred list).
+# lives in one script constant rather than in SKILL.md prose.
 PASS_THRESHOLD = 0.8
 
 UNMEASURED = "unmeasured"

--- a/skills/ablate/scripts/report.py
+++ b/skills/ablate/scripts/report.py
@@ -29,8 +29,7 @@ TRANSCRIPTS_ROOT = Path.home() / ".claude" / "projects"
 # The ablation apparatus's own script tree. A path under here is the code that produced the
 # observation, not a harness element under test, so it must never appear in
 # delete_candidates: deleting the apparatus that measures harness elements would remove the
-# ability to keep measuring them (this unit's T-015 contract, "the ablation apparatus itself
-# is absent from the delete candidates").
+# ability to keep measuring them.
 APPARATUS_DIR = "skills/ablate/"
 
 REPORT_NAME = "ablate"

--- a/skills/scribe/scripts/verify_run.py
+++ b/skills/scribe/scripts/verify_run.py
@@ -18,8 +18,6 @@ from typing import TypedDict, cast
 # alone does not separate one run from the history behind it.
 COMMIT_PREFIX = "docs(wiki):"
 
-NOT_A_PAGE = {"_candidates.md", "README.md"}
-
 WIKI_DIR = "docs/wiki"
 
 WAITING = "## 昇格待ち"
@@ -77,21 +75,6 @@ def run_commits(repo: Path, base: str) -> list[str]:
         if subject.startswith(COMMIT_PREFIX):
             hashes.append(commit_hash)
     return hashes
-
-
-def pages_added(repo: Path, commit_hash: str) -> int:
-    out = _git(
-        repo, "diff-tree", "--no-commit-id", "--name-status", "-r", commit_hash, "--", WIKI_DIR
-    )
-    count = 0
-    for line in out.splitlines():
-        if not line:
-            continue
-        status, path = line.split("\t", 1)
-        name = Path(path).name
-        if status == "A" and name.endswith(".md") and name not in NOT_A_PAGE:
-            count += 1
-    return count
 
 
 def section_rows(text: str, heading: str) -> int:

--- a/workflows/_lib/run-workflow.js
+++ b/workflows/_lib/run-workflow.js
@@ -44,7 +44,7 @@ const toHostRealmError = (err) => {
 };
 
 // The own properties production leaves on an error it hands to the script, in the order it
-// writes them. Measured 2026-08-22 (#441): the object's prototype is null, so `e instanceof
+// writes them. Measured: the object's prototype is null, so `e instanceof
 // Error` is false there and cause, errors and any custom property are gone. Handing a script
 // the host Error itself would let it branch on instanceof under test and take the other branch
 // in production.

--- a/workflows/assert.js
+++ b/workflows/assert.js
@@ -14,22 +14,17 @@ export const meta = {
   ],
 };
 
-// Four design points.
-// 1. The static reviewer fan-out reuses the nested workflow("audit") instead of duplicating
-//    the routing table (so a routing-table change propagates to assert directly). Audit
-//    findings already passed critic-audit / critic-evidence inside audit, so assert's Challenge
-//    applies only to Codex findings, avoiding a double challenge by the same agents.
-// 2. The gate is computed by schema + script rule. Instead of decoding the gate from the
-//    enhancer's prose, the script computes it by rule from (build, tests, issues), so the
-//    re-spawn / fail-close machinery itself becomes unneeded.
-// 3. worktree.py / bootstrap.py are deterministic scripts, so agents run them as-is.
-//    The session id resolves via the agent environment's $CLAUDE_SESSION_ID, so setup and
-//    cleanup derive the same branch / path from the same id and never drift.
-// 4. adversarial (codex 600s) starts with Evidence and runs behind Challenge / Triage
-//    (putting it in a barrier would let the longest stage block everything).
-//
-// When OUTCOME.md is absent, do NOT generate a stub via /outcome. assert is verification and
-// has no write side-effects on the target repo. Record the absence in the report and move on.
+// 1. The static reviewer fan-out is the nested workflow("audit"), so its routing table is not
+//    duplicated. Its findings already passed critic-audit / critic-evidence there, so assert's
+//    Challenge applies to Codex findings only.
+// 2. The gate is computed by schema + script rule from (build, tests, issues), never decoded
+//    from the enhancer's prose.
+// 3. worktree.py / bootstrap.py are deterministic; setup and cleanup derive the same branch /
+//    path from $CLAUDE_SESSION_ID.
+// 4. adversarial (codex 600s) starts with Evidence and runs behind Challenge / Triage; in a
+//    barrier the longest stage would block everything.
+// When OUTCOME.md is absent, no stub is generated: assert has no write side-effects on the
+// target repo. The absence goes in the report.
 
 const parseArgs = () => {
   if (typeof args === "object" && args) return args;
@@ -59,10 +54,8 @@ if (!repo) {
 const anchor = (p) =>
   `Run every git / file / build command from the ${repo} repository (start each shell command with \`cd ${repo} && \`).\n\n${p}`;
 
-// Plugin-aware asset resolution. When this script ships as a plugin, bundled assets
-// live under ~/.claude/plugins instead of ~/.claude; the shell fragment tries the
-// dev-tree path first, so the dev tree keeps working unchanged. The -e test admits a
-// directory, which the SCRIPTS constant below needs.
+// As a plugin, bundled assets live under ~/.claude/plugins; the shell fragment tries the
+// dev-tree path first. The -e test admits a directory, which SCRIPTS below needs.
 const bundled = (rel) =>
   `"$(P="$HOME/.claude/${rel}"; [ -e "$P" ] || P="$(find "$HOME/.claude/plugins" -path "*/${rel}" -not -path "*/.ja/*" 2>/dev/null | sort -V | tail -1)"; printf %s "$P")"`;
 // Scripts bundled with this workflow. The loader only reads .js directly under workflows/,
@@ -72,10 +65,10 @@ const SCRIPTS = bundled("workflows/assert");
 // instead of judging TBD markers by eye.
 const OUTCOME_VALIDATOR = bundled("skills/outcome/scripts/validate-outcome.py");
 
-// Inline the two rules of merge-findings.py in JS. P1 -> high, P2 -> medium, P3 -> dropped.
-// critical / high / medium / low pass through. Unrecognized severities cannot be ranked,
-// so they are dropped. The dedup key is file:line only (category schemas differ per
-// source). On collision, keep the higher severity and union the sources.
+// merge-findings.py's two rules, inlined. P1 -> high, P2 -> medium, P3 -> dropped; critical /
+// high / medium / low pass through; an unrecognized severity is dropped. Dedup key is file:line
+// only, since category schemas differ per source; on collision keep the higher severity and
+// union the sources.
 const SEVERITY_MAP = {
   P1: "high",
   P2: "medium",
@@ -290,10 +283,9 @@ if (boot.mode === "none") {
   return { stopped: "no-changes", why: boot.reason || "Nothing to assert." };
 }
 
-// Distinguish env fail (worktree impossible / install fail) from build smoke fail (the
-// target itself does not build). Among dynamic-evidence gaps, only env fail may demote to
-// caveat. Demoting a build smoke fail would produce a false Ready that lets a broken build
-// reach merge.
+// env fail (worktree impossible / install fail) is kept apart from build smoke fail (the target
+// does not build): only env fail may demote to caveat, or a broken build would reach merge as
+// Ready.
 const envFail = !boot.worktree_ok || boot.install === "fail";
 const buildCol = envFail ? "skipped" : boot.build;
 const dynamicOk = !envFail && buildCol !== "fail";

--- a/workflows/audit.js
+++ b/workflows/audit.js
@@ -15,14 +15,11 @@ export const meta = {
   ],
 };
 
-// Routing lives in the script, not an agent: an agent re-deriving the glob
-// table would reintroduce the exact drift this workflow exists to remove.
-// Reviewers run on sonnet because opus + deep analysis stalls the stream
-// watchdog.
+// Routing lives in the script: an agent re-deriving the glob table would reintroduce the drift
+// this workflow exists to remove. Reviewers run on sonnet; opus stalls the stream watchdog.
 
-// args may arrive as an object or, if a caller stringifies it, as a JSON-encoded
-// string. Normalize once: a string that parses to an object is that object; any
-// other string is the scope shorthand.
+// args arrives as an object or, stringified by a caller, as JSON. A string that parses to an
+// object is that object; any other string is the scope shorthand.
 const parseArgs = () => {
   if (typeof args === "object" && args) return args;
   if (typeof args !== "string") return {};
@@ -54,23 +51,15 @@ const noLimit = opts.noLimit === true;
 const skipPreflight = opts.skipPreflight === true;
 const anchor = (p) =>
   `Run every git command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`;
-// A finding's summary is LLM free text folded verbatim into the next stage's prompt,
-// so an injected directive hiding in it must not read as an instruction. This is why
-// fenced differs from build.js's fencedBody: a fixed marker can be closed early by a
-// payload string equal to it, since JSON.stringify does not escape hyphens. No random
-// source exists in the sandbox, and one would change value across a resume even if it did.
-// The base's contents carry no meaning. It only has to be unlikely in a payload. Both the
-// base and the padding go into the regex below, so pick them from characters that carry
-// no regex meaning.
+// A finding's summary is LLM free text folded verbatim into the next stage's prompt, so the
+// fence marker must not be closable by a payload string equal to it. With no random source in
+// the sandbox, the marker is FENCE_BASE padded one longer than the longest run in the payload;
+// both go into the regex below, so neither holds a regex metacharacter.
 const FENCE_BASE = "e5f9a2";
 const FENCE_PAD = "0";
 const FENCE_RUNS = new RegExp(`${FENCE_BASE}${FENCE_PAD}*`, "g");
-// Growing the marker one character at a time re-scans the payload on every step, and
-// the payload is exactly where an attacker writes: seeding `base`, `base0`, `base00`, ...
-// makes the step count rise with the payload's own length. A marker padded one longer
-// than the longest run cannot occur, because a longer run would have been the longest,
-// so predicting the marker does not let an attacker close the fence early either.
-// longest starts at -1 so a payload that never collides needs no branch of its own.
+// One scan for the longest run keeps the cost linear; growing the marker one character at a
+// time would let a payload seeded `base`, `base0`, `base00`, ... raise the step count.
 const fenceMarker = (value) => {
   let longest = -1;
   for (const [hit] of value.matchAll(FENCE_RUNS)) {
@@ -85,23 +74,16 @@ const fenced = (value) => {
     `----- BEGIN UNTRUSTED FINDINGS ${marker} -----\n${value}\n----- END UNTRUSTED FINDINGS ${marker} -----`
   );
 };
-// Plugin-aware asset resolution. When this script ships as a plugin, bundled assets
-// live under ~/.claude/plugins instead of ~/.claude; the shell fragment tries the
-// dev-tree path first, so the dev tree keeps working unchanged.
+// As a plugin, bundled assets live under ~/.claude/plugins; the shell fragment tries the
+// dev-tree path first.
 const bundled = (rel) =>
   `"$(P="$HOME/.claude/${rel}"; [ -e "$P" ] || P="$(find "$HOME/.claude/plugins" -path "*/${rel}" -not -path "*/.ja/*" 2>/dev/null | sort -V | tail -1)"; printf %s "$P")"`;
 
-// audit/snapshot.py resolves the timestamp and branch. The agent only writes the
-// payload to a temp file and runs the script once; the disk side-effect is the
-// goal, its result is not consumed.
-// snapshot.py's build_record turns the payload keys into the record's fields verbatim.
-// Anything that lives only on the return value cannot be read back from the record, so
-// whatever a reader must find there has to be passed here.
-//
-// The payload only reaches the agent embedded in a prompt, and summarizing while
-// transcribing leaves the record alone thinned out. Having the agent report the counts
-// would make the party that cut them the one reporting on it, so they come from
-// snapshot.py, which counted the stdin it received.
+// audit/snapshot.py resolves the timestamp and branch; the agent only writes the payload to a
+// temp file and runs it once, for the disk side-effect. build_record turns the payload keys
+// into the record's fields verbatim, so whatever a reader must find in the record is passed here.
+// The counts come from snapshot.py, which counted the stdin it received: an agent transcribing
+// the payload through a prompt can thin it, and must not be the one reporting on the cut.
 const SNAPSHOT_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -201,10 +183,9 @@ const writeSnapshot = async ({
   return { written: true, path: written.path, truncated: lost.length > 0, lost, expected, actual };
 };
 
-// /audit routing table. react-pattern only attaches to JSX files (jsx / tsx), so a
-// pure-js audit does not fire it on empty. Heuristic: React written without JSX
-// loses react-pattern. A file takes the first matching row via classify(). Mechanical
-// type checks (any / assertions / strict mode) belong to the gates linters, not a reviewer.
+// /audit routing table. A file takes the first matching row via classify(). react-pattern
+// attaches to jsx / tsx only, so React written without JSX loses it. Mechanical type checks
+// (any / assertions / strict mode) belong to the gates linters, not a reviewer.
 const ROUTING = {
   "*.sh": ["security", "silence", "duplication", "reuse", "efficiency", "operations", "resilience"],
   "*.js": [
@@ -335,10 +316,9 @@ const classify = (p) => {
   if (e === ".css" || e === ".html") return ROUTING["*.css,*.html"];
   return ROUTING.default;
 };
-// Only Integrate returns source_ids. Kept optional on the shared schema, an Integrate run
-// that omits it still passes validation and R-N tracking breaks per run. The reviewer
-// variant lacks the property entirely, so additionalProperties: false rejects a reviewer
-// that invents ids.
+// Only Integrate returns source_ids. Optional on the shared schema, an Integrate run omitting it
+// would pass validation and break R-N tracking; the reviewer variant lacks the property, so
+// additionalProperties: false rejects a reviewer that invents ids.
 const findingsSchema = ({ withSourceIds = false } = {}) => ({
   type: "object",
   additionalProperties: false,
@@ -465,10 +445,8 @@ const SCOPE_STATUS_SCHEMA = {
 };
 
 // ---- Scope resolution ----
-// git takes a revision and a path in the same position, so passing a path collapses into
-// the uncommitted changes under it. This script owns the branch table and the command it
-// builds, leaving the agent stage nothing but the git call. Moving that judgment into the
-// prompt undoes the reason the header comment gives for keeping routing in the script.
+// git takes a revision and a path in the same position, so a path collapses into the uncommitted
+// changes under it. The script owns the branch table and the command; the agent only runs git.
 const base = typeof opts.base === "string" && opts.base.trim() ? opts.base.trim() : "main";
 // rev-parse returns 40-hex SHA lines alone once it resolves a revision, with a leading ^ on
 // the excluded side of a range. A path comes back verbatim.
@@ -673,9 +651,8 @@ const raw = await parallel(
 const findings = raw.filter(Boolean).flatMap((r) => r.findings || []);
 // Pinned rather than derived from severity (agents/_lib/finding-disposition.md § Disposition):
 // assert's gate ignores severity, so a derived default would put nits on a blocking finding.
-// Derived from the schema, not hand-listed: a field the schema admits but this copy forgets is
-// silently dropped, which is the gap #425 closed. file / line / severity / summary are renamed on
-// the way in and disposition goes through dispositionOf, so those six are excluded.
+// Derived from the schema so a field this copy forgets is not silently dropped; file / line /
+// severity / summary are renamed on the way in and disposition goes through dispositionOf.
 const MAPPED_FIELDS = new Set([
   "file",
   "line",
@@ -764,9 +741,8 @@ if (!findings.length) {
 // Two independent passes over the same findings run concurrently. Only Challenge's
 // verdicts decide membership; Verify's evidence never reaches Integrate.
 const findingsJson = JSON.stringify(findings);
-// Mirrors workflows/polish.js's VERDICTS_SCHEMA shape (id/verdict/severity/why); the
-// severity enum tracks this file's own FINDINGS_SCHEMA (critical/high/medium/low) rather
-// than polish's P1/P2/P3, since the two workflows score severity on different scales.
+// Same shape as polish.js's VERDICTS_SCHEMA (id/verdict/severity/why), but the severity enum
+// follows this file's FINDINGS_SCHEMA; polish scores severity as P1/P2/P3.
 const VERDICTS_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -802,9 +778,8 @@ const toCriticRef = (f) => ({
   severity: f.severity,
   summary: f.message,
 });
-// The critic's input is rawFindings (the source of the R-N ids triage keys off of) with
-// the reviewer field left out, so the challenge verdict cannot be biased by which
-// reviewer raised the finding.
+// The critic gets rawFindings (the source of the R-N ids triage keys off) without the reviewer
+// field, so the verdict cannot be biased by which reviewer raised the finding.
 const challengeInput = rawFindings.map(toCriticRef);
 const [challenged, verified] = await parallel([
   () =>
@@ -842,10 +817,9 @@ const [challenged, verified] = await parallel([
 ]);
 
 // ---- Triage: script owns survivor determination, the critic only returns verdicts ----
-// Loop the finding side, not the verdict side. A finding the challenge agent dropped a
-// verdict for is not silently lost; it defaults to confirmed and lands in no_verdict.
-// A run where challenge failed entirely takes the same path, so the degradation survives
-// as a count.
+// Loop the finding side, not the verdict side: a finding the critic gave no verdict defaults to
+// confirmed and lands in no_verdict, and a run where challenge failed entirely takes the same
+// path, so the degradation survives as a count.
 const verdictById = new Map(((challenged && challenged.verdicts) || []).map((v) => [v.id, v]));
 const survivors = [];
 const needsContext = [];
@@ -890,14 +864,12 @@ const info = {
   disputed: { count: disputedIds.length, ids: disputedIds },
   downgraded: { count: downgradedIds.length, ids: downgradedIds },
 };
-// challenge_ran separates a run that returned verdicts from the fail-open path (an empty
-// verdictById drops every finding to confirmed via no_verdict). verify returns free-form
-// text, so it is judged by whether content came back rather than by a schema shape.
+// challenge_ran separates a run that returned verdicts from the fail-open path, where every
+// finding drops to confirmed via no_verdict. verify returns free-form text, so it is judged by
+// whether content came back.
 const challengeRan = !!(challenged && Array.isArray(challenged.verdicts));
-// Names the degraded side, as assert.js's challengeStalled does. challengeRan alone would
-// count an empty verdicts array as having run (its own definition stays out of scope here),
-// but no verdict was actually rendered for that run, so this adds a length check
-// challengeRan does not have.
+// challengeRan counts an empty verdicts array as having run, so the degradation flag adds the
+// length check.
 const challengeDegraded = !challengeRan || challenged.verdicts.length === 0;
 const verifyRan = !!String(verified || "").trim();
 const tally = {
@@ -933,9 +905,9 @@ const integrated = await agent(
 // Falling back to the pre-triage findings array would land on the state before ids were
 // assigned, silently readmitting findings the challenge pass had disputed.
 const integratedFindings = (integrated && integrated.findings) || survivorsInput;
-// toCriticRef strips disposition before Integrate sees a finding, so what Integrate returns is
-// not sourced from the survivors and is not trusted. The rank derives from
-// DECLARABLE_DISPOSITIONS rather than restating the order agents/_lib/finding-schema.md owns.
+// toCriticRef strips disposition before Integrate sees a finding, so Integrate's value is not
+// trusted. The rank derives from DECLARABLE_DISPOSITIONS rather than restating
+// agents/_lib/finding-schema.md's order.
 const DISPOSITION_RANK = Object.fromEntries(
   [...DECLARABLE_DISPOSITIONS].map((d, i) => [d, DECLARABLE_DISPOSITIONS.size - i]),
 );
@@ -946,12 +918,9 @@ const consolidatedDisposition = (sourceIds) =>
     if (!d) return strongest;
     return !strongest || DISPOSITION_RANK[d] > DISPOSITION_RANK[strongest] ? d : strongest;
   }, null) || DEFAULT_DISPOSITION;
-// Sort mirrors workflows/assert.js's mergeIssues: SEVERITY_RANK descending, then file
-// ascending (localeCompare), then line ascending. Applied once here so the return value's
-// findings and the snapshot's findings (below) share the identical order.
-// Not SEVERITY_RANK[severity] on its own: a missing entry makes the subtraction NaN, and
-// `NaN || next` falls through to the file compare, so an unranked finding sorts by filename
-// among the ranked ones instead of after them.
+// Sorted once here so the return value and the snapshot share the order assert.js's mergeIssues
+// uses: SEVERITY_RANK descending, then file, then line. `?? 0` puts an unranked severity last;
+// a bare lookup would make the subtraction NaN and fall through to the file compare.
 const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1 };
 const severityRank = (f) => SEVERITY_RANK[f.severity] ?? 0;
 const finalFindings = integratedFindings

--- a/workflows/build.js
+++ b/workflows/build.js
@@ -15,10 +15,8 @@ export const meta = {
   ],
 };
 
-// build does not re-plan a human ## Plan section. A plan-less issue stops
-// and is handed back for refinement. Extraction is left to the
-// LLM; verification belongs to the script. Fan-out stages are delegated to a nested
-// workflow (code).
+// build never re-plans a human ## Plan section; a plan-less issue stops as no-plan. Extraction
+// is the LLM's, verification the script's, and fan-out stages the nested code workflow's.
 
 phase("Load");
 
@@ -45,9 +43,8 @@ const issueRef = String(typeof argsValue === "string" ? argsValue : input.issue 
 const issueNumber =
   (issueRef.match(/^#?(\d+)$/) || issueRef.match(/\/issues\/(\d+)(?:[/?#]|$)/) || [])[1] || "";
 // ---- Run recording: one jsonl row per build run ----
-// PLAN_QUALITY says whether the issue's ## Plan section could have prevented the stop. Counting
-// the true ones decides whether /qualify becomes mandatory ahead of build (DR-0084's
-// reassessment trigger), which a stopped return value reaching no file could never answer.
+// PLAN_QUALITY marks a stop the issue's ## Plan section could have prevented. Its count decides
+// whether /qualify becomes mandatory ahead of build (DR-0084's reassessment trigger).
 const PLAN_QUALITY = {
   "no-issue": false,
   "no-repo": false,
@@ -64,9 +61,8 @@ const PLAN_QUALITY = {
   "plan-drift": true,
   "code-failed": false,
 };
-// The window-tally keys record.py's stdout carries alongside path/run_id (its own docstring).
-// Naming each key's type here once and deriving RECORD_SCHEMA's matching properties below
-// keeps the two from drifting apart when a key is added, renamed, or retyped.
+// The window-tally keys record.py prints beside path/run_id. RECORD_SCHEMA derives its matching
+// properties from this map, so a key added, renamed, or retyped changes in one place.
 const RECORD_COUNT_TYPES = {
   started: "number",
   stops: "number",
@@ -158,10 +154,9 @@ if (!issueRef || !issueNumber) {
   });
 }
 
-// Without repo, agents resolve "the repository" from their own cwd and can run
-// steps in the wrong checkout. anchor pins every step to the target repository;
-// guard makes the agent confirm the repo root before the hard-to-reverse git
-// mutations (branch / commit / push / PR).
+// Without repo, an agent resolves "the repository" from its own cwd. anchor pins every step to
+// the target repository, and guard makes the agent confirm the repo root before branch /
+// commit / push / PR.
 const repo = typeof input.repo === "string" ? input.repo : "";
 // base serves the flow that aggregates slice PRs into an epic branch, used both
 // as the starting point of a fresh checkout and as the PR base.
@@ -182,11 +177,9 @@ if (baseBranch && !BRANCH_NAME_SHAPE.test(baseBranch)) {
 const anchor = (p) =>
   `Run every git, file, and build command from the repository at ${repo} (begin each shell command with \`cd ${repo} && \`).\n\n${p}`;
 const guard = ` Before the first commit / push / branch change in this step, run \`cd ${repo} && git rev-parse --show-toplevel\` and confirm the output is ${repo}. If it differs, abort without mutating git and report the mismatch.`;
-// As a plugin, sibling resolves the build: namespace and bundled resolves
-// ~/.claude/plugins. Both try the bare dev-tree form first, so the dev tree keeps working.
-// Falling back on anything but an unresolved name discards the nested workflow's own failure
-// and leaves the fallback's name-resolution error as the only one left. A nested failure
-// carries the child's stack in its message, so match on the name, not on the wording.
+// As a plugin, sibling resolves the build: namespace and bundled ~/.claude/plugins; both try the
+// dev-tree form first. The fallback runs only on an unresolved name, matched by the name rather
+// than the wording, so a nested workflow's own failure is not replaced by a resolution error.
 const sibling = async (name, a) => {
   try {
     return await workflow(name, a);
@@ -229,9 +222,8 @@ recordable = true;
 await recordRun("started");
 
 // ---- Load: verbatim fetch -> Plan heading check -> deterministic id collection -> extract -> validate + cross-check ----
-// The extracted number, never the reference as given: a URL matches as long as /issues/N
-// appears anywhere in it, so passing it through would carry whatever follows into the shell.
-// gh resolves a bare number against the repository anchor already runs in.
+// The extracted number goes to gh, never the reference as given: a URL matches on /issues/N
+// anywhere in it, so passing it through would carry whatever follows into the shell.
 const fetched = await agent(
   anchor(
     `Run exactly \`gh issue view ${issueNumber} --json title,body\` and return its title field as title and its body field as body, both verbatim; ` +
@@ -253,11 +245,9 @@ if (!fetched || !fetched.found || !String(fetched.body || "").trim()) {
 }
 const body = fetched.body;
 
-// What the schema layer cannot express: an empty tests array is legal (code implements that
-// unit directly), but the checks below are about how the units relate to each other. The seam rule exists because per-unit tests
-// stub their own boundaries, so a plan whose units are each green can still ship
-// layers that were never connected to each other. Once two units carry tests there
-// is a seam between them, and only a test crossing it fails when the wiring is absent.
+// Checks on how the units relate to each other, which the schema layer cannot express. Per-unit
+// tests stub their own boundaries, so a plan whose units are each green can still ship layers
+// never connected; once two units carry tests, only a test crossing their seam catches that.
 const validate = (plan, isBug) => {
   const errors = [];
   // A Bug plan that skips root_cause tends to code around the symptom instead of the cause.
@@ -279,11 +269,9 @@ const validate = (plan, isBug) => {
 
   // reference_module carries either an existing module to replicate or the reason for
   // not replicating one. Neither a bare null nor an absent field can carry that reason,
-  // so both are blockers;
-  // extract is expected to turn the existing `null (理由)` prose format into a kind-tagged
-  // object instead of leaving it null. The field stays out of the schema's
-  // required list: when extract drops the key, that would stop as extraction-failed,
-  // which carries no blockers text to rewrite the plan from.
+  // so both are blockers. The field stays out of the schema's required list: when extract
+  // drops the key, that would stop as extraction-failed, which carries no blockers text to
+  // rewrite the plan from.
   const refModule = plan.reference_module;
   if (refModule === undefined) {
     errors.push(
@@ -295,10 +283,10 @@ const validate = (plan, isBug) => {
       "reference_module is null with no reason. Record it as an object " +
         "{ kind, reason } (kind: module/no-module/new-shape) instead of a bare null",
     );
-  } else if (refModule && typeof refModule === "object" && "kind" in refModule) {
-    // A legacy object with no kind field (bare path/files) goes unchecked for
-    // backward compatibility.
-    if (refModule.kind === "module") {
+  } else if (typeof refModule === "object") {
+    if (!String(refModule.kind || "").trim()) {
+      errors.push("reference_module.kind is missing (module/no-module/new-shape)");
+    } else if (refModule.kind === "module") {
       if (!String(refModule.path || "").trim())
         errors.push("reference_module.path is empty while kind is module");
     } else if (!String(refModule.reason || "").trim()) {
@@ -459,12 +447,10 @@ const PLAN_SCHEMA = obj(
   },
 );
 
-// Coupled with /think Phase 3's unit-size guidance; do not change one side without
-// the other. A seam unit's tests cross the boundary between units, so its files
-// count legitimately grows. Only non-seam units are checked.
-// The canonical. skills/think/SKILL.md restates these in prose and unit-caps-ssot.test.js
-// fails on drift; a third copy in .agents/skills/build/scripts/validate-plan.ts is out of reach
-// of any test here and has to be changed by hand.
+// Coupled with /think Phase 3's unit-size guidance; change both sides together. A seam unit's
+// tests cross unit boundaries, so only non-seam units are checked.
+// Canonical here. skills/think/SKILL.md restates these and unit-caps-ssot.test.js fails on drift;
+// .agents/skills/build/scripts/validate-plan.ts is out of any test's reach and is changed by hand.
 const UNIT_CAPS = { files: 3, tests: 4 };
 const oversizedUnits = (p) =>
   p.units.filter((u) => {
@@ -474,9 +460,8 @@ const oversizedUnits = (p) =>
     return fileCount > UNIT_CAPS.files || testCount > UNIT_CAPS.tests;
   });
 
-// Implement only verified selections. A plan-less issue has nothing to implement
-// against, so build hands it back for refinement instead of drafting a plan in its
-// place.
+// A plan-less issue has nothing to implement against, so build hands it back instead of
+// drafting a plan in its place.
 const planHeading = body.match(/^##\s+Plan\b.*$/m);
 if (!planHeading) {
   return await stop("no-plan", {
@@ -489,9 +474,9 @@ if (!planHeading) {
 const afterHeading = body.slice(planHeading.index + planHeading[0].length);
 const nextSection = afterHeading.search(/^##[^#]/m);
 const planSection = nextSection === -1 ? afterHeading : afterHeading.slice(0, nextSection);
-// Match ids at their definition position only, not prose references (see think templates/plan.md).
-// A test id's prefix is optional. Where a repo's convention writes prefixed ids in test
-// docs (`[T-SK077]`), a plan restricted to bare ids leaves the rename to implementation time.
+// Ids match at their definition position only, not prose references (think templates/plan.md).
+// A test id's prefix is optional: a repo whose test docs write `[T-SK077]` would otherwise be
+// left renaming at implementation time.
 const idSet = (re) => new Set([...planSection.matchAll(re)].map((m) => m[1]));
 const bodyUnitIds = idSet(/^###\s+(U-\d{3})\b/gm);
 const bodyTestIds = idSet(/^[ \t]*[-*+][ \t]+(T-[A-Z]*\d{3})\b/gm);
@@ -503,7 +488,7 @@ const plan = await agent(
       `preconditions is the list of {path, pattern} of existing code the plan presupposes; backlog_candidates are out-of-scope candidates written in the issue. Empty arrays if absent from the body.\n` +
       `rules holds the ### Rules (### 決まりごと) section as {source, quote} pairs, where source is the document path on the line and quote is the text after the colon, verbatim. Empty array when the section is absent.\n` +
       `seam is true only for a unit the body marks \`seam: true\`; every other unit is false. Do not infer it from the unit's content.\n` +
-      `reference_module: the body writes it as an object \`{kind, reason}\` (kind: module/no-module/new-shape), with path/files/instances/conventions added only when kind is module. Copy kind and reason verbatim, and path/files/instances/conventions too when kind is module. A legacy body may still write it as \`null (reason)\` prose instead; turn that into the same object shape rather than leaving it a bare null. Emit a bare null only when the body's reference_module carries no reason at all. Omit the field when the body has no reference_module line.\n` +
+      `reference_module: the body writes it as an object \`{kind, reason}\` (kind: module/no-module/new-shape), with path/files/instances/conventions added only when kind is module. Copy kind and reason verbatim, and path/files/instances/conventions too when kind is module. Emit a bare null only when the body's reference_module carries no reason at all. Omit the field when the body has no reference_module line.\n` +
       `root_cause: copy verbatim if the body states one (e.g. a Root Cause / 原因 line). Omit the field if the body states none.\n\n${fencedBody}`,
   ),
   {
@@ -519,52 +504,33 @@ if (!plan) {
   return await stop("extraction-failed", { why: "The extract agent returned no plan." });
 }
 
-// Deterministic fallback for reference_module.kind/reason: the extract prompt above still
-// trails skills/think, which now writes the object form per DR-0093, so an extraction that has
-// not caught up can still drop kind or reason a body states plainly. Recovers them the same way
-// bodyUnitIds/bodyTestIds above recover ids: a line-anchored regex scoped to planSection, not
-// the whole fencedBody, so a template quotation used as prose elsewhere is never counted as a
-// hit. Fills only when planSection carries exactly one reference_module line, and only
-// kind/reason - it never fabricates path.
-// Both quoted and bare: `/think` writes the line as `{ kind: no-module, reason: ... }` with no
-// quotes, so a quoted-only pattern fills nothing on the very bodies this fallback exists for.
-// reason runs to the closing brace because it carries prose, commas and all.
+// The extract agent can drop kind or reason the body states, so the one reference_module line
+// inside planSection overrides both; a template quotation elsewhere in the body is not a hit,
+// and path is never fabricated. /think writes the line unquoted, so both forms match, and reason
+// runs to the closing brace because it carries commas.
 const REFERENCE_MODULE_KIND_RE = /kind:\s*"?([A-Za-z][\w-]*)"?/;
 const REFERENCE_MODULE_REASON_RE = /reason:\s*"?([\s\S]*?)"?\s*\}?\s*$/;
 const REFERENCE_MODULE_LINE_RE = /^reference_module:[ \t]*(.+)$/gm;
 const refModuleLines = [...planSection.matchAll(REFERENCE_MODULE_LINE_RE)];
 if (refModuleLines.length === 1) {
   const refModuleLine = refModuleLines[0][1].trim();
-  const kindMatch = refModuleLine.match(REFERENCE_MODULE_KIND_RE);
-  const reasonMatch = refModuleLine.match(REFERENCE_MODULE_REASON_RE);
-  // Legacy compat (DR-0093): the pre-split body writes `null (reason)` prose with no kind at
-  // all; "no-module" is the closest reading of a plan that only ever recorded a reason.
-  const legacyMatch = kindMatch ? null : refModuleLine.match(/^null\s*\(([\s\S]*)\)$/);
-  const filledKind = kindMatch ? kindMatch[1] : legacyMatch ? "no-module" : undefined;
-  const filledReason = reasonMatch ? reasonMatch[1] : legacyMatch ? legacyMatch[1] : undefined;
-  if (filledKind !== undefined || filledReason !== undefined) {
-    const existingRefModule =
-      plan.reference_module &&
-      typeof plan.reference_module === "object" &&
-      !Array.isArray(plan.reference_module)
+  const kind = refModuleLine.match(REFERENCE_MODULE_KIND_RE)?.[1];
+  const reason = refModuleLine.match(REFERENCE_MODULE_REASON_RE)?.[1];
+  if (kind !== undefined || reason !== undefined) {
+    const extracted =
+      plan.reference_module && typeof plan.reference_module === "object" && !Array.isArray(plan.reference_module)
         ? plan.reference_module
         : {};
-    const hasKind = typeof existingRefModule.kind === "string" && existingRefModule.kind.trim();
-    const hasReason =
-      typeof existingRefModule.reason === "string" && existingRefModule.reason.trim();
-    if (!hasKind || !hasReason) {
-      plan.reference_module = {
-        ...existingRefModule,
-        ...(!hasKind && filledKind !== undefined ? { kind: filledKind } : {}),
-        ...(!hasReason && filledReason !== undefined ? { reason: filledReason } : {}),
-      };
-    }
+    plan.reference_module = {
+      ...extracted,
+      ...(kind !== undefined ? { kind } : {}),
+      ...(reason !== undefined ? { reason } : {}),
+    };
   }
 }
 
-// A Bug issue carries a `[Bug]` prefix in its title. fetch omits title when it could not read
-// one, so classification then stays undecidable and startsWith on the empty fallback reads as
-// not-a-Bug rather than guessing either way.
+// A Bug issue carries a `[Bug]` title prefix. fetch omits title when it could not read one, and
+// the empty fallback then reads as not-a-Bug rather than a guess either way.
 const blockers = validate(plan, String(fetched.title || "").startsWith("[Bug]"));
 if (blockers.length) {
   return await stop("invalid-plan", {
@@ -610,9 +576,8 @@ const relayVerifier = ({ what, script, payload, count }) =>
   `(3) return the verifier's stdout "results" array verbatim, all ${count} entries; add, drop, or edit none.\n` +
   `The input JSON is as follows.\n${JSON.stringify(payload)}`;
 
-// A relay that hands the payload over as one argv element and brings stdout back verbatim. The
-// agent never reads the JSON; relayedJson interprets it on the script side. A broken relay is
-// null, not an empty result.
+// The relay hands the payload over as one argv element and brings stdout back verbatim;
+// relayedJson interprets it on the script side. A broken relay is null, not an empty result.
 const STDOUT_RELAY_SCHEMA = obj(["stdout"], {
   stdout: { type: "string", description: "the command's stdout, verbatim" },
 });
@@ -643,18 +608,14 @@ const REVALIDATE_SCHEMA = obj(["results"], {
 });
 
 // ---- Revalidate: re-verify preconditions against the current codebase ----
-// Catches, fail-closed, presupposed code that moved since issue filing. Runs in
-// parallel with Branch (both depend only on plan). On drift the created branch is
-// surfaced in the stopped return.
+// Fail-closed on presupposed code that moved since issue filing. Runs in parallel with Branch,
+// and on drift the created branch rides the stopped return.
 phase("Revalidate");
 const preconditions = plan.preconditions || [];
-// reference_module names existing code the plan presupposes just as much as
-// preconditions does; fold its path and files into the same {path} shape revalidate.py
-// accepts, so a moved-or-deleted reference module surfaces as drift too. kind is not
-// consulted: a no-module plan can still cite a shape's path, so any path is checked.
-// Unlike preconditions, a dropped reference_module result stays fail-open (no
-// unreported-retry / revalidate-incomplete): it documents structure for later units
-// rather than gating the build the way a precondition does.
+// reference_module's path and files fold into the same {path} shape as preconditions, so a moved
+// reference module surfaces as drift too; kind is not consulted, since a no-module plan can still
+// cite a path. Unlike preconditions its dropped result stays fail-open: it documents structure
+// for later units rather than gating the build.
 const refModule = plan.reference_module;
 const refModuleEntries =
   refModule && typeof refModule === "object" && String(refModule.path || "").trim()
@@ -665,9 +626,8 @@ const refModuleEntries =
 // Sent as one relay payload so resultByKey below binds both from a single relay call;
 // preconditions alone still drives the unreported-retry / revalidate-incomplete gate.
 const revalidationTargets = [...preconditions, ...refModuleEntries];
-// Code commits per unit, so HEAD stops being the branch point mid-run and every
-// downstream `git diff HEAD` comes back empty - a silent pass, not a visible failure.
-// Hold the base as the branch point's sha.
+// Code commits per unit, so HEAD stops being the branch point mid-run and `git diff HEAD` would
+// come back empty. The base is held as the branch point's sha.
 const BRANCH_SCHEMA = obj(["branch", "head", "ahead_of_base"], {
   branch: { type: "string", description: "the checked-out branch name, nothing else" },
   head: {
@@ -758,10 +718,9 @@ const perUnitCommits = /^[0-9a-f]{7,40}$/.test(startPoint);
 const diffBase = perUnitCommits ? startPoint : "HEAD";
 if (!perUnitCommits)
   log("Branch point sha unavailable; committing once at Ship and diffing against HEAD.");
-// For a base-anchored call, a branch point ahead of base means that delta is not this
-// build's work. Stacking onto a discarded or previous-task branch makes Verify and the
-// PR treat it as this run's output. It shows up in neither scope deviations nor
-// conformance, so stop here.
+// Under a base anchor, a branch point ahead of base is not this build's work; stacking onto a
+// previous branch would make Verify and the PR treat it as this run's output, unseen by scope
+// deviations and conformance alike.
 if (baseBranch && Number(branchRes && branchRes.ahead_of_base) > 0) {
   return await stop("dirty-branch-point", {
     branch,
@@ -901,8 +860,8 @@ log(
 );
 
 // ---- Cleanup: simplify skill + test validation ----
-// The review lens does not belong to build; /polish is human-invoked on
-// the PR. Cleanup runs before Verify so the verified tree is the shipped tree.
+// Runs before Verify so the verified tree is the shipped tree. The review lens is /polish's,
+// human-invoked on the PR.
 const CLEANUP_SCHEMA = obj(["edits", "tests_pass", "stashed"], {
   edits: {
     type: "array",
@@ -933,10 +892,9 @@ const cleanup = (await agent(
 log(`Cleanup: ${cleanup.edits.length} edit(s), tests_pass=${cleanup.tests_pass}.`);
 
 // ---- Verify: deterministic selection checks (diff scope + T-NNN presence) ∥ conformance ----
-// Correctness checking compares against the plan's anchors, not a defect hunt.
-// Static analysis belongs to the edit-time gates hooks; heavy assurance
-// is human-invoked /audit on the PR. Both checks fail open and surface on the PR.
-// conformance is the only LLM review; its findings go to a dedicated PR section.
+// Compares against the plan's anchors, not a defect hunt: static analysis is the gates hooks',
+// heavy assurance the human-invoked /audit's. Both checks fail open and surface on the PR;
+// conformance is the only LLM review and gets its own PR section.
 
 const TEST_PRESENCE_SCHEMA = obj(["results"], {
   results: {
@@ -948,9 +906,8 @@ const TEST_PRESENCE_SCHEMA = obj(["results"], {
   },
 });
 
-// Structural drift from the plan's reference module. Conformance answers "does it do what
-// the spec asked"; this answers "is it shaped like its neighbors". A contract cites one
-// behavior, so the structure around it can be hand-rolled without any anchor catching it.
+// Structural drift from the plan's reference module: conformance asks "does it do what the spec
+// asked", this asks "is it shaped like its neighbors", which no behavior contract catches.
 const STRUCTURE_SCHEMA = obj(["reference_checked", "findings"], {
   reference_checked: {
     type: "boolean",
@@ -1104,17 +1061,14 @@ const [diff, testPresence, conformance, structure] = await parallel([
 const planFiles = new Set(plan.units.flatMap((u) => u.files));
 // A directory can arrive as a single "dir/" line, from porcelain and from a diff agent that
 // ignored --untracked-files=all alike, so a line ending in "/" stands for everything under it.
-const dirCovers = (line, path) => line.endsWith("/") && path.startsWith(line);
-// A baseline entry is read as a directory even without the trailing slash: it comes from a
-// listing that may collapse one, and treating it as a file alone would let its contents back
-// into the scope deviations.
-const preexisting = (f) =>
-  baselineUntracked.some((b) => b && (f === b || f.startsWith(b.endsWith("/") ? b : `${b}/`)));
+const under = (dir, path) => path.startsWith(dir.endsWith("/") ? dir : `${dir}/`);
+const dirCovers = (line, path) => line.endsWith("/") && under(line, path);
+// A baseline entry is read as a directory even without the trailing slash, which the listing may
+// collapse; read as a file, its contents would count as scope deviations.
+const preexisting = (f) => baselineUntracked.some((b) => b && (f === b || under(b, f)));
 const coveredByPlan = (f) => planFiles.has(f) || [...planFiles].some((p) => dirCovers(f, p));
-// Each check carries a status beside its findings. A count alone reads a dead agent's 0 and a
-// clean check's 0 as the same number, so the array holds findings and the status holds whether
-// the check ran at all.
-// files is null when git failed, and diff-files.py carries its stderr in error.
+// status sits beside findings because a dead agent's 0 and a clean check's 0 are the same count.
+// files is null when git failed, with diff-files.py's stderr in error.
 const diffReport = relayedJson(diff);
 if (diffReport && diffReport.files === null) log(`diff-files: git failed (${diffReport.error}).`);
 const diffFiles = diffReport && Array.isArray(diffReport.files) ? diffReport.files : null;
@@ -1136,16 +1090,14 @@ if (!allTestNames.length) {
 } else {
   testPresenceStatus = "agent-failed";
 }
-// Files the plan named but that were never changed. Scope deviations answer "did it
-// touch a file outside the plan"; this answers "did it leave a planned file untouched".
-// A whole unit can go unimplemented and still pass green, and nobody notices when
-// conformance is down. No LLM judgment, so it cannot fail.
+// Planned files never changed. Scope deviations ask "did it touch a file outside the plan"; this
+// asks "did it leave a planned file untouched", which a green run with a whole unit
+// unimplemented passes. No LLM judgment, so it cannot fail.
 const untouchedPlanFiles = diffListed
   ? [...planFiles].filter((p) => !diffFiles.some((f) => f && (f === p || dirCovers(f, p))))
   : [];
-// When an agent dies and returns null, findings 0 means "did not run", not "found
-// nothing". Collapsing both into the same 0 in the return value makes the caller read
-// it as reviewed.
+// A dead agent's null and a clean review's 0 findings must not collapse into the same 0, or the
+// caller reads it as reviewed.
 const confStatus = !conformance ? "agent-failed" : conformance.spec_found ? "reviewed" : "no-spec";
 const structStatus = !structure
   ? "agent-failed"
@@ -1182,9 +1134,8 @@ if (backlogCandidates.length) {
 }
 
 // ---- Ship: commit + draft PR (outward-facing, so draft = reversible) ----
-// The fact tail is rendered by the deterministic pr-body.py so a fact section is
-// never silently dropped. The append and gh pr create are chained with && so a
-// renderer failure aborts before the PR is created.
+// pr-body.py renders the fact tail deterministically, so a fact section is never silently
+// dropped; the append and gh pr create are chained with && so a renderer failure aborts first.
 phase("Ship");
 
 // Translate + compress only the informational free-text; safety facts and structured
@@ -1192,14 +1143,11 @@ phase("Ship");
 const shipAnomalies = (code.anomalies || []).map((a) => ({ ...a }));
 const shipConformance = conf.spec_found ? conf.findings.map((f) => ({ ...f })) : [];
 
-// Writing back goes through set(), never touching structured fields. kind splits how hard the
-// text is compressed: a finding's detail can lose prose because location / spec_line carry its
-// evidence separately.
+// Writing back goes through set(), never touching structured fields. kind sets how hard the text
+// is compressed: a finding's detail can lose prose because location / spec_line carry its evidence.
 const shipStructure = struct.reference_checked ? struct.findings.map((f) => ({ ...f })) : [];
-// An anomaly's evidence stays out of the slots, the same way a finding's location and
-// spec_line do. The prompt keeps those verbatim, so translating one buys its trailing
-// explanatory clause alone, while each slot added is another id the all-or-nothing write-back
-// needs; a single missing id ships the whole tail in English.
+// An anomaly's evidence stays out of the slots, like a finding's location / spec_line: the prompt
+// keeps those verbatim, and every slot is one more id the all-or-nothing write-back needs.
 const slots = [];
 for (const [items, field, kind] of [
   [shipConformance, "detail", "finding"],
@@ -1290,18 +1238,15 @@ const shipPayload = {
   manual_checks: manualChecks,
 };
 
-// An agent-chosen file name can be reused across runs, and the fact tail is appended, so a
-// stale body would ship with this run's tail stacked on the previous run's text. A title the
-// agent settles goes through a file for a different reason: interpolated, it would reach the
-// shell as syntax. A title the script settled rides the command directly as one shq argv element.
+// The body goes through a fresh file because an agent-chosen name can be reused across runs and
+// the fact tail is appended. A title the agent settles goes through a file because interpolated
+// it would reach the shell as syntax; one the script settled rides the command as one shq argv.
 const runSlug = `${issueNumber || "no-issue"}-${String(branch).replace(/[^\w.-]+/g, "-")}`;
 
-// pr-writing.md's title rule (with an issue reference, use the issue title as it stands and
-// strip a feat: / fix: prefix) is applied by the script. Left to the Ship agent, it has opened
-// the PR under an English title of its own without reading the issue. When Load could not
-// fetch the title this stays empty and the agent settles the title as before.
-// The type list matches verify-commit.py's COMMIT_TYPES. Stripping any word would also eat
-// "WIP:" and "RFC:".
+// The script applies pr-writing.md's title rule (the issue title minus a feat: / fix: prefix);
+// the Ship agent has opened PRs under a title of its own without reading the issue. Empty when
+// Load could not fetch the title. The type list matches verify-commit.py's COMMIT_TYPES;
+// stripping any word would also eat "WIP:" and "RFC:".
 const CONVENTIONAL_PREFIX =
   /^(?:feat|fix|refactor|docs|test|chore|perf|style|ci)(?:\([^()]*\))?!?:\s*/i;
 const prTitle = String(fetched.title || "")

--- a/workflows/build/tests/build.behavior.test.js
+++ b/workflows/build/tests/build.behavior.test.js
@@ -416,12 +416,9 @@ test("a plan carrying both kind and reason clears validate", async () => {
   assert.notEqual(result.stopped, "invalid-plan", "kind plus reason clears validate");
 });
 
-// U-003: the extract prompt (line ~500) still only describes the legacy
-// `reference_module: null (reason)` prose, not the current `reference_module: {kind, reason}`
-// skeleton form skills/think now writes (DR-0093's Transition Plan). Until that prompt catches
-// up, a still-imperfect extraction can drop kind or reason even though the raw issue body states
-// them plainly. A deterministic regex fallback recovers them from planSection, the same way
-// bodyUnitIds scans planSection with a line-anchored regex rather than reading the whole body.
+// An extraction can drop kind or reason even though the raw issue body states them plainly. A
+// deterministic regex fallback recovers them from planSection, the same way bodyUnitIds scans
+// planSection with a line-anchored regex rather than reading the whole body.
 const bodyWithRefModule = (refModuleLine) =>
   [
     "Background on the issue.",
@@ -464,9 +461,6 @@ test("the fill reads kind and reason off the body line when the extraction omits
     args,
     stubs: makeStubs({ body, plan: makePlan({ reference_module: {} }) }),
   });
-  // An object with no "kind" key already clears validate() unchecked (its own legacy-compat
-  // branch: "goes unchecked for backward compatibility"), so clearing validate alone would not
-  // prove the fill ran; the code workflow's structured payload is read directly instead.
   assert.notEqual(result.stopped, "invalid-plan");
   const codeCall = calls.workflow.find((c) => c.name === "code");
   assert.ok(codeCall, "the code workflow runs");
@@ -507,31 +501,61 @@ test("the fill reads an unquoted kind and reason, the form /think writes", async
   );
 });
 
-test("the legacy `reference_module: null (reason)` form fills a kind rather than being left absent", async () => {
-  const reason = "adds one line to an existing skill; no new module needed";
-  const body = bodyWithRefModule(`reference_module: null (${reason})`);
+test("the body line's kind and reason override the ones the extraction returned", async () => {
+  const reason = "no equivalent structure exists yet";
+  const body = bodyWithRefModule(`reference_module: {kind: "new-shape", reason: "${reason}"}`);
+  const { calls, result } = await runWorkflow(buildJs, {
+    args,
+    stubs: makeStubs({
+      body,
+      plan: makePlan({ reference_module: { kind: "no-module", reason: "paraphrased by extract" } }),
+    }),
+  });
+  assert.notEqual(result.stopped, "invalid-plan");
+  const codeCall = calls.workflow.find((c) => c.name === "code");
+  assert.equal(codeCall.args.plan.reference_module.kind, "new-shape", "kind comes from the body");
+  assert.equal(codeCall.args.plan.reference_module.reason, reason, "reason comes from the body");
+});
+
+test("a `reference_module: null (reason)` body line stops as invalid-plan instead of being read as a kind", async () => {
+  const body = bodyWithRefModule("reference_module: null (adds one line to an existing skill)");
   const { calls, result } = await runWorkflow(buildJs, {
     args,
     stubs: makeStubs({ body, plan: makePlan({ reference_module: null }) }),
   });
-  assert.notEqual(
-    result.stopped,
-    "invalid-plan",
-    "the legacy null(reason) form fills a kind and reason instead of stopping",
+  assert.equal(result.stopped, "invalid-plan");
+  assert.equal(
+    calls.workflow.find((c) => c.name === "code"),
+    undefined,
+    "the code workflow does not run",
   );
-  const codeCall = calls.workflow.find((c) => c.name === "code");
-  assert.ok(codeCall, "the code workflow runs");
-  const filled = codeCall.args.plan.reference_module;
-  assert.ok(
-    filled && typeof filled === "object",
-    "reference_module becomes an object rather than staying the bare null the extraction produced",
+  assert.equal(
+    result.blockers.filter((b) => /reference_module is null/.test(String(b))).length,
+    1,
+    "blockers names the bare null once",
   );
-  assert.match(
-    filled.kind,
-    /^(no-module|new-shape)$/,
-    "a kind is filled; the fill never produces module, since it never fabricates a path",
+});
+
+test("a reference_module object without kind stops as invalid-plan", async () => {
+  const body = bodyWithRefModule('reference_module: {path: "src/x", files: ["src/x/a.ts"]}');
+  const { calls, result } = await runWorkflow(buildJs, {
+    args,
+    stubs: makeStubs({
+      body,
+      plan: makePlan({ reference_module: { path: "src/x", files: ["src/x/a.ts"] } }),
+    }),
+  });
+  assert.equal(result.stopped, "invalid-plan");
+  assert.equal(
+    calls.workflow.find((c) => c.name === "code"),
+    undefined,
+    "the code workflow does not run",
   );
-  assert.equal(filled.reason, reason, "the reason is carried over verbatim");
+  assert.equal(
+    result.blockers.filter((b) => /reference_module\.kind is missing/.test(String(b))).length,
+    1,
+    "blockers names the missing kind once",
+  );
 });
 
 // The outside quotation shares the reference_module shape but carries kind: "module" and a
@@ -1031,6 +1055,7 @@ const refModulePreconditionsPlan = (reference_module) => makePlan({ reference_mo
 
 test("a reference_module path that does not exist stops the run at plan-drift", async () => {
   const plan = refModulePreconditionsPlan({
+    kind: "module",
     path: "src/existing",
     files: ["src/existing/index.ts"],
   });
@@ -1097,6 +1122,7 @@ test("a plan whose kind is no-module with a path clears validate and takes the e
 
 test("a reference_module whose files include one that does not exist stops the run at plan-drift", async () => {
   const plan = refModulePreconditionsPlan({
+    kind: "module",
     path: "src/existing",
     files: ["src/existing/index.ts", "src/existing/missing.ts"],
   });
@@ -1131,6 +1157,7 @@ test("a reference_module with no path puts no reference_module row in the revali
     reason: "no existing module shares this shape",
   });
   const withPath = refModulePreconditionsPlan({
+    kind: "module",
     path: "src/existing",
     files: ["src/existing/index.ts"],
   });
@@ -1376,7 +1403,7 @@ test("a unit with no tests is not invalid-plan, and zero declared statements cal
 
 const refPlan = () =>
   makePlan({
-    reference_module: { path: "src/existing", files: ["src/existing/index.ts"] },
+    reference_module: { kind: "module", path: "src/existing", files: ["src/existing/index.ts"] },
   });
 
 test("Verify's diff, conformance, and structure measure from Branch's branch-point sha and never use a bare git diff HEAD", async () => {

--- a/workflows/code.js
+++ b/workflows/code.js
@@ -22,9 +22,8 @@ const parseArgs = () => {
   }
   return {};
 };
-// Only the presence of units is checked here. Validating the plan's structure and re-verifying
-// its preconditions belong to build's Load and Revalidate, and a standalone caller does both
-// before handing the plan over (#185).
+// Only the presence of units is checked here; validating the plan and re-verifying its
+// preconditions belong to build's Load and Revalidate, which a standalone caller runs first.
 const input = parseArgs();
 const plan = input.plan;
 if (!plan || !Array.isArray(plan.units) || !plan.units.length) {
@@ -131,10 +130,9 @@ const parsedReport = (stdout) => {
   }
 };
 
-// The report crosses back through an agent, and a long one comes back truncated: a run of
-// gate calls relayed reports of 1.5 KB to 8.7 KB and the one that arrived unparseable was
-// 5.7 KB. Most of that length is the two output tails, which nothing here reads -- the script
-// reads verdict, classification, and candidates. gate.ts defaults the tails to 12 KB each.
+// The report crosses back through an agent and a long one comes back truncated (a 5.7 KB one
+// arrived unparseable). Most of the length is the two output tails, which nothing here reads;
+// the script reads verdict, classification, and candidates. gate.ts defaults the tails to 12 KB.
 const GATE_TAIL_BYTES = "800";
 
 // gate.ts runs on Node's TypeScript type stripping. A shell whose node predates it kills the
@@ -301,6 +299,14 @@ const completed = [];
 const skipped = [];
 const anomalies = [];
 const commits = [];
+// codex-herdr pane state. panes stays null for a claude run and keeps its ids after the close,
+// so every return path reports them; closed guards the double close from stopUnit and loop end.
+const herdrState = { panes: null, closed: false, opens: 0, closes: 0 };
+const herdrReport = () => ({
+  herdr_panes: herdrState.panes,
+  pane_opens: herdrState.opens,
+  pane_closes: herdrState.closes,
+});
 // The run-level arrays are closed over, so a mid-loop stop still hands the caller its partial
 // progress.
 const stopUnit = async (stopped, unit, why) => {
@@ -313,17 +319,13 @@ const stopUnit = async (stopped, unit, why) => {
     skipped,
     anomalies,
     commits,
-    herdr_panes: herdrPanesResolved,
-    pane_opens: paneOpens,
-    pane_closes: paneCloses,
+    ...herdrReport(),
   };
 };
-// Decides the route and the destination in this one function alone. herdrPanes is declared
-// with let further below, but every call this function receives happens inside the for loop,
-// after that assignment runs.
+// Decides the route and the destination alone.
 const implementDestination = (role) =>
   implementer === "codex-herdr"
-    ? { opts: {}, paneId: herdrPanes ? herdrPanes[role] : undefined }
+    ? { opts: {}, paneId: herdrState.panes ? herdrState.panes[role] : undefined }
     : { opts: { model: input.model || "sonnet", effort: "high" }, paneId: undefined };
 
 const RED_SCHEMA = {
@@ -387,9 +389,8 @@ const COMMIT_SCHEMA = {
   },
 };
 
-// Never put the agent's prompt text in the message: the prompt carries issue-derived
-// (untrusted) prose, and a commit message becomes an unamendable record. Trailer form
-// keeps the plan's anchors machine-readable (git interpret-trailers / git log --format).
+// The agent's prompt text never enters the message: it carries issue-derived (untrusted) prose,
+// and a commit message is an unamendable record. Trailers keep the plan's anchors machine-readable.
 const commitBody = (unit, tests) =>
   [
     flatten(unit.goal),
@@ -402,10 +403,9 @@ const commitBody = (unit, tests) =>
     ...(issueRef ? [`Issue: #${issueRef}`] : []),
   ].join("\n");
 
-// Taken while the working tree still holds only that unit's work; splitting the merged
-// tree afterwards would be an LLM guess at hunk ownership. A failed commit (a blocking
-// pre-commit gate) does not stop the run because the work stays in the tree
-// and the caller's final commit sweeps it up.
+// Taken while the working tree holds only that unit's work; splitting a merged tree afterwards
+// would be an LLM guess at hunk ownership. A failed commit (a blocking pre-commit gate) does not
+// stop the run: the work stays in the tree and the caller's final commit sweeps it up.
 const commitUnit = async (unit, tests, testFiles) => {
   if (!commitPerUnit) return;
   // Read after the commit agent runs, the head it landed on is already gone.
@@ -470,9 +470,9 @@ const commitUnit = async (unit, tests, testFiles) => {
   log(`${unit.id}: not committed (${why}). Left in the working tree.`);
 };
 
-// The agent tool's schema only guarantees shape: a courier reading codex's response file can
-// hand back `{"red_confirmed": "false"}` as a string and still satisfy RED_SCHEMA's declared
-// properties. The type is checked here, right before a caller trusts it via truthiness.
+// The agent tool's schema only guarantees shape: a courier can hand back
+// `{"red_confirmed": "false"}` as a string and still satisfy RED_SCHEMA. The type is checked
+// here, right before a caller trusts it via truthiness.
 const boolMismatch = (result, field) => !!result && typeof result[field] !== "boolean";
 
 const courierTypeStop = (unit, result, field) =>
@@ -495,10 +495,9 @@ const recordDeferred = (unit, result) => {
 // no fs), so unit + role settle on one file reused across the first attempt and its retry.
 const responsePath = (unit, role) => `.codex-response/${unit.id}-${role}.json`;
 
-// role is "tester" for the Red step and "coder" for Green / direct implementation. What a
-// still-failing result means belongs to the caller: an unconfirmed Red is recorded as an
-// anomaly, while a failing impl / Green stops the run. A null first result skips the retry, so
-// a dead agent is not asked twice.
+// role is "tester" for Red and "coder" for Green / direct implementation. The caller decides
+// what a still-failing result means: an unconfirmed Red is an anomaly, a failing impl / Green
+// stops the run. A null first result skips the retry, so a dead agent is not asked twice.
 const stepWithRetry = async (unit, label, role, schema, ok, prompt, retryPrompt) => {
   const dest = implementDestination(role);
   // Prepended to both the first prompt and the retry prompt, so a codex-herdr retry addresses
@@ -556,11 +555,10 @@ const PANE_CLOSE_SCHEMA = {
   },
 };
 
-// From the herdr CLI reference (https://herdr.dev/ja/docs/cli-reference/, fetched 2026-08-27):
-// `pane split`'s response carries the new pane's id at `.result.pane.pane_id`. `agent start
-// <name> --kind KIND --pane ID` targets an existing shell pane; name must match
-// `[a-z][a-z0-9_-]{0,31}`. A blocked detection state returns `agent_not_ready` immediately.
-// `pane close <pane_id>` takes the same id read from split.
+// From the herdr CLI reference (https://herdr.dev/ja/docs/cli-reference/): `pane split` returns
+// the new pane's id at `.result.pane.pane_id`; `agent start <name> --kind KIND --pane ID` targets
+// an existing shell pane, name matching `[a-z][a-z0-9_-]{0,31}`; a blocked detection state
+// returns `agent_not_ready` immediately; `pane close <pane_id>` takes the id read from split.
 const startPane = (role) =>
   agent(
     anchor(
@@ -596,35 +594,19 @@ const closePane = (role, paneId) =>
     },
   );
 
-// Stays null for a non-codex-herdr run, so closeHerdrPanes is a no-op there.
-let herdrPanes = null;
-// run-workflow.js's calls.agent records only each agent's {prompt, opts}, which cannot show
-// that the pane id resolved from pane split, or the open/close count, actually reached this
-// workflow's own return value - the value build.js in turn forwards into its own return value.
-// herdrPanesResolved survives closeHerdrPanes nulling herdrPanes out, so the ids stay on every
-// return path after teardown, not just before it.
-let herdrPanesResolved = null;
-let paneOpens = 0;
-let paneCloses = 0;
-
-// Every close (loop-end teardown via closeHerdrPanes, and the early-failure branches below
-// that close a lone already-open tester pane) goes through here, so paneCloses stays the one
-// running count of panes actually closed.
+// Every close goes through here, so herdrState.closes is the one count of panes actually closed.
 const closePaneCounted = async (role, paneId) => {
   const res = await closePane(role, paneId);
-  if (res && res.closed) paneCloses++;
+  if (res && res.closed) herdrState.closes++;
   return res;
 };
 
-// Called both from stopUnit's early returns and from the normal path after the loop ends, so
-// it clears herdrPanes on entry to avoid closing twice. A close failure does not stop the run;
-// it is recorded as an anomaly instead.
+// A close failure is an anomaly, not a stop.
 const closeHerdrPanes = async () => {
-  if (!herdrPanes) return;
-  const panes = herdrPanes;
-  herdrPanes = null;
-  for (const role of ["tester", "coder"]) {
-    const res = await closePaneCounted(role, panes[role]);
+  if (!herdrState.panes || herdrState.closed) return;
+  herdrState.closed = true;
+  for (const [role, paneId] of Object.entries(herdrState.panes)) {
+    const res = await closePaneCounted(role, paneId);
     if (res && res.closed) continue;
     const why = res
       ? res.notes || `${role} pane close reported closed: false`
@@ -634,9 +616,9 @@ const closeHerdrPanes = async () => {
   }
 };
 
-// herdr talks over a Unix socket, so a sandboxed Bash call cannot reach it and the agent
-// needs dangerouslyDisableSandbox. Mirrors assert.js's codex_available: confirm both the
-// command's presence and a real round trip before any unit enters implementation.
+// herdr talks over a Unix socket, so the agent needs dangerouslyDisableSandbox. As with
+// assert.js's codex_available, both the command's presence and a real round trip are confirmed
+// before any unit enters implementation.
 if (implementer === "codex-herdr") {
   const herdr = await agent(
     anchor(
@@ -660,9 +642,7 @@ if (implementer === "codex-herdr") {
       why: herdr
         ? herdr.notes || "herdr is unreachable."
         : "the herdr reachability check returned no result",
-      herdr_panes: herdrPanesResolved,
-      pane_opens: paneOpens,
-      pane_closes: paneCloses,
+      ...herdrReport(),
     };
   }
 
@@ -676,35 +656,29 @@ if (implementer === "codex-herdr") {
       why: testerStart
         ? testerStart.notes || "the tester pane failed to start."
         : "the tester pane-start agent returned no result",
-      herdr_panes: herdrPanesResolved,
-      pane_opens: paneOpens,
-      pane_closes: paneCloses,
+      ...herdrReport(),
     };
   }
-  paneOpens++;
+  herdrState.opens++;
   // Recorded per pane, not once both are up: a coder-start failure stops between the two, and a
-  // caller chasing a leaked pane needs the tester id the stop already resolved.
-  herdrPanesResolved = { tester: testerStart.pane_id };
+  // caller chasing a leaked pane needs the tester id.
+  herdrState.panes = { tester: testerStart.pane_id };
 
   // A coder pane failure closes the tester pane already open before stopping.
   const coderStart = await startPane("coder");
   if (!coderStart || !coderStart.started) {
-    await closePaneCounted("tester", testerStart.pane_id);
+    await closeHerdrPanes();
     return {
       stopped: "pane-start-failed",
       why: coderStart
         ? coderStart.notes || "the coder pane failed to start."
         : "the coder pane-start agent returned no result",
-      herdr_panes: herdrPanesResolved,
-      pane_opens: paneOpens,
-      pane_closes: paneCloses,
+      ...herdrReport(),
     };
   }
-  paneOpens++;
-
+  herdrState.opens++;
   // These 2 panes are reused across every unit. closeHerdrPanes (loop end) owns closing them.
-  herdrPanes = { tester: testerStart.pane_id, coder: coderStart.pane_id };
-  herdrPanesResolved = herdrPanes;
+  herdrState.panes.coder = coderStart.pane_id;
 }
 
 // A contract cites one behavior, so without the plan's reference module the surrounding
@@ -723,12 +697,10 @@ const referenceModuleCtx = ref?.path
     `Deviating from the reference module is allowed only when the plan says so; state any deviation in your result.\n`
   : "";
 
-// Leaving reference discovery to the LLM's own initiative adds a skipped-search dropout point
-// and makes the read unverifiable, so the read is an explicit agent call and the glob match
-// against units[].files is held by the script, deterministically.
-// The plan carries the rules, and this passes them straight into the implementation prompt.
-// Nothing is looked up at implementation time, so what reached the agent is readable from the
-// issue's `### Rules` section alone.
+// The reference read is an explicit agent call, and the glob match against units[].files is the
+// script's: left to the LLM's initiative, the search can be skipped and the read cannot be
+// verified. The plan's rules pass straight into the prompt; nothing is looked up at
+// implementation time, so what reached the agent is readable from the issue's `### Rules` alone.
 const RULES_START = "---- rules start ----";
 const RULES_END = "---- rules end ----";
 
@@ -748,9 +720,8 @@ const rulesCtx = () => {
 const PRECEDING_START = "---- preceding units start ----";
 const PRECEDING_END = "---- preceding units end ----";
 
-// Built from plan.units, never from an implementation agent's self-report: a self-report
-// arrives through GREEN_SCHEMA, and a missing field there falls into the unit-failed branch
-// and ends the run mid-plan.
+// Built from plan.units, never from an implementation agent's self-report: a missing field in a
+// GREEN_SCHEMA self-report would fall into the unit-failed branch and end the run mid-plan.
 const precedingUnitsCtx = (index) =>
   index
     ? [
@@ -972,8 +943,7 @@ for (const [index, unit] of units.entries()) {
   await commitUnit(unit, tests, red.test_files || []);
 }
 
-// Every unit's implementation is done, so close the panes opened for codex-herdr. herdrPanes
-// stays null for a claude run, so this is a no-op there.
+// Every unit's implementation is done, so close the panes opened for codex-herdr.
 await closeHerdrPanes();
 
 const VERIFY_SCHEMA = {
@@ -1029,9 +999,6 @@ return {
   tests_pass: verify.tests_pass,
   gates_pass: verify.gates_pass,
   verify_output: verify.output_tail,
-  // Stays null for a claude run (herdrPanesResolved / paneOpens / paneCloses are never touched
-  // there); build.js forwards this trio into its own return value unchanged.
-  herdr_panes: herdrPanesResolved,
-  pane_opens: paneOpens,
-  pane_closes: paneCloses,
+  // build.js forwards this trio into its own return value unchanged.
+  ...herdrReport(),
 };


### PR DESCRIPTION
## What & Why

workflow script から `reference_module` の旧形式互換を外し、過去の仕様変遷や導出過程を語っていたコメントを why-not だけに圧縮する。open な issue に旧形式の body は残っておらず、互換コードとその説明が本文の読みにくさの主因だった。あわせて repo 全体を走査し、呼び出し側の無い関数と build 計画の unit id が残ったコメントを消す。

## Review focus

- `workflows/build.js` の validate と `reference_module` 補完。kind の無い object が `invalid-plan` で止まるようになり、本文の行が extract の値を常に上書きする。この 2 つは振る舞いの変更
- `workflows/code.js` の `herdrState`。coder pane の起動失敗時に tester の close が `closeHerdrPanes()` を通るようになり、close 失敗が `pane-not-closed` の anomaly として返り値に載る
- audit.js / assert.js / run-workflow.js / sandbox/hako / skills/ablate はコメントのみの変更なので流し読みでよい

## Changes

- `null (reason)` 散文と kind 無し object の受け入れを削除。extract prompt の該当文も外した
- code.js の herdr pane の 4 変数を 1 つの状態オブジェクトにまとめ、6 箇所の return を `herdrReport()` に統一
- build.js の `dirCovers` / `preexisting` が共有する配下判定を `under()` に切り出し
- verify_run.py の `pages_added` と `NOT_A_PAGE` を削除 (呼び出し側もテストも無かった)
- 4 script のコメント行を build.js 250→203、audit.js 141→110、code.js 127→113、assert.js 114→106 に圧縮。`.ja` も同じ箇所を同じ形に

## Scope

- Not included: `adrift.js` の ADR-NNNN 形式の検出。wiki と古い DR に 850 件の参照が残っているため
- Not included: 参照ゼロの `workflows/_lib/codex-run.js` と `hooks/_lib/hook_payload.ts` の扱い。前者は用途未記載、後者は #634 の TS 移行で一本化する

## How to Test

1. `node --test workflows/` を実行する。453 件が通る (本文行の上書きを固定するテストを 1 件追加)
2. `python3 skills/scribe/tests/verify_run_test.py` と `python3 skills/ablate/tests/arms_test.py` を実行する。どちらも OK
3. `find sandbox -name '*.test.sh' -exec bash {} \;` を実行する。`hako-run.test.sh` の 1 件は main でも同じ 1 件が失敗しており、この PR とは無関係

https://claude.ai/code/session_0131gkYQQHKGm6yj1sKDfW4G
