### PR TITLE
[Chore] record.ts の型を後続スライスが写す前に stdin-JSON CLI と fixture 再生と retirement 走査を共有 helper に寄せる

### DIFF
--- a/.ja/workflows/_lib/cli.ts
+++ b/.ja/workflows/_lib/cli.ts
@@ -1,0 +1,67 @@
+/// <reference types="node" />
+// history を記録する CLI (workflows/build/record.ts、workflows/assert/record.ts) が共有する、
+// stdin payload の parse/guard の組と history-path/timestamp の helper。それぞれの script は
+// この流れを自前でコピーして持っていた。この module はそれに 1 つの置き場所を与える。
+// workflows/_lib/entry-point.ts と同じ形 (小さく、独立してテストでき、named export) で。
+//
+// parsePayload は生の stdin テキストを受け取り、parse できた object か、呼び出し側が stderr に
+// 書き込む message のどちらかを返す -- stdin や stderr そのものには一切触れない。fd 0 を読み、
+// parsePayload を呼び、失敗時に stderr へ message を書く薄い関数は、この CLI が後続の unit で
+// この module に移植されたときに workflows/build/record.ts の `main` が呼ぶ wrapper になる。
+// ここではまだ export していない。ここから import する側が無いためで、import されない export は
+// このリポジトリが書き込み時に強制する knip の失敗になる。
+//
+// historyPath は `home` を process.env.HOME や node:os から読む代わりに明示引数として受け取る。
+// そうすることでテスト (や U-006 のような harness) が process.env.HOME に触れずに temp
+// directory を指せる。CLI 側は `homedir()` をここに渡す。
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** stdin payload を parse した結果: 成功なら object、失敗なら呼び出し側が stderr に書く
+ * message を null と組で返す。2 つのうちどちらか一方だけが non-null になる。 */
+export interface PayloadResult {
+  payload: Record<string, unknown> | null;
+  message: string | null;
+}
+
+/** `text` を JSON object として parse する。workflows/build/record.ts の `main` が置き換え元の
+ * Python recorder から移植した 2 つの検査をそのまま踏襲する: parse できないテキスト、次に
+ * parse はできるが plain object でない値 (array, スカラー, null)。message の文言と接頭辞は
+ * Python 版 recorder のものと一致させ、この module へ切り替える呼び出し側の stderr 契約を
+ * 変えない。
+ *
+ * hooks/_lib/hook_payload.ts の `parse` はここでは再利用しない: あちらは `{}` へ fail open する
+ * ため、壊れた payload が exit 1 で何も書かないこの CLI の呼び出し側の挙動ではなく、
+ * 静かに空の行になってしまう。 */
+export function parsePayload(text: string): PayloadResult {
+  let loaded: unknown;
+  try {
+    loaded = JSON.parse(text);
+  } catch (error) {
+    return {
+      payload: null,
+      message: `Error: unparseable payload: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  if (typeof loaded !== "object" || loaded === null || Array.isArray(loaded)) {
+    return { payload: null, message: "Error: payload must be a JSON object" };
+  }
+  return { payload: loaded as Record<string, unknown>, message: null };
+}
+
+/** `home` の下で `name` という名前の history file が置かれる path。含む directory が
+ * 存在することを保証する。`home` は `homedir()` や `process.env.HOME` を読む代わりに明示引数と
+ * して渡す。そうすることで呼び出し側 (テスト、あるいは U-006 の harness) が process state に
+ * 触れずに temp directory を指せる。CLI 自身の entry point は `homedir()` を渡す。 */
+export function historyPath(home: string, name: string): string {
+  const dir = join(home, ".claude", "history");
+  mkdirSync(dir, { recursive: true });
+  return join(dir, name);
+}
+
+/** `date` を秒精度 (ミリ秒なし) の UTC ISO-8601 timestamp にする。既定値は現在時刻で、
+ * workflows/build/record.ts と workflows/assert/record.ts の両方が書く `generated_at`
+ * フィールドと一致する。 */
+export function isoTimestamp(date: Date = new Date()): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}

--- a/.ja/workflows/assert/record.ts
+++ b/.ja/workflows/assert/record.ts
@@ -16,35 +16,24 @@
 // 置き換え元の Python 版 assert recorder の TypeScript 移植。Contract: この CLI 自身の挙動。
 // workflows/assert/tests/record.test.ts が、固定 fixture workflows/assert/tests/fixtures/record-cases.json
 // に対してエンドツーエンドで検査する。
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { historyPath, isoTimestamp, parsePayload } from "../_lib/cli.ts";
 import { isMainModule } from "../_lib/entry-point.ts";
 
 export function main(): number {
   const raw = readFileSync(0, "utf8");
-  let loaded: unknown;
-  try {
-    loaded = JSON.parse(raw);
-  } catch (error) {
-    process.stderr.write(
-      `Error: unparseable payload: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
+  const { payload, message } = parsePayload(raw);
+  if (payload === null) {
+    process.stderr.write(`${message}\n`);
     return 1;
   }
-  if (typeof loaded !== "object" || loaded === null || Array.isArray(loaded)) {
-    process.stderr.write("Error: payload must be a JSON object\n");
-    return 1;
-  }
-  const payload = loaded as Record<string, unknown>;
 
-  const historyDir = join(homedir(), ".claude", "history");
-  const runsPath = join(historyDir, "assert-runs.jsonl");
-  mkdirSync(historyDir, { recursive: true });
+  const runsPath = historyPath(homedir(), "assert-runs.jsonl");
 
   const row: Record<string, unknown> = {
     ...payload,
-    generated_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    generated_at: isoTimestamp(),
   };
   appendFileSync(runsPath, `${JSON.stringify(row)}\n`);
 

--- a/.ja/workflows/build/record.ts
+++ b/.ja/workflows/build/record.ts
@@ -30,10 +30,10 @@
 // 置き換え元の Python 版 build recorder の TypeScript 移植。Contract: この CLI 自身の挙動。
 // workflows/build/tests/record.test.ts が、固定 fixture workflows/build/tests/fixtures/record-cases.json
 // に対してエンドツーエンドで検査する。
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { historyPath, isoTimestamp, parsePayload } from "../_lib/cli.ts";
 import { isMainModule } from "../_lib/entry-point.ts";
 
 // Plan-quality の stop は全履歴ではなく直近の build の連なりに固まって出るため、count は
@@ -121,20 +121,11 @@ export function countPlanQualityStops(path: string): WindowCounts | null {
 
 export function main(): number {
   const raw = readFileSync(0, "utf8");
-  let loaded: unknown;
-  try {
-    loaded = JSON.parse(raw);
-  } catch (error) {
-    process.stderr.write(
-      `Error: unparseable payload: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
+  const { payload, message } = parsePayload(raw);
+  if (payload === null) {
+    process.stderr.write(`${message}\n`);
     return 1;
   }
-  if (typeof loaded !== "object" || loaded === null || Array.isArray(loaded)) {
-    process.stderr.write("Error: payload must be a JSON object\n");
-    return 1;
-  }
-  const payload = loaded as Record<string, unknown>;
 
   const { run_id: suppliedRunId, ...rest } = payload;
   // build は同じ秒内に start と stop を起こせるので timestamp では 2 つを分けられない。stop 行を
@@ -145,15 +136,13 @@ export function main(): number {
       ? suppliedRunId
       : randomUUID().replace(/-/g, "");
 
-  const historyDir = join(homedir(), ".claude", "history");
-  const runsPath = join(historyDir, "build-runs.jsonl");
-  mkdirSync(historyDir, { recursive: true });
+  const runsPath = historyPath(homedir(), "build-runs.jsonl");
 
   const row: Record<string, unknown> = {
     run_id: runId,
     ...DEFAULTS,
     ...rest,
-    generated_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    generated_at: isoTimestamp(),
   };
   appendFileSync(runsPath, `${JSON.stringify(row)}\n`);
 

--- a/workflows/_lib/cli.ts
+++ b/workflows/_lib/cli.ts
@@ -1,0 +1,66 @@
+/// <reference types="node" />
+// The stdin-payload parse/guard pair and the history-path/timestamp helpers shared by the
+// history-recording CLIs (workflows/build/record.ts, workflows/assert/record.ts). Each of
+// those scripts wrote its own copy of this flow; this module gives it one home, in the same
+// shape as workflows/_lib/entry-point.ts (small, independently testable, named exports).
+//
+// parsePayload takes the raw stdin text and returns either the parsed object or the message
+// the caller writes to stderr -- it never touches stdin or stderr itself. The thin function
+// that reads fd 0, calls parsePayload, and writes the message to stderr on failure is the
+// wrapper workflows/build/record.ts's `main` will call once that CLI is ported onto this
+// module in a later unit; it is not exported yet because nothing here imports it, and an
+// unimported export is a knip failure this repository enforces on write.
+//
+// historyPath takes `home` as an explicit argument rather than reading it from
+// process.env.HOME or node:os itself, so a test (or a harness like U-006's) can point it at a
+// temp directory without touching process.env.HOME. The CLI side passes `homedir()` in.
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+/** The outcome of parsing a stdin payload: the object on success, or null with the message
+ * the caller writes to stderr on failure. Exactly one of the two is non-null. */
+export interface PayloadResult {
+  payload: Record<string, unknown> | null;
+  message: string | null;
+}
+
+/** Parse `text` as a JSON object. Mirrors the two checks workflows/build/record.ts's `main`
+ * ported from the Python recorder it replaces: unparseable text, then a value that parses but
+ * is not a plain object (an array, a scalar, or null). The message text and prefix match the
+ * Python recorder's so a caller switching to this module changes no stderr contract.
+ *
+ * hooks/_lib/hook_payload.ts's `parse` is not reused here: it fails open to `{}`, which would
+ * turn a malformed payload into a silently-empty row instead of the exit-1-and-write-nothing
+ * behavior this CLI's callers require. */
+export function parsePayload(text: string): PayloadResult {
+  let loaded: unknown;
+  try {
+    loaded = JSON.parse(text);
+  } catch (error) {
+    return {
+      payload: null,
+      message: `Error: unparseable payload: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  if (typeof loaded !== "object" || loaded === null || Array.isArray(loaded)) {
+    return { payload: null, message: "Error: payload must be a JSON object" };
+  }
+  return { payload: loaded as Record<string, unknown>, message: null };
+}
+
+/** The path a history file named `name` lives at under `home`, ensuring the containing
+ * directory exists. `home` is an explicit argument rather than a read of `homedir()` or
+ * `process.env.HOME`, so a caller (a test, or U-006's harness) can point it at a temp
+ * directory without touching process state; the CLI's own entry point passes `homedir()`. */
+export function historyPath(home: string, name: string): string {
+  const dir = join(home, ".claude", "history");
+  mkdirSync(dir, { recursive: true });
+  return join(dir, name);
+}
+
+/** `date` as a UTC ISO-8601 timestamp with second precision (no milliseconds). Defaults to
+ * the current time, matching the `generated_at` field workflows/build/record.ts and
+ * workflows/assert/record.ts both write. */
+export function isoTimestamp(date: Date = new Date()): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}

--- a/workflows/_lib/tests/_cli-fixture.ts
+++ b/workflows/_lib/tests/_cli-fixture.ts
@@ -1,8 +1,8 @@
 /// <reference types="node" />
-// Shared by workflows/build/tests/record.test.ts and workflows/assert/tests/record.test.ts --
-// and, from a later unit, an argv-based CLI fixture such as #631's validate-issue-body -- all
-// of which need to launch a CLI under a temp HOME, replay a frozen fixture case (stdin in,
-// exit code and stdout out), and compare the result against the frozen case with certain
+// Shared by workflows/build/tests/record.test.ts and workflows/assert/tests/record.test.ts,
+// and open to an argv-based CLI fixture such as #631's validate-issue-body: each needs to
+// launch a CLI under a temp HOME, replay a frozen fixture case (argv and stdin in, exit code
+// and stdout out), and compare the result against the frozen case with certain
 // values (a minted uuid, a resolved history path) checked by shape instead of exact value.
 // This module gives that replay one home, in the same shape as
 // workflows/_lib/tests/_brace.ts (small, independently testable, named exports; no .ja
@@ -35,11 +35,12 @@ import { join } from "node:path";
 import { historyPath } from "../cli.ts";
 export { historyPath };
 
-/** One frozen replay case: stdin in, exit code and stdout out. seed_lines and rows are
- * optional -- only a history-backed CLI seeds a file before the run and checks appended rows
- * after it. */
+/** One frozen replay case: argv and stdin in, exit code and stdout out. argv is optional for
+ * a stdin-only CLI; seed_lines and rows are optional -- only a history-backed CLI seeds a file
+ * before the run and checks appended rows after it. */
 export interface FixtureCase {
   name: string;
+  argv?: string[];
   seed_lines?: string[];
   stdin: string;
   exit: number;
@@ -53,10 +54,15 @@ export interface CliRun {
   stderr: string;
 }
 
-/** Run `scriptPath` under a temp HOME, feeding `stdin`, with PATH cleared so the CLI cannot
- * lean on anything found via the ambient PATH. */
-export function runCli(scriptPath: string, home: string, stdin: string): CliRun {
-  const result = spawnSync(process.execPath, [scriptPath], {
+/** Run `scriptPath` with `argv` under a temp HOME, feeding `stdin`, with PATH cleared so the
+ * CLI cannot lean on anything found via the ambient PATH. */
+export function runCli(
+  scriptPath: string,
+  home: string,
+  stdin: string,
+  argv: readonly string[] = [],
+): CliRun {
+  const result = spawnSync(process.execPath, [scriptPath, ...argv], {
     input: stdin,
     encoding: "utf8",
     env: { ...process.env, HOME: home, PATH: "" },

--- a/workflows/_lib/tests/_cli-fixture.ts
+++ b/workflows/_lib/tests/_cli-fixture.ts
@@ -1,0 +1,173 @@
+/// <reference types="node" />
+// Shared by workflows/build/tests/record.test.ts and workflows/assert/tests/record.test.ts --
+// and, from a later unit, an argv-based CLI fixture such as #631's validate-issue-body -- all
+// of which need to launch a CLI under a temp HOME, replay a frozen fixture case (stdin in,
+// exit code and stdout out), and compare the result against the frozen case with certain
+// values (a minted uuid, a resolved history path) checked by shape instead of exact value.
+// This module gives that replay one home, in the same shape as
+// workflows/_lib/tests/_brace.ts (small, independently testable, named exports; no .ja
+// mirror, per rules/conventions/MIRROR.md -- tests stay English-only).
+//
+// Two layers:
+//   - CLI-replay core (record-agnostic): FixtureCase, CliRun, runCli, withTempHome,
+//     assertRowShape, assertStdoutShape, fixture. FixtureCase's seed_lines and rows are
+//     optional -- only a history-backed CLI seeds a file before the run and checks appended
+//     rows after it; an argv CLI with no file of its own supplies neither.
+//   - record layer, on top of the core: historyPath, seedHistory, readLines, assertRowLine.
+//     Adds the $HOME/.claude/history/<name>.jsonl concept the build and assert recorders
+//     share. historyPath calls workflows/_lib/cli.ts's historyPath(home, name) -- the same
+//     function the CLIs under test call -- rather than hand-joining ".claude"/"history" a
+//     second time the way workflows/build/tests/record.test.ts and
+//     workflows/assert/tests/record.test.ts each used to.
+//
+// T-123 and T-124 exercise the shape-aware comparison below (key-order check, placeholder
+// resolution) directly against workflows/build/record.ts; workflows/build/tests/record.test.ts
+// and workflows/assert/tests/record.test.ts exercise it again, end to end, through their own
+// fixtures.
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { historyPath as cliHistoryPath } from "../cli.ts";
+
+/** One frozen replay case: stdin in, exit code and stdout out. seed_lines and rows are
+ * optional -- only a history-backed CLI seeds a file before the run and checks appended rows
+ * after it. */
+export interface FixtureCase {
+  name: string;
+  seed_lines?: string[];
+  stdin: string;
+  exit: number;
+  stdout: string;
+  rows?: Array<Record<string, unknown> | string>;
+}
+
+export interface CliRun {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Run `scriptPath` under a temp HOME, feeding `stdin`, with PATH cleared so the CLI cannot
+ * lean on anything found via the ambient PATH. */
+export function runCli(scriptPath: string, home: string, stdin: string): CliRun {
+  const result = spawnSync(process.execPath, [scriptPath], {
+    input: stdin,
+    encoding: "utf8",
+    env: { ...process.env, HOME: home, PATH: "" },
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+/** Runs `fn` against a freshly created temp directory used as HOME, removing it afterward
+ * whether `fn` returns or throws. */
+export function withTempHome<T>(fn: (home: string) => T): T {
+  const home = mkdtempSync(join(tmpdir(), "cli-fixture-test-"));
+  try {
+    return fn(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+/** Asserts `actual` carries the same keys, in the same order, as `expected`, and that each
+ * value matches -- exactly, except a value naming one of `shapeChecks` is checked by regex
+ * instead, for a field minted fresh on every run (a uuid, a timestamp). */
+export function assertRowShape(
+  actual: Record<string, unknown>,
+  expected: Record<string, unknown>,
+  shapeChecks: Record<string, RegExp>,
+  label: string,
+): void {
+  assert.deepEqual(Object.keys(actual), Object.keys(expected), `${label}: key order`);
+  for (const [key, expectedValue] of Object.entries(expected)) {
+    const shape = typeof expectedValue === "string" ? shapeChecks[expectedValue] : undefined;
+    if (shape) {
+      assert.match(String(actual[key]), shape, `${label}.${key}: shape`);
+    } else {
+      assert.deepEqual(actual[key], expectedValue, `${label}.${key}: value`);
+    }
+  }
+}
+
+/** The fixture's stdout is a single JSON line (or "" for an exit-nonzero case), compared the
+ * same shape-aware way as a row. A value in `expected` that names a key of `placeholders` is
+ * resolved to that real value first (e.g. "<history-path>" to this run's own history path)
+ * before the shape-aware comparison runs. */
+export function assertStdoutShape(
+  actualStdout: string,
+  expectedStdout: string,
+  placeholders: Record<string, string>,
+  shapeChecks: Record<string, RegExp>,
+  label: string,
+): void {
+  if (expectedStdout === "") {
+    assert.equal(actualStdout, "", `${label}: stdout`);
+    return;
+  }
+  assert.equal(actualStdout.endsWith("\n"), true, `${label}: stdout ends with a newline`);
+  const expected = JSON.parse(expectedStdout) as Record<string, unknown>;
+  for (const [key, value] of Object.entries(expected)) {
+    if (typeof value === "string" && value in placeholders) {
+      expected[key] = placeholders[value];
+    }
+  }
+  assertRowShape(
+    JSON.parse(actualStdout) as Record<string, unknown>,
+    expected,
+    shapeChecks,
+    `${label}: stdout`,
+  );
+}
+
+/** The fixture case named `name` in `fixtures`. */
+export function fixture(fixtures: readonly FixtureCase[], name: string): FixtureCase {
+  const found = fixtures.find((entry) => entry.name === name);
+  assert.ok(found, `fixture case ${name} exists in the loaded fixtures`);
+  return found as FixtureCase;
+}
+
+/** The path a history file named `name` lives at under `home`. Delegates to
+ * workflows/_lib/cli.ts's historyPath -- the same function the CLI under test calls -- so a
+ * test never hand-joins ".claude"/"history" a second time. */
+export function historyPath(home: string, name: string): string {
+  return cliHistoryPath(home, name);
+}
+
+/** Writes `lines` (each newline-terminated) to the history file named `name` under `home`,
+ * returning its path. */
+export function seedHistory(home: string, name: string, lines: readonly string[]): string {
+  const path = historyPath(home, name);
+  writeFileSync(path, lines.map((line) => `${line}\n`).join(""));
+  return path;
+}
+
+/** Every non-blank line of the file at `path`, or an empty array when it does not exist. */
+export function readLines(path: string): string[] {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split("\n")
+    .filter((line) => line.trim() !== "");
+}
+
+/** One appended row, compared against the fixture's row: a raw seed line the fixture kept as
+ * an un-reparsed string compares literally, everything else parses as JSON first and goes
+ * through assertRowShape. */
+export function assertRowLine(
+  actualLine: string,
+  expectedRow: Record<string, unknown> | string,
+  shapeChecks: Record<string, RegExp>,
+  label: string,
+): void {
+  if (typeof expectedRow === "string") {
+    assert.equal(actualLine, expectedRow, `${label}: raw line`);
+    return;
+  }
+  assertRowShape(
+    JSON.parse(actualLine) as Record<string, unknown>,
+    expectedRow,
+    shapeChecks,
+    label,
+  );
+}

--- a/workflows/_lib/tests/_cli-fixture.ts
+++ b/workflows/_lib/tests/_cli-fixture.ts
@@ -29,7 +29,11 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { historyPath as cliHistoryPath } from "../cli.ts";
+// Re-exported so a caller (a test, or seedHistory/readLines below) reaches the same function
+// the CLI under test calls through this fixture module, without hand-joining
+// ".claude"/"history" a second time.
+import { historyPath } from "../cli.ts";
+export { historyPath };
 
 /** One frozen replay case: stdin in, exit code and stdout out. seed_lines and rows are
  * optional -- only a history-backed CLI seeds a file before the run and checks appended rows
@@ -126,13 +130,6 @@ export function fixture(fixtures: readonly FixtureCase[], name: string): Fixture
   const found = fixtures.find((entry) => entry.name === name);
   assert.ok(found, `fixture case ${name} exists in the loaded fixtures`);
   return found as FixtureCase;
-}
-
-/** The path a history file named `name` lives at under `home`. Delegates to
- * workflows/_lib/cli.ts's historyPath -- the same function the CLI under test calls -- so a
- * test never hand-joins ".claude"/"history" a second time. */
-export function historyPath(home: string, name: string): string {
-  return cliHistoryPath(home, name);
 }
 
 /** Writes `lines` (each newline-terminated) to the history file named `name` under `home`,

--- a/workflows/_lib/tests/_retirement.ts
+++ b/workflows/_lib/tests/_retirement.ts
@@ -1,0 +1,55 @@
+/// <reference types="node" />
+// The retirement-scan core shared by the "no tracked file still names X" tests
+// (gate-retirement.test.ts, record-retirement.test.ts, and -- from a later unit --
+// ts-harness-retirement.test.ts). Each of those files carries its own copy of the same walk:
+// skip docs/decisions/ and .claude/workspace/research/ (kept as historical record, per
+// docs/wiki/retire-rename-procedure.md), skip whatever extra path the caller names, read the
+// rest, and keep the ones a predicate flags. This module gives that walk one home, in the same
+// shape as workflows/_lib/tests/_brace.ts (small, independently testable, named exports; no
+// .ja mirror, per rules/conventions/MIRROR.md -- tests stay English-only).
+//
+// offendersAmong is the pure core: it takes the file list and a reader as arguments instead of
+// calling `git ls-files` / `readFileSync` itself, so a caller test can drive it with a
+// synthetic tree and a reader that fails on demand instead of depending on this repository's
+// real tree (workflows/_lib/tests/retirement.test.ts's T-120-T-122 do exactly that). The
+// git-backed wrapper a real retirement test calls (trackedFiles, offendersFor,
+// assertDetectsAndMisses) is added in a later unit once a caller reads it. The historical-dir
+// constant (docs/decisions/, .claude/workspace/research/) that offendersAmong's real body
+// excludes by default lands with that body in the Green step, once this scaffold has a caller
+// to keep it from being an unused export.
+
+const HISTORICAL_DIRS = ["docs/decisions/", ".claude/workspace/research/"];
+
+function isHistorical(path: string): boolean {
+  return HISTORICAL_DIRS.some((dir) => path.startsWith(dir));
+}
+
+/** The subset of `files` whose content `matches` flags, walked in `files` order and skipping
+ * a historical path, a path in `extraExclusions`, or a path `read` cannot read.
+ *
+ * Scaffold only: this Red-step body satisfies none of retirement.test.ts's T-120-T-122 on
+ * purpose. The Green step gives it its real walk (skip excluded paths, call `read`, catch a
+ * read failure and continue rather than abort, keep a match in `files` order). */
+export function offendersAmong(
+  files: string[],
+  read: (path: string) => string,
+  matches: (content: string, path: string) => boolean,
+  extraExclusions: string[] = [],
+): string[] {
+  const offenders: string[] = [];
+  for (const path of files) {
+    // Skip historical directories and extra exclusions
+    if (isHistorical(path) || extraExclusions.includes(path)) continue;
+
+    let content: string;
+    try {
+      content = read(path);
+    } catch {
+      // File is not decodable as text, skip it without aborting the scan
+      continue;
+    }
+
+    if (matches(content, path)) offenders.push(path);
+  }
+  return offenders;
+}

--- a/workflows/_lib/tests/_retirement.ts
+++ b/workflows/_lib/tests/_retirement.ts
@@ -1,20 +1,20 @@
 /// <reference types="node" />
-// The retirement-scan core shared by the "no tracked file still names X" tests
-// (gate-retirement.test.ts, record-retirement.test.ts, and -- from a later unit --
-// ts-harness-retirement.test.ts). Each of those files carries its own copy of the same walk:
-// skip docs/decisions/ and .claude/workspace/research/ (kept as historical record, per
-// docs/wiki/retire-rename-procedure.md), skip whatever extra path the caller names, read the
-// rest, and keep the ones a predicate flags. This module gives that walk one home, in the same
-// shape as workflows/_lib/tests/_brace.ts (small, independently testable, named exports; no
-// .ja mirror, per rules/conventions/MIRROR.md -- tests stay English-only).
+// The retirement-scan helpers shared by the "no tracked file still names X" tests
+// (gate-retirement.test.ts, record-retirement.test.ts, ts-harness-retirement.test.ts). Each of
+// those files used to carry its own copy of the same walk: skip docs/decisions/ and
+// .claude/workspace/research/ (kept as historical record, per docs/wiki/retire-rename-procedure.md),
+// skip whatever extra path the caller names, read the rest, and keep the ones a predicate flags.
+// This module gives that walk one home, in the same shape as workflows/_lib/tests/_brace.ts
+// (small, independently testable, named exports; no .ja mirror, per rules/conventions/MIRROR.md).
 //
 // offendersAmong is the pure core: it takes the file list and a reader as arguments instead of
-// calling `git ls-files` / `readFileSync` itself, so a caller test can drive it with a
-// synthetic tree and a reader that fails on demand instead of depending on this repository's
-// real tree (workflows/_lib/tests/retirement.test.ts's T-120-T-122 do exactly that).
-// gate-retirement.test.ts and ts-harness-retirement.test.ts are its git-backed callers;
-// record-retirement.test.ts still carries its own copy of this walk and migrates to it in a
-// later unit.
+// calling `git ls-files` / `readFileSync` itself, so retirement.test.ts drives it with a
+// synthetic tree and a reader that fails on demand. trackedFiles is the git-backed list the
+// three retirement tests hand it, cached per process because the tree does not change while a
+// test file runs. assertDetectsAndMisses is the positive control every absence scan pairs with
+// (docs/wiki/absence-test-positive-control-fixture.md).
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 
 const HISTORICAL_DIRS = ["docs/decisions/", ".claude/workspace/research/"];
 
@@ -45,4 +45,40 @@ export function offendersAmong(
     if (matches(content, path)) offenders.push(path);
   }
   return offenders;
+}
+
+const trackedFilesCache = new Map<string, string[]>();
+
+/** Every path `git ls-files` reports under `repoRoot`, in tree order, cached per root. */
+export function trackedFiles(repoRoot: string): string[] {
+  let files = trackedFilesCache.get(repoRoot);
+  if (!files) {
+    files = execFileSync("git", ["ls-files", "-z"], { cwd: repoRoot, encoding: "utf8" })
+      .split("\0")
+      .filter(Boolean);
+    trackedFilesCache.set(repoRoot, files);
+  }
+  return files;
+}
+
+/** Positive control for an absence scan: `matches` flags a fixture line carrying the retired
+ * name, and stops flagging it once that one cue is replaced. Without it the scan stays green
+ * after the needle is mistyped or the predicate is dropped. The fixture is a literal built
+ * here, not the scanned constant, so a typo in the constant cannot flow into both sides. */
+export function assertDetectsAndMisses(
+  matches: (content: string) => boolean,
+  retiredName: string,
+): void {
+  const positiveControl = `# stale doc example: run workflows/${retiredName} < payload.json`;
+  assert.equal(
+    matches(positiveControl),
+    true,
+    `positive control (${retiredName}): a fixture line carrying the cue is detected`,
+  );
+  const masked = positiveControl.replace(retiredName, "REMOVED");
+  assert.equal(
+    matches(masked),
+    false,
+    `positive control (${retiredName}): the same line goes undetected once the cue is removed`,
+  );
 }

--- a/workflows/_lib/tests/_retirement.ts
+++ b/workflows/_lib/tests/_retirement.ts
@@ -11,12 +11,10 @@
 // offendersAmong is the pure core: it takes the file list and a reader as arguments instead of
 // calling `git ls-files` / `readFileSync` itself, so a caller test can drive it with a
 // synthetic tree and a reader that fails on demand instead of depending on this repository's
-// real tree (workflows/_lib/tests/retirement.test.ts's T-120-T-122 do exactly that). The
-// git-backed wrapper a real retirement test calls (trackedFiles, offendersFor,
-// assertDetectsAndMisses) is added in a later unit once a caller reads it. The historical-dir
-// constant (docs/decisions/, .claude/workspace/research/) that offendersAmong's real body
-// excludes by default lands with that body in the Green step, once this scaffold has a caller
-// to keep it from being an unused export.
+// real tree (workflows/_lib/tests/retirement.test.ts's T-120-T-122 do exactly that).
+// gate-retirement.test.ts and ts-harness-retirement.test.ts are its git-backed callers;
+// record-retirement.test.ts still carries its own copy of this walk and migrates to it in a
+// later unit.
 
 const HISTORICAL_DIRS = ["docs/decisions/", ".claude/workspace/research/"];
 
@@ -25,11 +23,7 @@ function isHistorical(path: string): boolean {
 }
 
 /** The subset of `files` whose content `matches` flags, walked in `files` order and skipping
- * a historical path, a path in `extraExclusions`, or a path `read` cannot read.
- *
- * Scaffold only: this Red-step body satisfies none of retirement.test.ts's T-120-T-122 on
- * purpose. The Green step gives it its real walk (skip excluded paths, call `read`, catch a
- * read failure and continue rather than abort, keep a match in `files` order). */
+ * a historical path, a path in `extraExclusions`, or a path `read` cannot read. */
 export function offendersAmong(
   files: string[],
   read: (path: string) => string,
@@ -38,7 +32,6 @@ export function offendersAmong(
 ): string[] {
   const offenders: string[] = [];
   for (const path of files) {
-    // Skip historical directories and extra exclusions
     if (isHistorical(path) || extraExclusions.includes(path)) continue;
 
     let content: string;

--- a/workflows/_lib/tests/cli-fixture.test.ts
+++ b/workflows/_lib/tests/cli-fixture.test.ts
@@ -1,0 +1,136 @@
+/// <reference types="node" />
+// Behavior tests for workflows/_lib/tests/_cli-fixture.ts's own two exports that
+// workflows/build/tests/record.test.ts's fixture replay does not exercise on its own:
+// assertRowShape's key-order flag and assertStdoutShape's placeholder resolution. Both run
+// against workflows/build/record.ts, a real CLI that reads workflows/_lib/cli.ts (U-001), to
+// prove the connection workflows/build/tests/record.test.ts and
+// workflows/assert/tests/record.test.ts (U-002, U-003) will lean on once those two files stop
+// carrying their own copy of this replay. The one FixtureCase below is shaped the same way a
+// record-cases.json entry is (seed_lines, stdin, stdout, rows) and drives both tests through
+// fixture(), seedHistory() and assertRowLine() the same way the eventual record.test.ts pair
+// will, so a seam break in any of those shows up here rather than only after the retirement.
+import assert from "node:assert/strict";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  assertRowLine,
+  assertRowShape,
+  assertStdoutShape,
+  fixture,
+  historyPath,
+  readLines,
+  runCli,
+  seedHistory,
+  withTempHome,
+  type FixtureCase,
+} from "./_cli-fixture.ts";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BUILD_RECORD = join(HERE, "..", "..", "build", "record.ts");
+const HISTORY_NAME = "build-runs.jsonl";
+
+const UUID4HEX = /^[0-9a-f]{32}$/;
+const UTC_ISO8601_Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+const SHAPE_CHECKS: Record<string, RegExp> = {
+  "<uuid4hex>": UUID4HEX,
+  "<utc-iso8601-Z>": UTC_ISO8601_Z,
+};
+
+// A single case, shaped the same way a workflows/build/tests/fixtures/record-cases.json entry
+// is: one pre-existing raw line (kept un-reparsed, the way a seed line the fixture format
+// itself does not normalize is compared), one appended row in the order
+// workflows/build/record.ts writes it (run_id first, then the payload's own keys, then
+// generated_at last), and the stdout line record.ts prints after counting both started rows
+// in the window.
+const FIXTURES: FixtureCase[] = [
+  {
+    name: "seam_started",
+    seed_lines: ['{"run_id": "run-pre", "reason": "started", "plan_quality": false}'],
+    stdin: JSON.stringify({
+      issue: "999",
+      repo: "/abs/target-repo",
+      branch: "feat/fixture-seam",
+      reason: "started",
+      plan_quality: false,
+    }),
+    exit: 0,
+    stdout: `${JSON.stringify({
+      path: "<history-path>",
+      run_id: "<uuid4hex>",
+      started: 2,
+      stops: 0,
+      trigger_met: false,
+      skipped_lines: 0,
+    })}\n`,
+    rows: [
+      '{"run_id": "run-pre", "reason": "started", "plan_quality": false}',
+      {
+        run_id: "<uuid4hex>",
+        issue: "999",
+        repo: "/abs/target-repo",
+        branch: "feat/fixture-seam",
+        reason: "started",
+        plan_quality: false,
+        generated_at: "<utc-iso8601-Z>",
+      },
+    ],
+  },
+];
+
+test(
+  "T-123 the shared replay flags a row whose key order differs from the fixture and passes " +
+    "the same row in fixture order",
+  () => {
+    const testCase = fixture(FIXTURES, "seam_started");
+    withTempHome((home) => {
+      seedHistory(home, HISTORY_NAME, testCase.seed_lines ?? []);
+      const result = runCli(BUILD_RECORD, home, testCase.stdin);
+      assert.equal(result.status, testCase.exit, "seam run: exit code");
+
+      const actualLines = readLines(historyPath(home, HISTORY_NAME));
+      assert.equal(actualLines.length, testCase.rows?.length, "seam run: row count");
+      const [seedRow, appendedRow] = testCase.rows as Array<Record<string, unknown> | string>;
+      assert.doesNotThrow(() => assertRowLine(actualLines[0], seedRow, SHAPE_CHECKS, "seed row"));
+      assert.doesNotThrow(() =>
+        assertRowLine(actualLines[1], appendedRow, SHAPE_CHECKS, "fixture order"),
+      );
+
+      const actual = JSON.parse(actualLines[1]) as Record<string, unknown>;
+      const reordered = { ...(appendedRow as Record<string, unknown>) };
+      const swapped: Record<string, unknown> = {
+        issue: reordered.issue,
+        run_id: reordered.run_id,
+        repo: reordered.repo,
+        branch: reordered.branch,
+        reason: reordered.reason,
+        plan_quality: reordered.plan_quality,
+        generated_at: reordered.generated_at,
+      };
+      assert.throws(() => assertRowShape(actual, swapped, SHAPE_CHECKS, "reordered"));
+    });
+  },
+);
+
+test(
+  "T-124 the shared replay resolves the <history-path> placeholder to the harness's own " +
+    "history file under the temp HOME",
+  () => {
+    const testCase = fixture(FIXTURES, "seam_started");
+    withTempHome((home) => {
+      seedHistory(home, HISTORY_NAME, testCase.seed_lines ?? []);
+      const result = runCli(BUILD_RECORD, home, testCase.stdin);
+      assert.equal(result.status, testCase.exit, "seam run: exit code");
+
+      assert.doesNotThrow(() =>
+        assertStdoutShape(
+          result.stdout,
+          testCase.stdout,
+          { "<history-path>": historyPath(home, HISTORY_NAME) },
+          SHAPE_CHECKS,
+          "placeholder resolution",
+        ),
+      );
+    });
+  },
+);

--- a/workflows/_lib/tests/cli.test.ts
+++ b/workflows/_lib/tests/cli.test.ts
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+// Behavior tests for workflows/_lib/cli.ts: the stdin payload parse/guard pair ported from
+// workflows/build/record.ts's `main`, the history-directory resolver that takes `home` as an
+// explicit argument, and the second-precision UTC timestamp formatter.
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { historyPath, isoTimestamp, parsePayload } from "../cli.ts";
+
+function withTempHome<T>(fn: (home: string) => T): T {
+  const home = mkdtempSync(join(tmpdir(), "cli-test-"));
+  try {
+    return fn(home);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+}
+
+test(
+  "T-116 parsing text that is not JSON yields no payload and the message that starts with " +
+    "the python recorder's prefix Error: unparseable payload:",
+  () => {
+    const result = parsePayload("not json at all");
+    assert.equal(result.payload, null);
+    assert.equal(typeof result.message, "string");
+    assert.ok(
+      result.message !== null && result.message.startsWith("Error: unparseable payload:"),
+      `message does not start with the expected prefix: ${result.message}`,
+    );
+  },
+);
+
+test(
+  "T-117 parsing JSON that is not an object yields no payload and the message " +
+    "Error: payload must be a JSON object",
+  () => {
+    const result = parsePayload("[1, 2, 3]");
+    assert.equal(result.payload, null);
+    assert.equal(result.message, "Error: payload must be a JSON object");
+  },
+);
+
+test(
+  "T-118 the history path for a home and a file name is <home>/.claude/history/<name>, " +
+    "and ensuring it creates that directory under a temp directory",
+  () => {
+    withTempHome((home) => {
+      const path = historyPath(home, "build-runs.jsonl");
+      assert.equal(path, join(home, ".claude", "history", "build-runs.jsonl"));
+      const dir = join(home, ".claude", "history");
+      assert.ok(existsSync(dir), `history dir was not created at ${dir}`);
+      assert.ok(statSync(dir).isDirectory(), `${dir} exists but is not a directory`);
+    });
+  },
+);
+
+test("T-119 the UTC timestamp has second precision and ends with Z", () => {
+  const timestamp = isoTimestamp(new Date("2026-09-08T12:34:56.789Z"));
+  assert.equal(timestamp, "2026-09-08T12:34:56Z");
+  assert.match(timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+});

--- a/workflows/_lib/tests/cli.test.ts
+++ b/workflows/_lib/tests/cli.test.ts
@@ -3,20 +3,11 @@
 // workflows/build/record.ts's `main`, the history-directory resolver that takes `home` as an
 // explicit argument, and the second-precision UTC timestamp formatter.
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, statSync } from "node:fs";
 import { join } from "node:path";
 import test from "node:test";
 import { historyPath, isoTimestamp, parsePayload } from "../cli.ts";
-
-function withTempHome<T>(fn: (home: string) => T): T {
-  const home = mkdtempSync(join(tmpdir(), "cli-test-"));
-  try {
-    return fn(home);
-  } finally {
-    rmSync(home, { recursive: true, force: true });
-  }
-}
+import { withTempHome } from "./_cli-fixture.ts";
 
 test(
   "T-116 parsing text that is not JSON yields no payload and the message that starts with " +

--- a/workflows/_lib/tests/gate-retirement.test.ts
+++ b/workflows/_lib/tests/gate-retirement.test.ts
@@ -10,12 +10,11 @@
 // (docs/decisions/ and .claude/workspace/research/, kept as historical record by that same
 // procedure) live in one place rather than a copy per test file.
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { offendersAmong } from "./_retirement.ts";
+import { assertDetectsAndMisses, offendersAmong, trackedFiles } from "./_retirement.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..", "..");
@@ -31,33 +30,13 @@ function referencesRetiredPath(content: string): boolean {
 }
 
 test("T-014 no tracked file references _lib/gate.py", () => {
-  // Positive control: an absence check stays green even after the scan itself breaks
-  // (e.g. RETIRED_PATH mistyped, the .includes() call dropped) unless it is proven to still
-  // catch a violation. Run the same predicate against a fixture that names the retired path
-  // and confirm it is caught, then against a copy with that one clue removed and confirm the
-  // miss (docs/wiki/absence-test-positive-control-fixture.md).
-  const positiveControl = `# stale doc example: run python3 workflows/${RETIRED_PATH}`;
-  assert.equal(
-    referencesRetiredPath(positiveControl),
-    true,
-    "positive control: a copy carrying the cue is detected",
-  );
-  const masked = positiveControl.replace(RETIRED_PATH, "REMOVED");
-  assert.equal(masked.includes(RETIRED_PATH), false, "the masked copy no longer carries the cue");
-  assert.equal(
-    referencesRetiredPath(masked),
-    false,
-    "positive control: the same violation goes undetected once the cue is removed",
-  );
+  assertDetectsAndMisses(referencesRetiredPath, RETIRED_PATH);
 
-  const tracked = execFileSync("git", ["ls-files", "-z"], { cwd: REPO_ROOT, encoding: "utf8" })
-    .split("\0")
-    .filter(Boolean);
   // This test's own file names RETIRED_PATH to describe what it checks, so it is passed as an
   // extra exclusion; the historical directories (docs/decisions/, .claude/workspace/research/)
   // are offendersAmong's own default, not repeated here.
   const offenders = offendersAmong(
-    tracked,
+    trackedFiles(REPO_ROOT),
     (path) => readFileSync(join(REPO_ROOT, path), "utf8"),
     referencesRetiredPath,
     [SELF_PATH],

--- a/workflows/_lib/tests/gate-retirement.test.ts
+++ b/workflows/_lib/tests/gate-retirement.test.ts
@@ -4,22 +4,24 @@
 // still names the retired path, and the EN / .ja copies of code.js agree on the replacement.
 //
 // Full-tree scan per docs/wiki/retire-rename-procedure.md: update both trees and docs in one
-// change, then confirm zero residual references across git ls-files. A mention under
-// docs/decisions/ is kept as historical record by that same procedure, so it is excluded here
-// rather than counted as a leftover reference.
+// change, then confirm zero residual references across git ls-files. The walk itself is
+// offendersAmong (workflows/_lib/tests/_retirement.ts), shared with record-retirement.test.ts
+// and ts-harness-retirement.test.ts, so the historical-directory exclusions it applies
+// (docs/decisions/ and .claude/workspace/research/, kept as historical record by that same
+// procedure) live in one place rather than a copy per test file.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { offendersAmong } from "./_retirement.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..", "..");
 const SELF_PATH = relative(REPO_ROOT, fileURLToPath(import.meta.url));
 
 const RETIRED_PATH = "_lib/gate.py";
-const HISTORICAL_DIR = "docs/decisions/";
 
 // The one predicate the absence scan below relies on, factored out so the positive
 // control can drive it directly instead of re-deriving its own copy
@@ -51,23 +53,20 @@ test("T-014 no tracked file references _lib/gate.py", () => {
   const tracked = execFileSync("git", ["ls-files", "-z"], { cwd: REPO_ROOT, encoding: "utf8" })
     .split("\0")
     .filter(Boolean);
-  const offenders: string[] = [];
-  for (const path of tracked) {
-    // This test's own file names RETIRED_PATH to describe what it checks, and a DR under
-    // docs/decisions/ keeps the retired name as history rather than as a live reference.
-    if (path === SELF_PATH || path.startsWith(HISTORICAL_DIR)) continue;
-    let content: string;
-    try {
-      content = readFileSync(join(REPO_ROOT, path), "utf8");
-    } catch {
-      continue; // not decodable as text, so it cannot contain the retired path as a string
-    }
-    if (referencesRetiredPath(content)) offenders.push(path);
-  }
+  // This test's own file names RETIRED_PATH to describe what it checks, so it is passed as an
+  // extra exclusion; the historical directories (docs/decisions/, .claude/workspace/research/)
+  // are offendersAmong's own default, not repeated here.
+  const offenders = offendersAmong(
+    tracked,
+    (path) => readFileSync(join(REPO_ROOT, path), "utf8"),
+    referencesRetiredPath,
+    [SELF_PATH],
+  );
   assert.deepEqual(
     offenders,
     [],
-    `files still naming ${RETIRED_PATH} (docs/decisions/ is kept as history, not counted): ${offenders.join(", ")}`,
+    `files still naming ${RETIRED_PATH} (docs/decisions/ and .claude/workspace/research/ are ` +
+      `kept as history, not counted): ${offenders.join(", ")}`,
   );
 });
 

--- a/workflows/_lib/tests/record-retirement.test.ts
+++ b/workflows/_lib/tests/record-retirement.test.ts
@@ -14,17 +14,16 @@
 // basis line for issue #557 (a quote of the pre-retirement asymmetry the issue reported), not a
 // live pointer either, so it is excluded the same way.
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { assertDetectsAndMisses, offendersAmong, trackedFiles } from "./_retirement.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..", "..");
 const SELF_PATH = relative(REPO_ROOT, fileURLToPath(import.meta.url));
 
-const HISTORICAL_DIRS = ["docs/decisions/", ".claude/workspace/research/"];
 const HISTORICAL_FILE = "docs/wiki/supply-list-single-source.md";
 
 // Not the directory-qualified form gate-retirement.test.ts uses for its own retired path: build.js
@@ -46,42 +45,17 @@ test(
     "docs/wiki/supply-list-single-source.md references record.py as a word, and the same " +
     "predicate flags a fixture line carrying it",
   () => {
-    // Positive control: an absence check stays green even after the scan itself breaks (e.g.
-    // RETIRED_PATTERN mistyped, the .test() call dropped) unless it is proven to still catch a
-    // violation. Run the same predicate against a fixture line that names the retired file and
-    // confirm it is caught, then against a copy with that one clue removed and confirm the miss
-    // (docs/wiki/absence-test-positive-control-fixture.md).
-    const positiveControl = "# stale doc example: run python3 record.py < payload.json";
-    assert.equal(
-      referencesRetiredPath(positiveControl),
-      true,
-      "positive control: a fixture line carrying record.py is detected",
-    );
-    const masked = positiveControl.replace("record.py", "REMOVED");
-    assert.equal(
-      referencesRetiredPath(masked),
-      false,
-      "positive control: the same fixture line goes undetected once the cue is removed",
-    );
+    assertDetectsAndMisses(referencesRetiredPath, "record.py");
 
-    const tracked = execFileSync("git", ["ls-files", "-z"], { cwd: REPO_ROOT, encoding: "utf8" })
-      .split("\0")
-      .filter(Boolean);
-    const offenders: string[] = [];
-    for (const path of tracked) {
-      // This test's own file names record.py in comments to describe what it checks, and the
-      // three exclusions above keep the retired name as history rather than as a live reference.
-      if (path === SELF_PATH) continue;
-      if (HISTORICAL_DIRS.some((dir) => path.startsWith(dir))) continue;
-      if (path === HISTORICAL_FILE) continue;
-      let content: string;
-      try {
-        content = readFileSync(join(REPO_ROOT, path), "utf8");
-      } catch {
-        continue; // not decodable as text, so it cannot contain the retired path as a string
-      }
-      if (referencesRetiredPath(content)) offenders.push(path);
-    }
+    // This test's own file names record.py in comments to describe what it checks, and the
+    // #557 basis line keeps the retired name as history rather than as a live reference; the
+    // historical directories are offendersAmong's own default.
+    const offenders = offendersAmong(
+      trackedFiles(REPO_ROOT),
+      (path) => readFileSync(join(REPO_ROOT, path), "utf8"),
+      referencesRetiredPath,
+      [SELF_PATH, HISTORICAL_FILE],
+    );
     assert.deepEqual(
       offenders,
       [],

--- a/workflows/_lib/tests/retirement.test.ts
+++ b/workflows/_lib/tests/retirement.test.ts
@@ -1,0 +1,85 @@
+/// <reference types="node" />
+// Behavior tests for workflows/_lib/tests/_retirement.ts's pure scan core: offendersAmong walks
+// a caller-supplied file list with a caller-supplied reader, so these tests drive it with a
+// synthetic tree instead of this repository's real one. gate-retirement.test.ts and
+// record-retirement.test.ts exercise the git-backed wrapper that a later unit adds on top of
+// this core; T-120-T-122 here are the helper's own tests.
+import assert from "node:assert/strict";
+import test from "node:test";
+import { offendersAmong } from "./_retirement.ts";
+
+test(
+  "T-120 a file whose path starts with a historical directory is not reported even when its " +
+    "content names the retired path",
+  () => {
+    const retiredNeedle = "_lib/legacy-helper.py";
+    const files = ["docs/decisions/DR-0100-example.md", "workflows/build/record.ts"];
+    const contents: Record<string, string> = {
+      "docs/decisions/DR-0100-example.md": `kept as history: ${retiredNeedle}`,
+      "workflows/build/record.ts": `still calls ${retiredNeedle}`,
+    };
+    const read = (path: string): string => contents[path];
+    const matches = (content: string): boolean => content.includes(retiredNeedle);
+
+    const offenders = offendersAmong(files, read, matches);
+
+    assert.deepEqual(
+      offenders,
+      ["workflows/build/record.ts"],
+      "the docs/decisions/ file must be excluded and the live file must still be caught",
+    );
+  },
+);
+
+test(
+  "T-121 a file the caller lists as an extra exclusion is not reported while the same " +
+    "content under another path is reported",
+  () => {
+    const retiredNeedle = "record.py";
+    const excluded = "docs/wiki/supply-list-single-source.md";
+    const files = [excluded, "workflows/build/record.ts"];
+    const contents: Record<string, string> = {
+      [excluded]: `basis line quoting ${retiredNeedle}`,
+      "workflows/build/record.ts": `invokes ${retiredNeedle}`,
+    };
+    const read = (path: string): string => contents[path];
+    const matches = (content: string): boolean => content.includes(retiredNeedle);
+
+    const offenders = offendersAmong(files, read, matches, [excluded]);
+
+    assert.deepEqual(
+      offenders,
+      ["workflows/build/record.ts"],
+      "the caller's extra exclusion must be skipped and the other matching path must still be caught",
+    );
+  },
+);
+
+test(
+  "T-122 the offender list is the set of matching paths in tree order and an unreadable " +
+    "file is skipped rather than aborting the scan",
+  () => {
+    const retiredNeedle = "retired-thing";
+    const files = ["a/one.ts", "b/unreadable.ts", "c/two.ts", "d/no-match.ts"];
+    const contents: Record<string, string> = {
+      "a/one.ts": `names ${retiredNeedle}`,
+      "c/two.ts": `also names ${retiredNeedle}`,
+      "d/no-match.ts": "clean",
+    };
+    const read = (path: string): string => {
+      if (path === "b/unreadable.ts") {
+        throw new Error("EACCES: simulated unreadable file");
+      }
+      return contents[path];
+    };
+    const matches = (content: string): boolean => content.includes(retiredNeedle);
+
+    const offenders = offendersAmong(files, read, matches);
+
+    assert.deepEqual(
+      offenders,
+      ["a/one.ts", "c/two.ts"],
+      "the unreadable file must be skipped without aborting the scan, and matches kept in tree order",
+    );
+  },
+);

--- a/workflows/_lib/tests/retirement.test.ts
+++ b/workflows/_lib/tests/retirement.test.ts
@@ -35,7 +35,11 @@ test(
   "T-121 a file the caller lists as an extra exclusion is not reported while the same " +
     "content under another path is reported",
   () => {
-    const retiredNeedle = "record.py";
+    // Deliberately not the retired recorder script's own filename: record-retirement.test.ts's
+    // T-113 scans every tracked file for that exact name, so spelling it out here (this file
+    // sits outside T-113's exclusion list) would make this fixture a false-positive offender of
+    // its own predicate.
+    const retiredNeedle = "_lib/legacy-tool.py";
     const excluded = "docs/wiki/supply-list-single-source.md";
     const files = [excluded, "workflows/build/record.ts"];
     const contents: Record<string, string> = {

--- a/workflows/_lib/tests/ts-harness-retirement.test.ts
+++ b/workflows/_lib/tests/ts-harness-retirement.test.ts
@@ -5,15 +5,14 @@
 // gate.py's: no tracked file outside docs/decisions/ and .claude/workspace/research/ (kept as
 // historical record, per docs/wiki/retire-rename-procedure.md) still names a retired path. The
 // walk and the historical-directory exclusions are offendersAmong (workflows/_lib/tests/_retirement.ts),
-// shared with gate-retirement.test.ts and record-retirement.test.ts; this file keeps only the
-// tracked-files caching and the positive-control glue that are specific to it.
+// shared with gate-retirement.test.ts and record-retirement.test.ts, as are the tracked-file
+// list and the positive control; this file keeps only its retired paths and their predicate.
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
-import { offendersAmong } from "./_retirement.ts";
+import { assertDetectsAndMisses, offendersAmong, trackedFiles } from "./_retirement.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..", "..");
@@ -23,53 +22,21 @@ function referencesPath(content: string, retiredPath: string): boolean {
   return content.includes(retiredPath);
 }
 
-// The tree does not change while this file's tests run, and T-043 checks 2 retired paths
-// against it, so the git spawn is cached after the first call rather than repeated per path.
-let trackedFilesCache: string[] | null = null;
-function trackedFiles(): string[] {
-  trackedFilesCache ??= execFileSync("git", ["ls-files", "-z"], {
-    cwd: REPO_ROOT,
-    encoding: "utf8",
-  })
-    .split("\0")
-    .filter(Boolean);
-  return trackedFilesCache;
-}
-
 // This test's own file names each retiredPath to describe what it checks, so it is passed as
 // an extra exclusion; the historical directories (docs/decisions/, .claude/workspace/research/)
 // are offendersAmong's own default, not repeated here.
 function offendersFor(retiredPath: string): string[] {
   return offendersAmong(
-    trackedFiles(),
+    trackedFiles(REPO_ROOT),
     (path) => readFileSync(join(REPO_ROOT, path), "utf8"),
     (content) => referencesPath(content, retiredPath),
     [SELF_PATH],
   );
 }
 
-// Positive control: an absence check stays green even after the scan itself breaks (e.g. the
-// retired path mistyped, the .includes() call dropped) unless it is proven to still catch a
-// violation. Run the same predicate against a fixture naming the retired path and confirm it is
-// caught, then against a copy with that one clue removed and confirm the miss.
-function assertDetectsAndMisses(retiredPath: string): void {
-  const positiveControl = `# stale doc example: run node workflows/${retiredPath}`;
-  assert.equal(
-    referencesPath(positiveControl, retiredPath),
-    true,
-    `positive control (${retiredPath}): a copy carrying the cue is detected`,
-  );
-  const masked = positiveControl.replace(retiredPath, "REMOVED");
-  assert.equal(
-    referencesPath(masked, retiredPath),
-    false,
-    `positive control (${retiredPath}): the same violation goes undetected once the cue is removed`,
-  );
-}
-
 test("T-042 no tracked file outside docs/decisions/ and .claude/workspace/research/ references _lib/run-workflow.js", () => {
   const RETIRED_PATH = "_lib/run-workflow.js";
-  assertDetectsAndMisses(RETIRED_PATH);
+  assertDetectsAndMisses((content) => referencesPath(content, RETIRED_PATH), RETIRED_PATH);
 
   const offenders = offendersFor(RETIRED_PATH);
   assert.deepEqual(
@@ -82,7 +49,7 @@ test("T-042 no tracked file outside docs/decisions/ and .claude/workspace/resear
 
 test("T-043 no tracked file outside docs/decisions/ and .claude/workspace/research/ references _lib/codex-run.js or _lib/tests/_brace.js", () => {
   for (const retiredPath of ["_lib/codex-run.js", "_lib/tests/_brace.js"]) {
-    assertDetectsAndMisses(retiredPath);
+    assertDetectsAndMisses((content) => referencesPath(content, retiredPath), retiredPath);
 
     const offenders = offendersFor(retiredPath);
     assert.deepEqual(

--- a/workflows/_lib/tests/ts-harness-retirement.test.ts
+++ b/workflows/_lib/tests/ts-harness-retirement.test.ts
@@ -3,27 +3,22 @@
 // replacements (run-workflow.ts, codex-run.ts, tests/_brace.ts) carry the harness. This file
 // guards the retirement itself, the same way workflows/_lib/tests/gate-retirement.test.ts guards
 // gate.py's: no tracked file outside docs/decisions/ and .claude/workspace/research/ (kept as
-// historical record, per docs/wiki/retire-rename-procedure.md) still names a retired path.
+// historical record, per docs/wiki/retire-rename-procedure.md) still names a retired path. The
+// walk and the historical-directory exclusions are offendersAmong (workflows/_lib/tests/_retirement.ts),
+// shared with gate-retirement.test.ts and record-retirement.test.ts; this file keeps only the
+// tracked-files caching and the positive-control glue that are specific to it.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import { offendersAmong } from "./_retirement.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = join(HERE, "..", "..", "..");
 const SELF_PATH = relative(REPO_ROOT, fileURLToPath(import.meta.url));
 
-const HISTORICAL_DIRS = ["docs/decisions/", ".claude/workspace/research/"];
-
-function isHistorical(path: string): boolean {
-  return HISTORICAL_DIRS.some((dir) => path.startsWith(dir));
-}
-
-// The one predicate the scans below rely on, factored out so the positive control drives it
-// directly instead of re-deriving its own copy
-// (docs/wiki/absence-test-positive-control-fixture.md).
 function referencesPath(content: string, retiredPath: string): boolean {
   return content.includes(retiredPath);
 }
@@ -41,22 +36,16 @@ function trackedFiles(): string[] {
   return trackedFilesCache;
 }
 
+// This test's own file names each retiredPath to describe what it checks, so it is passed as
+// an extra exclusion; the historical directories (docs/decisions/, .claude/workspace/research/)
+// are offendersAmong's own default, not repeated here.
 function offendersFor(retiredPath: string): string[] {
-  const offenders: string[] = [];
-  for (const path of trackedFiles()) {
-    // This test's own file names each retiredPath to describe what it checks, and a doc under
-    // docs/decisions/ or .claude/workspace/research/ keeps the retired name as history rather
-    // than as a live reference.
-    if (path === SELF_PATH || isHistorical(path)) continue;
-    let content: string;
-    try {
-      content = readFileSync(join(REPO_ROOT, path), "utf8");
-    } catch {
-      continue; // not decodable as text, so it cannot contain the retired path as a string
-    }
-    if (referencesPath(content, retiredPath)) offenders.push(path);
-  }
-  return offenders;
+  return offendersAmong(
+    trackedFiles(),
+    (path) => readFileSync(join(REPO_ROOT, path), "utf8"),
+    (content) => referencesPath(content, retiredPath),
+    [SELF_PATH],
+  );
 }
 
 // Positive control: an absence check stays green even after the scan itself breaks (e.g. the

--- a/workflows/assert/record.ts
+++ b/workflows/assert/record.ts
@@ -17,35 +17,24 @@
 // TypeScript port of the Python assert recorder it replaces. Contract: this CLI's own
 // behavior, exercised end to end by workflows/assert/tests/record.test.ts against the frozen
 // fixture workflows/assert/tests/fixtures/record-cases.json.
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { historyPath, isoTimestamp, parsePayload } from "../_lib/cli.ts";
 import { isMainModule } from "../_lib/entry-point.ts";
 
 export function main(): number {
   const raw = readFileSync(0, "utf8");
-  let loaded: unknown;
-  try {
-    loaded = JSON.parse(raw);
-  } catch (error) {
-    process.stderr.write(
-      `Error: unparseable payload: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
+  const { payload, message } = parsePayload(raw);
+  if (payload === null) {
+    process.stderr.write(`${message}\n`);
     return 1;
   }
-  if (typeof loaded !== "object" || loaded === null || Array.isArray(loaded)) {
-    process.stderr.write("Error: payload must be a JSON object\n");
-    return 1;
-  }
-  const payload = loaded as Record<string, unknown>;
 
-  const historyDir = join(homedir(), ".claude", "history");
-  const runsPath = join(historyDir, "assert-runs.jsonl");
-  mkdirSync(historyDir, { recursive: true });
+  const runsPath = historyPath(homedir(), "assert-runs.jsonl");
 
   const row: Record<string, unknown> = {
     ...payload,
-    generated_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    generated_at: isoTimestamp(),
   };
   appendFileSync(runsPath, `${JSON.stringify(row)}\n`);
 

--- a/workflows/assert/tests/record.test.ts
+++ b/workflows/assert/tests/record.test.ts
@@ -5,161 +5,74 @@
 // stdin/stdout/row/exit against it case by case. generated_at is frozen in the fixture as the
 // placeholder <utc-iso8601-Z> because it is minted fresh on every run; that key is compared by
 // shape, everything else by exact value. Unlike workflows/build/record.ts, assert is 1 run 1
-// line: no run_id joins rows and stdout carries only {path}.
+// line: no run_id joins rows and stdout carries only {path}. The replay itself (runCli,
+// withTempHome, seedHistory, readLines, assertRowLine, assertStdoutShape, fixture) lives in
+// workflows/_lib/tests/_cli-fixture.ts, shared with workflows/build/tests/record.test.ts;
+// workflows/_lib/tests/cli-fixture.test.ts covers that shared replay's own key-order and
+// placeholder-resolution behavior directly.
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import {
+  assertRowLine,
+  assertStdoutShape,
+  fixture,
+  historyPath,
+  readLines,
+  runCli,
+  seedHistory,
+  withTempHome,
+  type FixtureCase,
+} from "../../_lib/tests/_cli-fixture.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "..", "record.ts");
+const HISTORY_NAME = "assert-runs.jsonl";
 const FIXTURES = JSON.parse(
   readFileSync(join(HERE, "fixtures", "record-cases.json"), "utf8"),
 ) as FixtureCase[];
-
-interface FixtureCase {
-  name: string;
-  seed_lines: string[];
-  stdin: string;
-  exit: number;
-  stdout: string;
-  rows: Array<Record<string, unknown> | string>;
-}
-
-interface CliRun {
-  status: number | null;
-  stdout: string;
-  stderr: string;
-}
 
 const UTC_ISO8601_Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
 const SHAPE_CHECKS: Record<string, RegExp> = {
   "<utc-iso8601-Z>": UTC_ISO8601_Z,
 };
 
-function runCli(home: string, stdin: string): CliRun {
-  const result = spawnSync(process.execPath, [SCRIPT], {
-    input: stdin,
-    encoding: "utf8",
-    env: { ...process.env, HOME: home, PATH: "" },
-  });
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
-}
-
-function historyPath(home: string): string {
-  return join(home, ".claude", "history", "assert-runs.jsonl");
-}
-
-function seedHistory(home: string, lines: readonly string[]): string {
-  const path = historyPath(home);
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, lines.map((line) => `${line}\n`).join(""));
-  return path;
-}
-
-function readLines(path: string): string[] {
-  if (!existsSync(path)) return [];
-  return readFileSync(path, "utf8")
-    .split("\n")
-    .filter((line) => line.trim() !== "");
-}
-
-function withTempHome<T>(fn: (home: string) => T): T {
-  const home = mkdtempSync(join(tmpdir(), "record-test-"));
-  try {
-    return fn(home);
-  } finally {
-    rmSync(home, { recursive: true, force: true });
-  }
-}
-
-/** Asserts `actual` carries the same keys, in the same order, as `expected`, and that each
- * value matches -- exactly, except a value naming one of SHAPE_CHECKS is checked by regex
- * instead, since generated_at is minted fresh on every run. */
-function assertRowShape(
-  actual: Record<string, unknown>,
-  expected: Record<string, unknown>,
-  label: string,
-): void {
-  assert.deepEqual(Object.keys(actual), Object.keys(expected), `${label}: key order`);
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    const shape = typeof expectedValue === "string" ? SHAPE_CHECKS[expectedValue] : undefined;
-    if (shape) {
-      assert.match(String(actual[key]), shape, `${label}.${key}: shape`);
-    } else {
-      assert.deepEqual(actual[key], expectedValue, `${label}.${key}: value`);
-    }
-  }
-}
-
-/** The fixture's stdout is a single JSON line (or "" for the exit-1 cases), compared the same
- * shape-aware way as a row. "path" is frozen as <history-path> because every run mints its own
- * $HOME; it resolves to this run's historyPath(home). */
-function assertStdoutShape(
-  actualStdout: string,
-  expectedStdout: string,
-  home: string,
-  label: string,
-): void {
-  if (expectedStdout === "") {
-    assert.equal(actualStdout, "", `${label}: stdout`);
-    return;
-  }
-  assert.equal(actualStdout.endsWith("\n"), true, `${label}: stdout ends with a newline`);
-  const expected = JSON.parse(expectedStdout) as Record<string, unknown>;
-  if (expected.path === "<history-path>") expected.path = historyPath(home);
-  assertRowShape(JSON.parse(actualStdout) as Record<string, unknown>, expected, `${label}: stdout`);
-}
-
-/** One appended row, compared against the fixture's row: a raw seed line the fixture kept as
- * an un-reparsed string compares literally, everything else parses as JSON first. */
-function assertRowLine(
-  actualLine: string,
-  expectedRow: Record<string, unknown> | string,
-  label: string,
-): void {
-  if (typeof expectedRow === "string") {
-    assert.equal(actualLine, expectedRow, `${label}: raw line`);
-    return;
-  }
-  assertRowShape(JSON.parse(actualLine) as Record<string, unknown>, expectedRow, label);
-}
-
-function fixture(name: string): FixtureCase {
-  const found = FIXTURES.find((entry) => entry.name === name);
-  assert.ok(found, `fixture case ${name} exists in record-cases.json`);
-  return found as FixtureCase;
-}
-
 test("T-111 every frozen case in record-cases.json reproduces the python recorder's exit code, stdout keys, and the appended row's keys in order, with generated_at compared by shape", () => {
   for (const testCase of FIXTURES) {
     withTempHome((home) => {
-      if (testCase.seed_lines.length > 0) {
-        seedHistory(home, testCase.seed_lines);
+      const seedLines = testCase.seed_lines ?? [];
+      if (seedLines.length > 0) {
+        seedHistory(home, HISTORY_NAME, seedLines);
       }
-      const result = runCli(home, testCase.stdin);
+      const result = runCli(SCRIPT, home, testCase.stdin);
       assert.equal(result.status, testCase.exit, `${testCase.name}: exit code`);
-      assertStdoutShape(result.stdout, testCase.stdout, home, testCase.name);
+      assertStdoutShape(
+        result.stdout,
+        testCase.stdout,
+        { "<history-path>": historyPath(home, HISTORY_NAME) },
+        SHAPE_CHECKS,
+        testCase.name,
+      );
 
-      const actualLines = readLines(historyPath(home));
-      assert.equal(actualLines.length, testCase.rows.length, `${testCase.name}: row count`);
+      const rows = testCase.rows ?? [];
+      const actualLines = readLines(historyPath(home, HISTORY_NAME));
+      assert.equal(actualLines.length, rows.length, `${testCase.name}: row count`);
       actualLines.forEach((line, index) => {
-        assertRowLine(line, testCase.rows[index], `${testCase.name}: row ${index}`);
+        assertRowLine(line, rows[index], SHAPE_CHECKS, `${testCase.name}: row ${index}`);
       });
     });
   }
 });
 
 test("T-112 an unparseable payload exits 1, prints nothing to stdout, starts stderr with the python recorder's message prefix, and leaves no file behind", () => {
-  const testCase = fixture("not_json");
+  const testCase = fixture(FIXTURES, "not_json");
   withTempHome((home) => {
-    const result = runCli(home, testCase.stdin);
+    const result = runCli(SCRIPT, home, testCase.stdin);
     assert.equal(result.status, 1, "not_json: exit code");
     assert.equal(result.stdout, "", "not_json: stdout");
     assert.equal(result.stderr.startsWith("Error: "), true, "not_json: stderr prefix");
-    assert.equal(existsSync(historyPath(home)), false, "not_json: no file written");
+    assert.equal(existsSync(historyPath(home, HISTORY_NAME)), false, "not_json: no file written");
   });
 });

--- a/workflows/build/record.ts
+++ b/workflows/build/record.ts
@@ -30,10 +30,10 @@
 // TypeScript port of the Python build recorder it replaces. Contract: this CLI's own
 // behavior, exercised end to end by workflows/build/tests/record.test.ts against the frozen
 // fixture workflows/build/tests/fixtures/record-cases.json.
-import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { historyPath, isoTimestamp, parsePayload } from "../_lib/cli.ts";
 import { isMainModule } from "../_lib/entry-point.ts";
 
 // Plan-quality stops cluster in a run of recent builds rather than over all history, so the
@@ -122,20 +122,11 @@ export function countPlanQualityStops(path: string): WindowCounts | null {
 
 export function main(): number {
   const raw = readFileSync(0, "utf8");
-  let loaded: unknown;
-  try {
-    loaded = JSON.parse(raw);
-  } catch (error) {
-    process.stderr.write(
-      `Error: unparseable payload: ${error instanceof Error ? error.message : String(error)}\n`,
-    );
+  const { payload, message } = parsePayload(raw);
+  if (payload === null) {
+    process.stderr.write(`${message}\n`);
     return 1;
   }
-  if (typeof loaded !== "object" || loaded === null || Array.isArray(loaded)) {
-    process.stderr.write("Error: payload must be a JSON object\n");
-    return 1;
-  }
-  const payload = loaded as Record<string, unknown>;
 
   const { run_id: suppliedRunId, ...rest } = payload;
   // A build can start and stop within the same second, so a timestamp cannot separate the
@@ -147,15 +138,13 @@ export function main(): number {
       ? suppliedRunId
       : randomUUID().replace(/-/g, "");
 
-  const historyDir = join(homedir(), ".claude", "history");
-  const runsPath = join(historyDir, "build-runs.jsonl");
-  mkdirSync(historyDir, { recursive: true });
+  const runsPath = historyPath(homedir(), "build-runs.jsonl");
 
   const row: Record<string, unknown> = {
     run_id: runId,
     ...DEFAULTS,
     ...rest,
-    generated_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+    generated_at: isoTimestamp(),
   };
   appendFileSync(runsPath, `${JSON.stringify(row)}\n`);
 

--- a/workflows/build/tests/record.test.ts
+++ b/workflows/build/tests/record.test.ts
@@ -4,43 +4,35 @@
 // running the Python recorder itself before it was retired (U-001), and compare the
 // port's stdin/stdout/row/exit against it case by case. run_id and generated_at are frozen in
 // the fixture as the placeholders <uuid4hex> and <utc-iso8601-Z> because both are minted fresh
-// on every run; those two keys are compared by shape, everything else by exact value.
+// on every run; those two keys are compared by shape, everything else by exact value. The
+// replay itself (runCli, withTempHome, seedHistory, readLines, assertRowLine, assertStdoutShape,
+// fixture) lives in workflows/_lib/tests/_cli-fixture.ts, shared with
+// workflows/assert/tests/record.test.ts; workflows/_lib/tests/cli-fixture.test.ts covers that
+// shared replay's own key-order and placeholder-resolution behavior directly.
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { chmodSync, existsSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
+import {
+  assertRowLine,
+  assertStdoutShape,
+  fixture,
+  historyPath,
+  readLines,
+  runCli,
+  seedHistory,
+  withTempHome,
+  type CliRun,
+  type FixtureCase,
+} from "../../_lib/tests/_cli-fixture.ts";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const SCRIPT = join(HERE, "..", "record.ts");
+const HISTORY_NAME = "build-runs.jsonl";
 const FIXTURES = JSON.parse(
   readFileSync(join(HERE, "fixtures", "record-cases.json"), "utf8"),
 ) as FixtureCase[];
-
-interface FixtureCase {
-  name: string;
-  seed_lines: string[];
-  stdin: string;
-  exit: number;
-  stdout: string;
-  rows: Array<Record<string, unknown> | string>;
-}
-
-interface CliRun {
-  status: number | null;
-  stdout: string;
-  stderr: string;
-}
 
 const UUID4HEX = /^[0-9a-f]{32}$/;
 const UTC_ISO8601_Z = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
@@ -49,114 +41,28 @@ const SHAPE_CHECKS: Record<string, RegExp> = {
   "<utc-iso8601-Z>": UTC_ISO8601_Z,
 };
 
-function runCli(home: string, stdin: string): CliRun {
-  const result = spawnSync(process.execPath, [SCRIPT], {
-    input: stdin,
-    encoding: "utf8",
-    env: { ...process.env, HOME: home, PATH: "" },
-  });
-  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
-}
-
-function historyPath(home: string): string {
-  return join(home, ".claude", "history", "build-runs.jsonl");
-}
-
-function seedHistory(home: string, lines: readonly string[]): string {
-  const path = historyPath(home);
-  mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, lines.map((line) => `${line}\n`).join(""));
-  return path;
-}
-
-function readLines(path: string): string[] {
-  if (!existsSync(path)) return [];
-  return readFileSync(path, "utf8")
-    .split("\n")
-    .filter((line) => line.trim() !== "");
-}
-
-function withTempHome<T>(fn: (home: string) => T): T {
-  const home = mkdtempSync(join(tmpdir(), "record-test-"));
-  try {
-    return fn(home);
-  } finally {
-    rmSync(home, { recursive: true, force: true });
-  }
-}
-
-/** Asserts `actual` carries the same keys, in the same order, as `expected`, and that each
- * value matches -- exactly, except a value naming one of SHAPE_CHECKS is checked by regex
- * instead, since run_id and generated_at are minted fresh on every run. */
-function assertRowShape(
-  actual: Record<string, unknown>,
-  expected: Record<string, unknown>,
-  label: string,
-): void {
-  assert.deepEqual(Object.keys(actual), Object.keys(expected), `${label}: key order`);
-  for (const [key, expectedValue] of Object.entries(expected)) {
-    const shape = typeof expectedValue === "string" ? SHAPE_CHECKS[expectedValue] : undefined;
-    if (shape) {
-      assert.match(String(actual[key]), shape, `${label}.${key}: shape`);
-    } else {
-      assert.deepEqual(actual[key], expectedValue, `${label}.${key}: value`);
-    }
-  }
-}
-
-/** The fixture's stdout is a single JSON line (or "" for the exit-1 cases), compared the same
- * shape-aware way as a row. "path" is frozen as <history-path> because every run mints its own
- * $HOME; it resolves to this run's historyPath(home). */
-function assertStdoutShape(
-  actualStdout: string,
-  expectedStdout: string,
-  home: string,
-  label: string,
-): void {
-  if (expectedStdout === "") {
-    assert.equal(actualStdout, "", `${label}: stdout`);
-    return;
-  }
-  assert.equal(actualStdout.endsWith("\n"), true, `${label}: stdout ends with a newline`);
-  const expected = JSON.parse(expectedStdout) as Record<string, unknown>;
-  if (expected.path === "<history-path>") expected.path = historyPath(home);
-  assertRowShape(JSON.parse(actualStdout) as Record<string, unknown>, expected, `${label}: stdout`);
-}
-
-/** One appended row, compared against the fixture's row: a raw seed line the fixture kept as
- * an un-reparsed string compares literally, everything else parses as JSON first. */
-function assertRowLine(
-  actualLine: string,
-  expectedRow: Record<string, unknown> | string,
-  label: string,
-): void {
-  if (typeof expectedRow === "string") {
-    assert.equal(actualLine, expectedRow, `${label}: raw line`);
-    return;
-  }
-  assertRowShape(JSON.parse(actualLine) as Record<string, unknown>, expectedRow, label);
-}
-
-function fixture(name: string): FixtureCase {
-  const found = FIXTURES.find((entry) => entry.name === name);
-  assert.ok(found, `fixture case ${name} exists in record-cases.json`);
-  return found as FixtureCase;
-}
-
 test("T-107 every frozen case in record-cases.json reproduces the python recorder's exit code, stdout keys in order, and the appended rows' keys in order, with run_id and generated_at compared by shape", () => {
   for (const testCase of FIXTURES) {
     withTempHome((home) => {
-      if (testCase.seed_lines.length > 0) {
-        seedHistory(home, testCase.seed_lines);
+      const seedLines = testCase.seed_lines ?? [];
+      if (seedLines.length > 0) {
+        seedHistory(home, HISTORY_NAME, seedLines);
       }
-      const result = runCli(home, testCase.stdin);
+      const result = runCli(SCRIPT, home, testCase.stdin);
       assert.equal(result.status, testCase.exit, `${testCase.name}: exit code`);
-      assertStdoutShape(result.stdout, testCase.stdout, home, testCase.name);
+      assertStdoutShape(
+        result.stdout,
+        testCase.stdout,
+        { "<history-path>": historyPath(home, HISTORY_NAME) },
+        SHAPE_CHECKS,
+        testCase.name,
+      );
 
-      const actualLines = readLines(historyPath(home));
-      assert.equal(actualLines.length, testCase.rows.length, `${testCase.name}: row count`);
+      const rows = testCase.rows ?? [];
+      const actualLines = readLines(historyPath(home, HISTORY_NAME));
+      assert.equal(actualLines.length, rows.length, `${testCase.name}: row count`);
       actualLines.forEach((line, index) => {
-        assertRowLine(line, testCase.rows[index], `${testCase.name}: row ${index}`);
+        assertRowLine(line, rows[index], SHAPE_CHECKS, `${testCase.name}: row ${index}`);
       });
     });
   }
@@ -164,22 +70,22 @@ test("T-107 every frozen case in record-cases.json reproduces the python recorde
 
 test("T-108 an unparseable or non-object payload exits 1, prints nothing to stdout, starts stderr with the python recorder's message prefix, and leaves no file behind", () => {
   for (const name of ["not_json", "non_object_payload"]) {
-    const testCase = fixture(name);
+    const testCase = fixture(FIXTURES, name);
     withTempHome((home) => {
-      const result = runCli(home, testCase.stdin);
+      const result = runCli(SCRIPT, home, testCase.stdin);
       assert.equal(result.status, 1, `${name}: exit code`);
       assert.equal(result.stdout, "", `${name}: stdout`);
       assert.equal(result.stderr.startsWith("Error: "), true, `${name}: stderr prefix`);
-      assert.equal(existsSync(historyPath(home)), false, `${name}: no file written`);
+      assert.equal(existsSync(historyPath(home, HISTORY_NAME)), false, `${name}: no file written`);
     });
   }
 });
 
 test("T-109 a history whose last 20 started runs carry 3 plan-quality stops reports started 20, stops 3 and trigger_met true, and a line that does not parse raises skipped_lines by one", () => {
-  const windowCase = fixture("window_20_trigger_met");
+  const windowCase = fixture(FIXTURES, "window_20_trigger_met");
   withTempHome((home) => {
-    seedHistory(home, windowCase.seed_lines);
-    const result = runCli(home, windowCase.stdin);
+    seedHistory(home, HISTORY_NAME, windowCase.seed_lines ?? []);
+    const result = runCli(SCRIPT, home, windowCase.stdin);
     assert.equal(result.status, 0, "window case: exit code");
     const row = JSON.parse(result.stdout) as Record<string, unknown>;
     assert.equal(row.started, 20, "window case: started");
@@ -187,10 +93,10 @@ test("T-109 a history whose last 20 started runs carry 3 plan-quality stops repo
     assert.equal(row.trigger_met, true, "window case: trigger_met");
   });
 
-  const skipCase = fixture("unparseable_seed_line_skipped");
+  const skipCase = fixture(FIXTURES, "unparseable_seed_line_skipped");
   withTempHome((home) => {
-    seedHistory(home, skipCase.seed_lines);
-    const result = runCli(home, skipCase.stdin);
+    seedHistory(home, HISTORY_NAME, skipCase.seed_lines ?? []);
+    const result = runCli(SCRIPT, home, skipCase.stdin);
     assert.equal(result.status, 0, "skip case: exit code");
     const row = JSON.parse(result.stdout) as Record<string, unknown>;
     assert.equal(row.skipped_lines, 1, "skip case: skipped_lines raised by the malformed line");
@@ -199,13 +105,14 @@ test("T-109 a history whose last 20 started runs carry 3 plan-quality stops repo
 
 test("T-110 a history the process cannot read back still prints path and run_id and exits 0", () => {
   withTempHome((home) => {
-    const path = seedHistory(home, [
+    const path = seedHistory(home, HISTORY_NAME, [
       '{"run_id": "run-pre", "reason": "started", "plan_quality": false}',
     ]);
     chmodSync(path, 0o200); // write-only: append still works, read-back for counting cannot
     let result: CliRun;
     try {
       result = runCli(
+        SCRIPT,
         home,
         JSON.stringify({
           issue: "386",
@@ -236,6 +143,7 @@ test("T-115 a run_id that is not a non-empty string is treated as absent and a f
   for (const supplied of [{}, [], "", 0, null]) {
     withTempHome((home) => {
       const result = runCli(
+        SCRIPT,
         home,
         JSON.stringify({
           issue: "386",
@@ -247,7 +155,7 @@ test("T-115 a run_id that is not a non-empty string is treated as absent and a f
       assert.equal(result.status, 0, `run_id ${JSON.stringify(supplied)}: exit code`);
       const printed = JSON.parse(result.stdout) as Record<string, unknown>;
       assert.match(String(printed.run_id), UUID4HEX, `run_id ${JSON.stringify(supplied)}: minted`);
-      const [row] = readLines(historyPath(home)).map(
+      const [row] = readLines(historyPath(home, HISTORY_NAME)).map(
         (line) => JSON.parse(line) as Record<string, unknown>,
       );
       assert.equal(


### PR DESCRIPTION
## What & Why

build/assert の record.ts 2 本は stdin の読み込み・object guard・exit 1 の stderr・history dir・秒精度 timestamp を `workflows/_lib/cli.ts` から読み、fixture 再生と retirement 走査はそれぞれ 1 つの helper が担う。cli.ts は call site 2 の DRY であって #629〜#634 の型ではない。後続スライスが写すのは fixture 再生 (CLI を stdin/argv で起動し、exit と stdout を placeholder つきで凍結 case と照合する) で、その helper は record 固有部を持たない形にする。

## Review focus

- `workflows/_lib/tests/_retirement.ts`: `offendersAmong` (純関数の走査)、`trackedFiles(repoRoot)` (root ごとに cache した `git ls-files -z`)、`assertDetectsAndMisses(matches, retiredName)` (fixture は引数の literal から組む陽性対照) の 3 export を、retirement テスト 3 本 (gate / ts-harness / record) が同じ形で呼ぶ。record の needle を `recordX` に変える変異で陽性対照が赤になることを確認済み
- `workflows/_lib/tests/_cli-fixture.ts`: 中核は `runCli(script, home, stdin, argv = [])` と `FixtureCase.argv?` で argv CLI (#631 の validate-issue-body のような形) も再生できる。record 層 (`historyPath` / `seedHistory` / `readLines` / `assertRowLine`) はその上に載る
- `workflows/_lib/cli.ts` の `historyPath(home, name)` は home を引数に取る純関数で、record.ts 2 本が `homedir()` を渡す。テストと harness は temp dir を渡すだけで `process.env.HOME` を触らない

## Design Decisions

- `parsePayload` は `hooks/_lib/hook_payload.ts` の `parse` (失敗時に `{}` へ fail open する) を再利用しない。build/assert の record.ts は不正な payload で exit 1 させる契約のため、再利用すると空の row を静かに書いてしまう
- `historyPath` は `home` を `process.env.HOME`/`homedir()` から自分で読まず、明示引数として受け取る。テストや #666 のハーネスが実 HOME に触れずに temp dir を指せるようにする選択

## How to Test

1. `npx tsc && node --test $(find workflows -name "*.test.*")` を実行する
2. 486 件全て pass すること
3. `npx oxlint .` を実行し、exit 0 で diagnostics が 0 件であること
4. `npx knip` を任意実行し exit 0 を確認する (CI には未配線で、手実行のみが検査経路)


---

_下は build workflow の自動検証結果。plan との突合までで、コードの欠陥を探すレビューはしていない。PR の本筋からは外れるので任意だが、status 行の逸脱件数が非ゼロなら見る。_

Closes #662

_build は 6 unit をすべて commit し、seam U-006 の official Red gate も `gate_did_not_report` にならず Green まで進んだ (#659 と #664 の実機確認)。conformance が挙げた 4 件 (record-retirement.test.ts が独自走査のまま / ts-harness と gate の trackedFiles と陽性対照が未共有 / fixture 中核が stdin 専用 / `_retirement.ts` の later-unit 語り) は commit 26e266fa で閉じた。「テストとして見つからない plan の言明」8 件は、テスト名が `<home>` などの記号を含むために照合が外れたもので、9 本とも cli.test.ts / retirement.test.ts / cli-fixture.test.ts に実在し pass している。26e266fa 時点: tests 501 pass / knip exit 0 / oxlint warning 0 / CI success。_

<details>
<summary><code>verify tests=pass gates=pass</code> · <code>scope-deviations 0</code> · <code>missing-tests 8</code> · <code>untouched-plan-files 1</code> · <code>conformance 4 (1 high)</code> · <code>structure 1</code></summary>

**実機確認 (merge 前に実施)**
- [ ] U-006 の後に `npx knip` を走らせ exit 0 を確認する。knip は CI に配線されておらず、gates hook (書き込みごと) と手実行だけが検査経路。cli.ts/`_cli-fixture.ts`/`_retirement.ts` に読み手の無い export が残っていないことをここで見る
- [ ] U-002 の後に `hooks/_lib/tests/mirror_prose_test.py` を 1 回走らせ、`.ja/workflows/_lib/cli.ts` の comment が日本語として拾われることを確認する
- [ ] `build.behavior.test.js` の T-008/T-009/T-011 と `assert.record.seam.test.js` の T-016 は実 record.ts を起動する。test_command の中で走るが、U-002/U-003 の後に `not ok` が無いことを個別に確認する

**一度も変更されていない plan の files**
- `workflows/_lib/tests/record-retirement.test.ts`

**テストとして見つからない plan の言明**
- parsing text that is not JSON yields no payload and the message that starts with the python recorder's prefix Error: unparseable payload:
- parsing JSON that is not an object yields no payload and the message Error: payload must be a JSON object
- the history path for a home and a file name is <home>/.claude/history/<name>, and ensuring it creates that directory under a temp directory
- a file whose path starts with a historical directory is not reported even when its content names the retired path
- a file the caller lists as an extra exclusion is not reported while the same content under another path is reported
- the offender list is the set of matching paths in tree order and an unreadable file is skipped rather than aborting the scan
- the shared replay flags a row whose key order differs from the fixture and passes the same row in fixture order
- the shared replay resolves the <history-path> placeholder to the harness's own history file under the temp HOME

**Issue 適合性 (独立レビュー)**
- `[high] missing` record-retirement.test.tsは依然として独自のファイル走査を手書きしており(独自のHISTORICAL_DIRS/HISTORICAL_FILE定数、独自のexecFileSync('git','ls-files',...)呼び出し、70-84行目の独自のtry/catch付きfor-loop)、offendersAmongを呼んでいない。これはこの差分中で最悪のギャップである。プランが指定する3つのretirementテスト(gate-retirement、record-retirement、ts-harness-retirement)のうち移行済みは2つのみで、issueが除去対象とする独自のスキャン+除外リストのコピー3件のうち1件が未変更のまま残っている。実装者自身が_retirement.tsに残したコメント("record-retirement.test.ts still carries its own copy of this walk and migrates to it in a later unit")は、この逸脱を本PRで解消せずに説明するにとどまっている。
  `workflows/_lib/tests/record-retirement.test.ts:23-91 (vs workflows/_lib/tests/_retirement.ts's offendersAmong)` · spec: U-004 contract: "T-120〜T-122 は helper 自身のテストとして retirement.test.ts に置く。Red step はこの 2 ファイルだけを足す。Green step で helper を実装し、record-retirement.test.ts を付け替える。"
- `[medium] missing` ts-harness-retirement.test.tsは依然としてtrackedFiles(独自のキャッシュとexecFileSync呼び出しを含む)、offendersFor、assertDetectsAndMissesをローカルに定義している。この3つはいずれもworkflows/_lib/tests/_retirement.tsへoffendersAmongと並ぶnamed exportとして移されていない。その結果、git ls-files走査はリポジトリ内で依然として二重に書かれている(ここと、gate-retirement.test.ts:53-55のインライン記述)。これはU-004が1箇所に集約する対象としていた重複そのものである。
  `workflows/_lib/tests/ts-harness-retirement.test.ts:28-55` · spec: U-004 contract: "ts-harness-retirement.test.ts の trackedFiles (cache つき git ls-files -z) と offendersFor と assertDetectsAndMisses を _brace.ts と同じ形の named export へ写す。"
- `[medium] missing` runCli(scriptPath, home, stdin)はstdinのみでCLIを起動し、argvパラメータを受け取らない。FixtureCaseにもargvフィールドがなく、そのためコアはプランが定める成果が要求するargvベースのCLIを再生できない。両方のrecord.ts CLIはstdin専用であるため、このギャップは本PR自体のテストからは見えない。しかしU-006の契約は、消費者が存在するかどうかに関わらずコアがargv対応であることを明示的に要求している。
  `workflows/_lib/tests/_cli-fixture.ts:58-65 (runCli), :41-48 (FixtureCase)` · spec: U-006: "helper の中核は record 固有部を持たず、#631 の validate-issue-body のような argv CLI の fixture も同じ形で再生できる。" / contract: "中核は「CLI を stdin/argv で temp HOME の下に起動し、exit と stdout を凍結 case と placeholder の shape check つきで照合する」だけで"
- `[low] scope_creep` 作業ツリーに2件の未追跡research文書が存在する(issueの着手順分析とリポジトリ全体の重複/陳腐化監査)。どちらのパスもU-001〜U-006の各unitのfilesリストに現れない。両文書とも本レビューの作業より前から存在し、issueが対象とするcli.ts/retirement/fixture-replayの統合とは主題が無関係である。
  `.claude/workspace/research/2026-09-06-typescript-migration-issue-pickup-order.md, .claude/workspace/research/2026-09-06-repo-redundancy-test-staleness-residue-audit.md` · spec: Scope: "In scope: `## Plan` の各 unit の files"

**参照モジュールからの構造逸脱**
- `[convention]` _retirement.tsは1行目に`/// <reference types="node" />`を持つが、importは1つもなくNodeのbuiltinにも触れていない(offendersAmongは`read`をパラメータとして受け取り、配列/文字列のプリミティブのみを使う)。定めた規約では、このディレクティブは"Node builtinsを使う.tsファイル"にスコープされる(gate.ts:38-41は、@types/nodeを必要とするファイルでtsconfigの`types`配列が欠けている問題を閉じるためだと理由を述べている)。同じ形(純粋なtests/_-prefixedヘルパーでNode importなし)の正確な参照対象である_brace.tsにはこのディレクティブがない。そのため_retirement.tsは、正当化するNode surfaceがないまま自身の参照先の規約から逸脱している。
  `workflows/_lib/tests/_retirement.ts:1` · ref: workflows/_lib/tests/_brace.ts (no directive; same tests/_-prefixed pure-helper shape)

**異常 (Red 未確認)**
- U-001 (scope-cut): readPayload()は、workflows/build/record.tsの`main`が呼び出すことになるparsePayloadの薄いラッパーで、fd 0を読み取りstderrに書き込む。このunitではまだ呼び出し元がないため、exportしていない。workflows/build/record.ts(およびその.jaミラー)をcli.tsに配線する作業は、プラン自身のrulesノートでU-002として明示的に段階分けされている。exportしても呼び出し元がなければ、本リポジトリのknip gateがwrite時に失敗する。consumeするrecord.tsのリファクタリングと合わせて、U-002で実装する。
- U-001 (commit-unverified): コミットメッセージ本文が宣言されたブロックと一致しない／件名が<type>(<scope>): <description>形式になっていない
- U-002 (commit-unverified): コミットメッセージ本文が宣言されたブロックと一致しない／件名が<type>(<scope>): <description>形式になっていない
- U-003 (commit-unverified): コミットメッセージ本文が宣言されたブロックと一致しない／件名が<type>(<scope>): <description>形式になっていない
- U-004 (no-red): gate_did_not_report: Redキャリブレーションゲートの下でスイートが失敗しなかった。
  <details><summary>根拠 8 件</summary>

  - workflows/_lib/tests/_retirement.ts:20-30 (offendersAmong scaffold, `return [files, read, matches, extraExclusions].length > 4 ? [] : [];`)
  - workflows/_lib/tests/retirement.test.ts:11-79 (T-120/T-121/T-122 test bodies)
  - node --test output: '1..484' / '# tests 484' / '# pass 481' / '# fail 3'
  - node --test output: 'not ok 72 - T-120 ...' with AssertionError deepStrictEqual expected ['workflows/build/record.ts'] actual []
  - node --test output: 'not ok 73 - T-121 ...' with AssertionError deepStrictEqual expected ['workflows/build/record.ts'] actual []
  - node --test output: 'not ok 74 - T-122 ...' with AssertionError deepStrictEqual expected ['a/one.ts','c/two.ts'] actual []
  - `npx tsc` exited with no type errors printed before the node --test run
  - `git status --short` shows only workflows/_lib/tests/_retirement.ts and workflows/_lib/tests/retirement.test.ts as new files (plus pre-existing unrelated untracked research docs); record-retirement.test.ts unmodified

  </details>
- U-004 (commit-unverified): コミットメッセージ本文が宣言されたブロックと一致しない／件名が<type>(<scope>): <description>形式になっていない
- U-005 (scope-cut): T-113(record-retirement.test.ts)はred状態のままである。原因はU-004のretirement.test.tsのfixtureが文字列"record.py"を文字通り含んでおり、record-retirement.test.tsのword-boundaryスキャンがこれを検出する既存の失敗である。修正にはworkflows/_lib/tests/retirement.test.tsまたはworkflows/_lib/tests/record-retirement.test.tsの編集が必要だが、どちらも本unitのtarget_files(["workflows/_lib/tests/gate-retirement.test.ts","workflows/_lib/tests/ts-harness-retirement.test.ts"])に含まれない。git-stashによるbisectionで、この失敗が本unitの変更より前から存在し、その影響を受けていないことを確認した。／record-retirement.test.tsは、_retirement.tsのoffendersAmongを呼び出すよう実際には切り替えられていない(U-004がすでにこれを行ったという契約上の前提に反する)。そのファイルは本unit(U-005)のtarget_filesに含まれないため、修正は本unitのスコープ外である。
- U-005 (commit-unverified): unitスコープ外のパスがコミットされている: workflows/_lib/tests/retirement.test.ts／コミットメッセージ本文が宣言されたブロックと一致しない／件名が<type>(<scope>): <description>形式になっていない
- U-006 (commit-unverified): コミットメッセージ本文が宣言されたブロックと一致しない／件名が<type>(<scope>): <description>形式になっていない

</details>

