### PR TITLE
[scribe] gate レポートを中継する relay が読まないフィールドは既定サイズを絞る を追加/更新

### DIFF
--- a/docs/wiki/_candidates.md
+++ b/docs/wiki/_candidates.md
@@ -62,7 +62,6 @@
 - tests を持つ unit は plan の files に、そのテストが動かすモジュールを含める。Red が触れるのは files にあるものだけなので、files 外を import するテストは Red を確立できない #600
 - plan 文の Markdown 整形は日本語中の ASCII 数字前後に空白を入れるため、テスト名照合は空白の連なりの有無を許容しないと候補を取りこぼす #609
 - unittest.main(verbosity=2) の verbose reporter は判定 (FAIL/ERROR) を行末に置くため、行頭マーカーのみを見る失敗検出は Python スイートの失敗を常に取りこぼす #609
-- gate レポートの中継はシェル→agent 経由で確率的に途中で切れるため、呼び出し側が読まない stdout_tail 等のフィールドは既定サイズを呼び出し元で絞る #614
 - skills 配下の Python を TypeScript へ移すとき、.github/workflows/test.yml の Node tests step は glob を手動で足さないと拾わない。Python 側は find なので .py を消せば自動で外れるが、.ts を足しても自動では入らない #615
 - exit 0 の hook の stdout print は単独では届かず hook_payload の notify (systemMessage/additionalContext) 経由が要る #618
 - settings.json で matcher 共通 command が if だけ Write/Edit に分かれる複数登録は重複でない #618

--- a/docs/wiki/gate-report-unread-field-size.md
+++ b/docs/wiki/gate-report-unread-field-size.md
@@ -1,0 +1,26 @@
+---
+globs: ["workflows/code.js", "workflows/_lib/gate.ts"]
+scenes: ["implement"]
+---
+
+# gate レポートを中継する relay が読まないフィールドは既定サイズを絞る
+
+## 内容
+
+gate のレポートはシェル→agent の relay を経由して戻る。呼び出し側 script が読まないフィールド (`stdout_tail`/`stderr_tail` 等) を既定で大きく残すと、中継が確率的に途中で切れて JSON が壊れる事故と、relay がレポート全体でなくその中の tail フィールドをそのまま返してしまう事故の両方が起きる。呼び出し側が読まないフィールドは、残す積極的な理由 (人間が run log を読む手掛かり等) がない限り既定サイズを絞る。
+
+## 定型手順
+
+1. relay を経由して呼び出し側へ返るレポートの各フィールドについて、呼び出し側の script が実際に読むかを確認する
+2. 読まないフィールドの既定サイズは、残す理由が無い限り最小 (0) にする
+3. サイズを 0 より大きく残す場合は、その理由をコメントに明記し、中継の確率的切断や取り違えのリスクを許容している旨を残す
+
+## 参照コード
+
+- `workflows/code.js` の `GATE_TAIL_BYTES`（`stdout_tail`/`stderr_tail` を既定で 0 にし、relay が report と取り違える中身自体を無くす）
+- `workflows/_lib/gate.ts` の `stdout_tail`/`stderr_tail`（呼び出し側の script は `verdict`/`classification`/`candidates` しか読まない）
+
+## 根拠
+
+- #614 gate レポートの中継はシェル→agent 経由で確率的に途中で切れるため、呼び出し側が読まない tail の既定サイズを 12000 から 800 に絞った
+- #664 relay agent が report 全体でなく中の `stdout_tail` をそのまま `stdout` に写し `gate_did_not_report` で止まった。tail の既定サイズを 0 にして取り違える中身自体を無くした


### PR DESCRIPTION
## 追加/更新したページ

- コミット [docs(wiki): gate レポートを中継する relay が読まないフィールドは既定サイズを絞る を追加/更新]
  - `docs/wiki/gate-report-unread-field-size.md`（新規、`_candidates.md` から昇格）

## 候補追加

なし

## 参照/由来の修復

なし（`docs/wiki/*.md` 全ページの参照コード・由来リンクを Phase 4/5 でスイープし、破損なしを確認）

## 検証で落ちた項目

なし

## 読んだ範囲

- PR: #664（前回 scribe PR #660 の mergedAt 2026-09-07T16:56:12Z 以降にマージされた分、`-label:scribe` で1件）
- issue: #663（同期間に closed、1件）
- research: 0 件（`.claude/workspace/research/*.md` に該当する追加/更新なし）

## 積み残し

なし（`_candidates.md` の昇格待ちは今回発生せず）