### PR TITLE
pageshot の成果物を gh pr create --attach で PR に添付する

### DIFF
--- a/.ja/skills/pr/SKILL.md
+++ b/.ja/skills/pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: ブランチ変更を分析し、draft の pull request を作成する。base ブランチは分岐元から検出し、本文は prose review で精査してから上げる。UI 変更があればスクリーンショットを撮る。
+description: ブランチ変更を分析し、draft の pull request を作成する。base ブランチは分岐元から検出し、本文は prose review で精査してから上げる。UI 変更があればスクリーンショットを撮って PR に添付する。
 when_to_use: PR作って, プルリクエスト, pull request, PR作成
 allowed-tools: Bash(git:*) Bash(gh:*) Bash(cat:*) Read Skill
 model: opus
@@ -34,8 +34,8 @@ commit なし、Git リポジトリでない、gh 認証失敗のいずれかを
 
 1. UI 変更があれば Skill で `use-workflow-pageshot` を PR 本文と共に呼ぶ (§ Pageshot 統合)
 2. `git push -u origin HEAD` で現在ブランチを push する
-3. 本文を一時ファイルに書き出し、`gh pr create --draft --title "<title>" --body-file <path>` で PR を作成する (§ 作成の制約)
-4. pageshot 成果物があれば表示 (§ Pageshot 統合)。成功時は `Created draft PR: #<number> <title> (base: <base>) <PR URL>` を出す
+3. 本文を一時ファイルに書き出し、`gh pr create --draft --title "<title>" --body-file <path>` で PR を作成する (§ 作成の制約)。pageshot 成果物があれば § Pageshot 統合の `--attach` を足す
+4. 成功時は `Created draft PR: #<number> <title> (base: <base>) <PR URL>` を出す。添付の失敗は § 作成の制約に従う
 
 ## 分析ソース
 
@@ -83,9 +83,12 @@ draft で上げるのは、人が本文を読んでから ready に変えるた�
 
 本文は `--body` でなく `--body-file` で渡す。テンプレート由来の本文は backtick や `$` を含み、`--body` では shell がそれを解釈する。
 
+pageshot 成果物は本文へ手書きせず `--attach` で渡す。gh が upload し、本文末尾へ追記する。upload が失敗しても PR は作られ、終了コードが非ゼロでも URL は stdout に出る。この場合も結果行を出し、失敗した成果物のパスと `gh pr edit <number> --attach <path>` を案内する。
+
 ## Pageshot 統合
 
 `Skill("use-workflow-pageshot")` を現在の PR 本文文字列を入力に呼ぶ。本文には上部近くの `Preview URL: <URL>` 行と、番号付きリストの `## How to Test` セクションが必要。skill は stdout に mode 行を 1 つ返す。
 
-- `mode=screenshot artifact=<path>`/`mode=video artifact=<path>` パスを表示し、GitHub の PR 説明か最初のコメントへドラッグ & ドロップするよう案内
+- `mode=screenshot artifact=<path>` `gh pr create` に `--attach "<path>#<title>"` を足す。`#` の後ろが alt text になり、PR タイトルを使う
+- `mode=video artifact=<path>` `gh pr create` に `--attach "<path>"` を足す。動画は alt text を持たない
 - `mode=failed` 欠落項目を報告し、pageshot をスキップして PR 作成を続行

--- a/.ja/skills/use-workflow-pageshot/SKILL.md
+++ b/.ja/skills/use-workflow-pageshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-workflow-pageshot
-description: /pr の内部ヘルパー。PR 本文 (Preview URL + How to Test) を読み取り、agent-browser を駆動してスクリーンショット (1 step) または動画 (2+ step) を撮影し、GitHub web UI への手動添付用に成果物のパスを返す。
+description: /pr の内部ヘルパー。PR 本文 (Preview URL + How to Test) を読み取り、agent-browser を駆動してスクリーンショット (1 step) または動画 (2+ step) を撮影し、/pr が gh pr create --attach に渡す成果物のパスを返す。
 when_to_use: /pr workflow UI変更検出時のスクショ/動画撮影, screenshot capture, video capture
 allowed-tools: Read Bash(agent-browser:*) Bash(ffmpeg:*) Bash(mkdir:*) Bash(date:*)
 model: opus

--- a/skills/pr/SKILL.md
+++ b/skills/pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr
-description: Analyzes branch changes and opens a draft pull request. Detects the base branch from where this one was cut, refines the body through a prose review before it goes up, and captures a screenshot when the change touches the UI.
+description: Analyzes branch changes and opens a draft pull request. Detects the base branch from where this one was cut, refines the body through a prose review before it goes up, and captures a screenshot and attaches it to the PR when the change touches the UI.
 when_to_use: PR作って, プルリクエスト, pull request, PR作成
 allowed-tools: Bash(git:*) Bash(gh:*) Bash(cat:*) Read Skill
 model: opus
@@ -34,8 +34,8 @@ If there are no commits, the directory is not a git repository, or gh auth fails
 
 1. If UI changes, invoke `use-workflow-pageshot` via Skill with the PR body (§ Pageshot Integration)
 2. Push the current branch with `git push -u origin HEAD`
-3. Write the body to a temp file and create the PR with `gh pr create --draft --title "<title>" --body-file <path>` (§ Creation Constraints)
-4. If a pageshot artifact exists, display it (§ Pageshot Integration). On success, display `Created draft PR: #<number> <title> (base: <base>) <PR URL>`
+3. Write the body to a temp file and create the PR with `gh pr create --draft --title "<title>" --body-file <path>` (§ Creation Constraints). If a pageshot artifact exists, add the `--attach` from § Pageshot Integration
+4. On success, display `Created draft PR: #<number> <title> (base: <base>) <PR URL>`. A failed attachment follows § Creation Constraints
 
 ## Analysis Sources
 
@@ -83,9 +83,12 @@ Nothing confirms during this phase. The draft state and the base on the result l
 
 Pass the body through `--body-file` rather than `--body`. A template-derived body contains backticks and `$`, and `--body` lets the shell interpret them.
 
+Pass the pageshot artifact through `--attach` rather than writing it into the body. gh uploads it and appends it to the end of the body. When the upload fails the PR is still created, and the URL still goes to stdout even though the exit code is non-zero. Display the result line in that case too, along with the path of the failed artifact and `gh pr edit <number> --attach <path>`.
+
 ## Pageshot Integration
 
 Call `Skill("use-workflow-pageshot")` with the current PR body string as input. The body must contain a `Preview URL: <URL>` line near the top and a `## How to Test` section as a numbered list. The skill returns a single mode line on stdout.
 
-- `mode=screenshot artifact=<path>` / `mode=video artifact=<path>` display the path and advise dragging it into the PR description or first comment on GitHub
+- `mode=screenshot artifact=<path>` add `--attach "<path>#<title>"` to `gh pr create`. The text after `#` becomes the alt text, and the PR title is used
+- `mode=video artifact=<path>` add `--attach "<path>"` to `gh pr create`. Video carries no alt text
 - `mode=failed` report missing items, skip pageshot, and continue PR creation

--- a/skills/pr/tests/template-priority.test.js
+++ b/skills/pr/tests/template-priority.test.js
@@ -33,6 +33,18 @@ test("the mode tokens pr branches on are the ones pageshot emits", () => {
   }
 });
 
+// The pageshot artifact reaches the PR through gh's --attach flag. With the flag gone from the
+// create step, the capture runs and the PR goes up without it, and the only remaining signal is
+// a stale instruction to upload the file by hand.
+test("the create step attaches the pageshot artifact through gh --attach", () => {
+  for (const lang of LANGS) {
+    const doc = skill(lang);
+    assert.match(doc, /--attach "<path>#<title>"/, `${lang}: the screenshot branch passes the artifact and alt text`);
+    assert.match(doc, /--attach "<path>"/, `${lang}: the video branch passes the artifact without alt text`);
+    assert.doesNotMatch(doc, /drag|ドラッグ/, `${lang}: no manual upload instruction remains`);
+    assert.doesNotMatch(pageshot(lang), /manual|手動/, `${lang}: pageshot no longer hands off to a manual step`);
+  }
+});
 
 // The order itself is checked. Matching sets in a swapped order change which template gets used.
 const PRIORITY = [

--- a/skills/use-workflow-pageshot/SKILL.md
+++ b/skills/use-workflow-pageshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: use-workflow-pageshot
-description: Internal helper for /pr. Reads PR body (Preview URL + How to Test), drives agent-browser to capture a screenshot (1 step) or a video (2+ steps), and returns the artifact path for manual attachment on GitHub web UI.
+description: Internal helper for /pr. Reads PR body (Preview URL + How to Test), drives agent-browser to capture a screenshot (1 step) or a video (2+ steps), and returns the artifact path that /pr passes to gh pr create --attach.
 when_to_use: /pr workflow UI変更検出時のスクショ/動画撮影, screenshot capture, video capture
 allowed-tools: Read Bash(agent-browser:*) Bash(ffmpeg:*) Bash(mkdir:*) Bash(date:*)
 model: opus


### PR DESCRIPTION
## What & Why

/pr が UI 変更で撮った pageshot の成果物を、`gh pr create --attach` で PR 本文に添付する。以前は成果物のパスを表示して GitHub の画面へ手でドラッグするよう案内していたので、誰も貼らなければスクリーンショット無しで PR が上がっていた。

## Review focus

- `skills/pr/SKILL.md` の § Pageshot 統合と § 作成の制約。screenshot は `<path>#<title>` で alt text に PR タイトルを、video はパスだけを渡す。upload が一部失敗しても gh は PR を作って URL を stdout に出すので、その場合の案内 (`gh pr edit <number> --attach <path>`) を書いた
- 手元の gh 2.100.0 の `gh pr create --help` / `gh pr edit --help` に `--attach` があり、本文末尾へ追記される、失敗しても PR は作られる、という help の記述と SKILL.md の文が一致することを確認済み

## How to Test

1. `node --test skills/pr/tests/template-priority.test.js` を実行する。11 件が通る。追加したテストは SKILL.md の EN / .ja 両方に `--attach` の 2 形があり、手動アップロードの案内が残っていないことを照合する
2. `gh pr create --help | grep attach` で `--attach file` が出る

https://claude.ai/code/session_0131gkYQQHKGm6yj1sKDfW4G
