### PR TITLE
issue form の label が言語や大文字小文字の違いで底を満たせない問題を直す

### DIFF
--- a/.ja/skills/issue/scripts/validate-issue-body.py
+++ b/.ja/skills/issue/scripts/validate-issue-body.py
@@ -31,6 +31,12 @@ FLOOR = {
     "feature": ("Acceptance Criteria", "Testing Decisions"),
     "bug": ("Steps to Reproduce", "Expected vs Actual"),
 }
+# リポジトリの form は底の節を自分の言語で名付ける。底の英語名ごとに、同じ節に当たるラベルを
+# 並べる。これが無いと、日本語 form の必須節と英語の底を両方置かない限り本文が通らない。
+FLOOR_ALIASES = {
+    "Steps to Reproduce": ("再現手順",),
+    "Expected vs Actual": ("期待 / 実際",),
+}
 # Plan と Backlog candidates は /think の plan を転記した issue が持ち、Parent と Blocked by は
 # /slice が骨格を挟む形で必ず付ける。骨格に無いという理由で errors にすると全て落ちる。
 ALLOWED_EXTRA = frozenset({"Plan", "Backlog candidates", "Parent", "Blocked by"})
@@ -205,8 +211,10 @@ def main() -> None:
         results["errors"].append(f"unreadable_skeleton:{template.name}")
     required = [name for name, optional in sections if not optional]
     present = body_section_names(body_text)
+    known = {n.casefold() for n in (*present, *required)}
     for name in FLOOR.get(template_type, ()):
-        if name not in present and name not in required:
+        names = (name, *FLOOR_ALIASES.get(name, ()))
+        if not any(n.casefold() in known for n in names):
             required.append(name)
     for name in required:
         if name in present:

--- a/skills/issue/scripts/validate-issue-body.py
+++ b/skills/issue/scripts/validate-issue-body.py
@@ -31,6 +31,13 @@ FLOOR = {
     "feature": ("Acceptance Criteria", "Testing Decisions"),
     "bug": ("Steps to Reproduce", "Expected vs Actual"),
 }
+# A repository form names the floor sections in its own language. Each English floor name lists
+# the labels that stand for the same section. Without this, a body passes only when it carries
+# both the Japanese form's required section and the English floor.
+FLOOR_ALIASES = {
+    "Steps to Reproduce": ("再現手順",),
+    "Expected vs Actual": ("期待 / 実際",),
+}
 # Plan and Backlog candidates come with a transferred /think plan; Parent and Blocked by come from
 # /slice, which wraps every skeleton it picks in the two. Faulting them for being absent from the
 # skeleton would fail every body those two routes produce.
@@ -209,8 +216,10 @@ def main() -> None:
         results["errors"].append(f"unreadable_skeleton:{template.name}")
     required = [name for name, optional in sections if not optional]
     present = body_section_names(body_text)
+    known = {n.casefold() for n in (*present, *required)}
     for name in FLOOR.get(template_type, ()):
-        if name not in present and name not in required:
+        names = (name, *FLOOR_ALIASES.get(name, ()))
+        if not any(n.casefold() in known for n in names):
             required.append(name)
     for name in required:
         if name in present:

--- a/skills/issue/tests/validate-issue-body.test.js
+++ b/skills/issue/tests/validate-issue-body.test.js
@@ -348,11 +348,20 @@ test("T-017 a body meeting the form but missing the type's floor is an error", a
     const floor = floorFor(type);
     assert.ok(floor.length > 0, `${type}: the floor is readable`);
     const path = join(dir, form);
-    const labels = [...readFileSync(path, "utf8").matchAll(/^\s*label:\s*(.+?)\s*$/gm)];
-    const body = labels.map((m) => `## ${m[1]}\n\nx\n`).join("\n");
+    const labels = [...readFileSync(path, "utf8").matchAll(/^\s*label:\s*(.+?)\s*$/gm)].map(
+      (m) => m[1],
+    );
+    const body = labels.map((label) => `## ${label}\n\nx\n`).join("\n");
+    const uncovered = floor.filter(
+      (name) => !labels.some((label) => label.toLowerCase() === name.toLowerCase()),
+    );
+    assert.ok(
+      uncovered.length > 0,
+      `${form}: the form leaves at least one floor section uncovered`,
+    );
     const { status, out } = runValidate(path, `[${type[0].toUpperCase()}${type.slice(1)}] x`, body);
     assert.equal(status, 1, `${form}: it exits 1 without the floor`);
-    for (const name of floor) {
+    for (const name of uncovered) {
       assert.ok(
         out.errors.includes(`missing_section:${name}`),
         `${form}: ${name} is reported missing (${out.errors.join(", ")})`,
@@ -514,4 +523,102 @@ test("T-024 braces inside a fenced block are not read as prompts", () => {
   const { status, out } = runContentOnly(body);
   assert.equal(status, 0, `it exits 0, got ${JSON.stringify(out.errors)}`);
   assert.ok(out.checks.includes("placeholder=none"), "it records that no prompt is left");
+});
+
+test("T-026 a form label that differs from the bug floor only in case satisfies the floor", () => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-issue-body-"));
+  try {
+    const form = join(dir, "bug.yml");
+    writeFileSync(
+      form,
+      [
+        "name: Bug report",
+        "body:",
+        "  - type: textarea",
+        "    attributes:",
+        "      label: What happened?",
+        "    validations:",
+        "      required: true",
+        "  - type: textarea",
+        "    attributes:",
+        "      label: Steps to reproduce",
+        "",
+      ].join("\n"),
+    );
+    const body = [
+      "## What happened?",
+      "",
+      "x",
+      "",
+      "## Steps to reproduce",
+      "",
+      "1. x",
+      "",
+      "## Expected vs Actual",
+      "",
+      "- x",
+      "",
+    ].join("\n");
+    const { status, out } = runValidate(form, "[Bug] x", body);
+    assert.equal(status, 0, `it exits 0, got ${JSON.stringify(out.errors)}`);
+    assert.ok(
+      !out.errors.includes("missing_section:Steps to Reproduce"),
+      "the lowercase form label stands in for the floor's capitalization",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// A repository form written in Japanese requires 再現手順 and 期待 / 実際. Those are the bug floor
+// under another name, so a body carrying them must not also have to carry the English headings.
+test("T-025 a Japanese form's required sections satisfy the bug floor", () => {
+  const dir = mkdtempSync(join(tmpdir(), "validate-issue-body-"));
+  try {
+    const form = join(dir, "bug.yml");
+    writeFileSync(
+      form,
+      [
+        "name: バグ",
+        "body:",
+        "  - type: textarea",
+        "    attributes:",
+        "      label: 事象",
+        "    validations:",
+        "      required: true",
+        "  - type: textarea",
+        "    attributes:",
+        "      label: 再現手順",
+        "    validations:",
+        "      required: true",
+        "  - type: textarea",
+        "    attributes:",
+        "      label: 期待 / 実際",
+        "    validations:",
+        "      required: true",
+        "",
+      ].join("\n"),
+    );
+    const body = [
+      "## 事象",
+      "",
+      "x",
+      "",
+      "## 再現手順",
+      "",
+      "1. x",
+      "",
+      "## 期待 / 実際",
+      "",
+      "- x",
+      "",
+    ].join("\n");
+    const { status, out } = runValidate(form, "[Bug] x", body);
+    assert.equal(status, 0, `it exits 0, got ${JSON.stringify(out.errors)}`);
+    for (const name of floorFor("bug")) {
+      assert.ok(!out.errors.includes(`missing_section:${name}`), `${name} is not reported missing`);
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## What & Why

日本語で書かれた issue form (`再現手順` / `期待 / 実際`) と、この repo 自身の `bug.yml` (`Steps to reproduce`) で書いた本文が、bug の底 `Steps to Reproduce` / `Expected vs Actual` を英語の見出しで二重に持たないと通らなかった。底の照合に別名表と casefold を入れ、form の label が同じ節を指していれば底を満たす形にする。

## Review focus

- `validate-issue-body.py` の底の照合 3 行。`FLOOR_ALIASES` が日本語 label を、casefold が大文字小文字の違いを吸収する
- T-017 の期待値。form の label から本文を組み立てているため、label が底と大文字小文字違いで一致する節は「欠落」の期待から外した。以前の期待は不具合そのものを固定していた

## How to Test

1. `node --test skills/issue/tests/validate-issue-body.test.js` を実行する。20 件が通る (T-025 が日本語 form、T-026 が大文字小文字違いの form)
2. `.github/ISSUE_TEMPLATE/bug.yml` に対して `## Steps to reproduce` と `## Expected vs Actual` を持つ本文を validator に通す。`errors` が空で exit 0

https://claude.ai/code/session_0131gkYQQHKGm6yj1sKDfW4G
