### PR TITLE
fix(gate): run the anchor checks and calibration over the whole output

### DIFF
--- a/.ja/workflows/_lib/gate.ts
+++ b/.ja/workflows/_lib/gate.ts
@@ -478,9 +478,13 @@ export function classifyObservation(
   const command = options.command;
   const { timedOut, executionError, returncode, signalName, stdout, stderr, durationMs } = observed;
 
+  // tail は report の payload。検査は出力全体を読む。呼び出し側は tail を短く保ち、
+  // 落ちた行は suite が出した位置にある。
+  const stdoutText = stdout.toString("utf8");
+  const stderrText = stderr.toString("utf8");
   const stdoutTail = tail(stdout, options.tail_bytes);
   const stderrTail = tail(stderr, options.tail_bytes);
-  const combined = `${stdoutTail}\n${stderrTail}`;
+  const combined = `${stdoutText}\n${stderrText}`;
   const commandPassed = returncode === 0;
   const commandFailed = returncode !== null && returncode > 0;
   const matchesExpectedExit = expect === "pass" ? commandPassed : commandFailed;
@@ -498,7 +502,7 @@ export function classifyObservation(
     checks.push({
       kind: "output_includes",
       value,
-      passed: hasExactOutputLine(stdoutTail, stderrTail, value),
+      passed: hasExactOutputLine(stdoutText, stderrText, value),
     });
   }
   for (const value of options.forbidden_output) {
@@ -545,7 +549,7 @@ export function classifyObservation(
             return [entry.slice(0, separator), entry.slice(separator + 1)];
           })
         : null;
-    candidates = calibrationCandidates(stdoutTail, stderrTail, planned);
+    candidates = calibrationCandidates(stdoutText, stderrText, planned);
     // コマンドが失敗することと、計画したシナリオが失敗することは別である。それを名指す
     // 行が 1 本も無ければ、アンカーを seal する対象が存在しない。
     if (verdict === "pass" && candidates.length === 0) {

--- a/workflows/_lib/gate.ts
+++ b/workflows/_lib/gate.ts
@@ -481,9 +481,13 @@ export function classifyObservation(
   const command = options.command;
   const { timedOut, executionError, returncode, signalName, stdout, stderr, durationMs } = observed;
 
+  // The tails are report payload. Every check reads the whole output, because a caller keeps
+  // the tails short and a failing line sits wherever the suite put it.
+  const stdoutText = stdout.toString("utf8");
+  const stderrText = stderr.toString("utf8");
   const stdoutTail = tail(stdout, options.tail_bytes);
   const stderrTail = tail(stderr, options.tail_bytes);
-  const combined = `${stdoutTail}\n${stderrTail}`;
+  const combined = `${stdoutText}\n${stderrText}`;
   const commandPassed = returncode === 0;
   const commandFailed = returncode !== null && returncode > 0;
   const matchesExpectedExit = expect === "pass" ? commandPassed : commandFailed;
@@ -501,7 +505,7 @@ export function classifyObservation(
     checks.push({
       kind: "output_includes",
       value,
-      passed: hasExactOutputLine(stdoutTail, stderrTail, value),
+      passed: hasExactOutputLine(stdoutText, stderrText, value),
     });
   }
   for (const value of options.forbidden_output) {
@@ -548,7 +552,7 @@ export function classifyObservation(
             return [entry.slice(0, separator), entry.slice(separator + 1)];
           })
         : null;
-    candidates = calibrationCandidates(stdoutTail, stderrTail, planned);
+    candidates = calibrationCandidates(stdoutText, stderrText, planned);
     // The command failing is not the same as the planned scenario failing. With no line
     // naming one, there is nothing an anchor could be sealed on.
     if (verdict === "pass" && candidates.length === 0) {

--- a/workflows/_lib/tests/gate.test.ts
+++ b/workflows/_lib/tests/gate.test.ts
@@ -488,3 +488,45 @@ test("T-034 a trailing unittest verdict counts as a failure marker and a passing
     [fail, error],
   );
 });
+
+// code.js passes --tail-bytes 800, and a suite of a few hundred tests ends with a TAP summary
+// longer than that, so a failing line that only the tail could see is never seen. The anchor
+// checks and the calibration candidates read the whole output; the tails are report payload.
+test("T-035 a failing line older than the tail window is still a calibration candidate and still satisfies --require-output", () => {
+  withTempDir((cwd) => {
+    const command =
+      "printf 'not ok 1 - T-001 x\\n'; for i in $(seq 1 60); do printf 'ok %s - filler line that pushes the failure out of the tail\\n' \"$i\"; done; exit 1";
+    const calibrated = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      command,
+      "--calibrate",
+      "--planned-test",
+      "T-001:x",
+      "--tail-bytes",
+      "200",
+    ]);
+    assert.equal(calibrated.report.verdict, "pass", "calibrate: verdict");
+    assert.deepEqual(
+      (calibrated.report.candidates as { text: string }[]).map((c) => c.text),
+      ["not ok 1 - T-001 x"],
+      "calibrate: the failing line outside the tail is the candidate",
+    );
+
+    const anchored = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      command,
+      "--expect",
+      "fail",
+      "--require-output",
+      "not ok 1 - T-001 x",
+      "--tail-bytes",
+      "200",
+    ]);
+    assert.equal(anchored.status, 0, "anchored: exit code");
+    assert.equal(anchored.report.verdict, "pass", "anchored: verdict");
+  });
+});


### PR DESCRIPTION
## What & Why

build の Red キャリブレーションが 3 回続けて同じ止まり方をしていた (#627 U-004、#626 U-004、#628 U-002、いずれも `calibration_missing_calibration_evidence`)。原因は `workflows/_lib/gate.ts` が `--require-output` / `--forbid-output` の照合と calibration の候補抽出を `--tail-bytes` で切った tail に対して行っていたことで、`workflows/code.js` は report を agent 経由で運ぶために `--tail-bytes 800` を渡す。469 件の suite の末尾 800 byte は TAP の summary だけで、`not ok 321 - T-107 ...` は窓の外にあった。

この PR で gate は出力全体を検査に使い、tail は report の payload だけに残る。seam unit が Red で止まらなくなる。

## Review focus

- `workflows/_lib/gate.ts` の `stdoutText` / `stderrText`: Buffer を 1 度 utf8 で decode して 3 つの検査に渡す。`tail()` は evidence の `stdout_tail` / `stderr_tail` だけが読む
- `.ja/workflows/_lib/gate.ts` は comment だけ日本語で本体は同一 (`ja-ts-parity.test.js` が照合)

## How to Test

1. `node --test --test-reporter=tap workflows/_lib/tests/gate.test.ts` で T-035 が pass する。修正前 (main) では `not ok 21 - T-035` になる
2. `npx tsc && node --test --test-reporter=tap "workflows/**/tests/*.test.js" "workflows/**/tests/*.test.ts"` で 466 件 pass

## Follow-up

マージ後に #628 の build を main から再実行する。partial branch `refactor/628-workflow-typescript-migration` (U-001 fixture と U-002 scaffold の 2 commit) は破棄する。

https://claude.ai/code/session_0124rGJ4dkNsDW9jHdxYsQEF
