### PR TITLE
[scribe] PR 本文の Review focus 節分離の候補行を追加

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -71,6 +71,7 @@
 - 同じ事実を 2 体の agent に聞かない。verifier の report が持つフィールド (head) を使い、再取得の relay を足さない #623
 - prefix 除去の正規表現は正準の列挙 (verify-commit.py の COMMIT_TYPES) と同じ集合に限定する。任意語だと WIP: や RFC: の先頭語が消える #623
 - 手元の gate (oxlint / oxfmt) は Python を見ないので、push 前に CI と同じ版の ruff (0.16.4) を手元で走らせる。E501 だけで CI が落ちた #623
+- PR 本文の Review focus 節で、振る舞いが変わったファイルと comment のみの変更ファイルを分けて示す #648
 
 ## 棄却
 


### PR DESCRIPTION
## 追加/更新したページ

なし。今回抽出したパターンは根拠 1 件のみで、2 件の閾値に届かずページ化はゼロ件。

## 候補追加

- PR 本文の Review focus 節で、振る舞いが変わったファイルと comment のみの変更ファイルを分けて示す (#648)

## 参照コード / 由来の修正

なし。既存全ページの参照コード (ファイル実在 + シンボル grep 一致) と 由来 リンク先 DR (6 件、いずれも status: accepted) を確認したが、破損・supersede は見つからなかった。`kind: structure` の 2 ページ (`workflow-structure.md`, `skills-structure.md`) の境界/契約/要求の各行も現行コード (件数・シンボル) と突き合わせ、すべて一致を確認した。

## スコープ

- PR: #648 (1 件、`merged:>2026-09-02T12:48:10Z`)
- issue: 0 件 (該当なし)
- research file: 0 件 (前回 scribe PR (#624) のマージ後にコミットされたものなし)

## 検証で落とした項目

なし。

## 持ち越し

なし (`昇格待ち` 0 件)。

---

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
