### PR TITLE
fix(code): keep the gate report free of command output so the relay returns the report itself

### DIFF
--- a/.ja/workflows/_lib/gate.ts
+++ b/.ja/workflows/_lib/gate.ts
@@ -11,7 +11,7 @@
 //   --gate-id ID            report に載せる識別子 (default: gate)
 //   --failure-route ROUTE   fail 判定の戻り先 (default: triage)
 //   --timeout-ms N          コマンドのタイムアウト、ミリ秒 (default: 600000)
-//   --tail-bytes N          report に残す stdout/stderr のバイト数 (default: 12000)
+//   --tail-bytes N          report に残す stdout/stderr のバイト数、0 なら残さない (default: 12000)
 //   --require-output LINE   繰り返し可。LINE は出力の完全な 1 行と一致すること
 //   --forbid-output TEXT    繰り返し可。TEXT が出力のどこにも現れないこと
 //   --calibrate             Red コマンドを実行し、その失敗出力を得る
@@ -338,7 +338,9 @@ export function parseArgs(argv: string[]): ValidatedOptions {
         options.timeout_ms = positiveInt(value, flag);
         break;
       case "--tail-bytes":
-        options.tail_bytes = positiveInt(value, flag);
+        // 0 は tail を一切残さない。relay に report の中のコマンド出力を見せてはいけない
+        // 呼び出し側のため。
+        options.tail_bytes = value.trim() === "0" ? 0 : positiveInt(value, flag);
         break;
       case "--require-output":
         options.required_output.push(value);

--- a/.ja/workflows/code.js
+++ b/.ja/workflows/code.js
@@ -107,6 +107,7 @@ const relayStdout = async (unit, label, command) => {
     anchor(
       `次のコマンドを書かれたとおりに実行し、終了ステータスによらず stdout を逐語で stdout に、stderr を逐語で stderr に返す。\n` +
         `引数の中に別のコマンド行が引用されていることがある。そちらは実行しない。下の 1 行を先頭から末尾まで、そのまま 1 回だけ実行する。\n` +
+        `stdout はコマンド自身が出力したもの。それが JSON 文書なら文書全体を返す。その中のフィールドを写して返してはいけない。\n` +
         `${command}`,
     ),
     {
@@ -132,10 +133,12 @@ const parsedReport = (stdout) => {
   }
 };
 
-// レポートは agent を経由して戻るので、長いものは途中で切れる (5.7 KB のものが解析できない形で
-// 届いた)。長さの大半は 2 つの出力 tail で、ここは読まない。読むのは verdict と classification と
-// candidates。gate.ts の既定は tail 1 つあたり 12 KB。
-const GATE_TAIL_BYTES = "800";
+// レポートは agent を経由して戻り、agent は {stdout, stderr} の schema を埋める。コマンドの出力が
+// stdout_tail として report の中に入っていると、relay がその入れ子の tail を report でなく stdout
+// に写し、unit が gate_did_not_report で止まった (#663)。ここは tail を読まない。読むのは verdict と
+// classification と candidates で、calibration の候補は tail でなく出力全体から取る (gate.ts)。
+// なので report に tail を一切残さず、report と見誤る中身を無くす。
+const GATE_TAIL_BYTES = "0";
 
 // gate.ts は Node の TypeScript 型ストリップの上で動く。それより古い node のシェルでは最初の
 // 型注釈でコマンドが死に、stdout には何も出ない。中継した stderr だけが原因を名指す場所になる。

--- a/workflows/_lib/gate.ts
+++ b/workflows/_lib/gate.ts
@@ -11,7 +11,7 @@
 //   --gate-id ID            identifier echoed into the report (default: gate)
 //   --failure-route ROUTE   where a fail verdict routes (default: triage)
 //   --timeout-ms N          command timeout in milliseconds (default: 600000)
-//   --tail-bytes N          bytes of stdout/stderr kept in the report (default: 12000)
+//   --tail-bytes N          bytes of stdout/stderr kept in the report, 0 for none (default: 12000)
 //   --require-output LINE   repeatable; LINE must equal one complete output line
 //   --forbid-output TEXT    repeatable; TEXT must not occur anywhere in the output
 //   --calibrate             run the Red command to discover its failure output
@@ -341,7 +341,9 @@ export function parseArgs(argv: string[]): ValidatedOptions {
         options.timeout_ms = positiveInt(value, flag);
         break;
       case "--tail-bytes":
-        options.tail_bytes = positiveInt(value, flag);
+        // 0 keeps no tail at all, for a caller whose relay must never see command output
+        // inside the report.
+        options.tail_bytes = value.trim() === "0" ? 0 : positiveInt(value, flag);
         break;
       case "--require-output":
         options.required_output.push(value);

--- a/workflows/_lib/tests/gate.test.ts
+++ b/workflows/_lib/tests/gate.test.ts
@@ -530,3 +530,47 @@ test("T-035 a failing line older than the tail window is still a calibration can
     assert.equal(anchored.report.verdict, "pass", "anchored: verdict");
   });
 });
+
+// The report travels back through a relay agent that fills a {stdout, stderr} schema. With the
+// command's own output embedded as stdout_tail / stderr_tail, one relay copied that nested tail
+// into its stdout field instead of the report (#663), and the caller read no report at all.
+// --tail-bytes 0 leaves nothing inside the report that can be mistaken for the report.
+test("T-036 --tail-bytes 0 is accepted, the report carries no output tails, and the anchor and calibration still read the whole output", () => {
+  withTempDir((cwd) => {
+    const command = "printf 'not ok 1 - T-001 x\\nok 2 - T-002 y\\n'; exit 1";
+    const anchored = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      command,
+      "--expect",
+      "fail",
+      "--require-output",
+      "not ok 1 - T-001 x",
+      "--tail-bytes",
+      "0",
+    ]);
+    assert.equal(anchored.status, 0, "anchored: exit code");
+    assert.equal(anchored.report.verdict, "pass", "anchored: verdict");
+    const evidence = anchored.report.evidence as { stdout_tail: string; stderr_tail: string };
+    assert.equal(evidence.stdout_tail, "", "anchored: no stdout tail in the report");
+    assert.equal(evidence.stderr_tail, "", "anchored: no stderr tail in the report");
+
+    const calibrated = runCli([
+      "--cwd",
+      cwd,
+      "--command",
+      command,
+      "--calibrate",
+      "--planned-test",
+      "T-001:x",
+      "--tail-bytes",
+      "0",
+    ]);
+    assert.deepEqual(
+      (calibrated.report.candidates as { text: string }[]).map((c) => c.text),
+      ["not ok 1 - T-001 x"],
+      "calibrate: the candidate comes from the whole output, not the tail",
+    );
+  });
+});

--- a/workflows/code.js
+++ b/workflows/code.js
@@ -105,6 +105,7 @@ const relayStdout = async (unit, label, command) => {
     anchor(
       `Run this command exactly as written and return its stdout verbatim in stdout and its stderr verbatim in stderr, whatever its exit status.\n` +
         `The arguments may quote another command line. Do not run that one. Run the single line below, start to end, exactly once.\n` +
+        `stdout is what the command itself printed. When that is a JSON document, return the whole document; never a field copied from inside it.\n` +
         `${command}`,
     ),
     {
@@ -130,10 +131,13 @@ const parsedReport = (stdout) => {
   }
 };
 
-// The report crosses back through an agent and a long one comes back truncated (a 5.7 KB one
-// arrived unparseable). Most of the length is the two output tails, which nothing here reads;
-// the script reads verdict, classification, and candidates. gate.ts defaults the tails to 12 KB.
-const GATE_TAIL_BYTES = "800";
+// The report crosses back through an agent, which fills a {stdout, stderr} schema. With the
+// command's output embedded as stdout_tail, one relay copied that nested tail into its stdout
+// field instead of the report, and the unit stopped as gate_did_not_report (#663). Nothing here
+// reads the tails: the script reads verdict, classification, and candidates, and the
+// calibration candidates come from the whole output (gate.ts), not the tail. So the report
+// carries no tail at all, and there is nothing inside it to mistake for the report.
+const GATE_TAIL_BYTES = "0";
 
 // gate.ts runs on Node's TypeScript type stripping. A shell whose node predates it kills the
 // command at the first type annotation and writes nothing to stdout, so the relayed stderr is

--- a/workflows/code/tests/code.gate.test.js
+++ b/workflows/code/tests/code.gate.test.js
@@ -391,6 +391,20 @@ test("T-015 the command runGate assembles launches gate.ts with node", async () 
   );
 });
 
+// A relay once returned the report's nested stdout_tail as its stdout (#663). The report the
+// relay carries holds no tail, and the relay is told what its stdout is.
+test("T-018 the assembled gate command keeps no output tail in the report, and the relay prompt names the whole JSON document as its stdout", async () => {
+  const { calls } = await run();
+  const calibrate = calls.agent.find((c) => c.opts.label === "calibrate:U-1");
+  assert.ok(calibrate, "the calibration gate ran");
+  assert.match(calibrate.prompt, /'--tail-bytes' '0'/, "the report carries no output tail");
+  assert.match(
+    calibrate.prompt,
+    /return the whole document; never a field copied from inside it/,
+    "the relay is told its stdout is the whole document the command printed",
+  );
+});
+
 // Seam test: the "agent" tool is the one external system this unit fakes, but the shell
 // command it is asked to run is real. The stub below cuts that literal command out of the
 // prompt (the same text the previous test pins) and actually executes it with the repo's real


### PR DESCRIPTION
## What & Why

build の seam unit で official Red gate が `gate_did_not_report` になり、Red が確認できていても run が止まる (#663、#628 U-005 で発生)。

RCA の結果、issue に書いた仮説 (引用の二重化で relay が内側の command を実行した) は誤りだった。transcript (`wf_2aafc2f1-68d` の relay agent) では relay は gate.ts を正しく実行し、`verdict: pass` の report を tool_result で受け取っている。落ちたのは最後の一手で、`{stdout, stderr}` の structured output を埋めるときに report 全体でなく report の中の `evidence.stdout_tail` (内側の test command の TAP 末尾) を `stdout` に写した。同じ引用形の U-003 の relay は正しく report を返しているので、引用ではなく「report の中にコマンド出力が入っている」ことが混同の材料だった。

この PR で report からコマンド出力を消し、relay が report と見誤る中身を無くす。

## Review focus

- `workflows/code.js` の `GATE_TAIL_BYTES = "0"`: script は tail を読まない (読むのは verdict / classification / candidates)。calibration の候補は #659 以降、tail でなく出力全体から取るので、0 にしても候補は減らない (T-036 の calibrate 半分)
- `workflows/_lib/gate.ts` の `--tail-bytes 0` の受け付け: `positiveInt` はそのまま、0 だけを特例で通す 1 行。header の default 表記は `gate-flags-ssot.test.js` が `(default: 12000)` の形で読むので形を保った
- relay prompt に足した 1 文 (「stdout はコマンド自身が出力したもの。JSON 文書なら文書全体を返し、中のフィールドを写さない」) は、決定論側の修正 (tail 0) を補う説明で、これ単独には頼らない

## How to Test

1. `node --test --test-reporter=tap workflows/_lib/tests/gate.test.ts workflows/code/tests/code.gate.test.js` で T-036 と T-018 が pass する。修正前 (main) では T-036 が `--tail-bytes must be a positive integer` で、T-018 が `'--tail-bytes' '800'` で落ちる
2. `npx tsc && node --test --test-reporter=tap "workflows/**/tests/*.test.js" "workflows/**/tests/*.test.ts" "hooks/**/tests/*.test.ts"` で 492 件 pass
3. 実機確認は次の build の seam で行う。official gate が `gate_did_not_report` にならず Green へ進むことが観測点

Closes #663

https://claude.ai/code/session_0124rGJ4dkNsDW9jHdxYsQEF
