### PR TITLE
fix(workflows): shim が先に書いた stdout からも gate レポートを読む

### DIFF
--- a/.ja/workflows/code.js
+++ b/.ja/workflows/code.js
@@ -124,13 +124,33 @@ const relayStdout = async (unit, label, command) => {
 
 const gateScript = bundled("workflows/_lib/gate.ts");
 
-const parsedReport = (stdout) => {
+const gateObject = (text) => {
   try {
-    const report = JSON.parse(stdout);
+    const report = JSON.parse(text);
     return report && typeof report.verdict === "string" ? report : null;
   } catch {
     return null;
   }
+};
+
+// コマンドはユーザーのログインシェルの下で走り、コマンド自身より先に shim が同じストリームへ書く。
+// worktree の中では mise が `mise WARN tracking config` の 1 行をレポートの前に出力し、JSON.parse が
+// stdout 全体を拒んで unit が gate_did_not_report で止まった (#641 U-002)。gate.ts はレポートを
+// pretty-print するので、文書は `{` だけの行で開き、`}` だけの最後の行で閉じる。開始行ごとに前から
+// 順に parse をやり直すので、戻るのは最も外側のオブジェクトになる。
+const parsedReport = (stdout) => {
+  const direct = gateObject(stdout);
+  if (direct) return direct;
+  const lines = stdout.split(/\r\n|\r|\n/);
+  let end = lines.length - 1;
+  while (end >= 0 && lines[end].trim() !== "}") end -= 1;
+  if (end < 0) return null;
+  for (let start = 0; start < end; start += 1) {
+    if (lines[start].trim() !== "{") continue;
+    const found = gateObject(lines.slice(start, end + 1).join("\n"));
+    if (found) return found;
+  }
+  return null;
 };
 
 // レポートは agent を経由して戻り、agent は {stdout, stderr} の schema を埋める。コマンドの出力が

--- a/workflows/code.js
+++ b/workflows/code.js
@@ -122,13 +122,34 @@ const relayStdout = async (unit, label, command) => {
 
 const gateScript = bundled("workflows/_lib/gate.ts");
 
-const parsedReport = (stdout) => {
+const gateObject = (text) => {
   try {
-    const report = JSON.parse(stdout);
+    const report = JSON.parse(text);
     return report && typeof report.verdict === "string" ? report : null;
   } catch {
     return null;
   }
+};
+
+// The command runs under the user's login shell, and a shim writes to that stream before the
+// command does: inside a worktree, mise printed one `mise WARN tracking config` line ahead of
+// the report and JSON.parse rejected the whole stdout, stopping the unit as gate_did_not_report
+// (#641 U-002). gate.ts pretty-prints its report, so the document opens on a line holding `{`
+// alone and closes on the last line holding `}` alone. The parse is retried from each opening
+// line, earliest first, so the outermost object is the one that comes back.
+const parsedReport = (stdout) => {
+  const direct = gateObject(stdout);
+  if (direct) return direct;
+  const lines = stdout.split(/\r\n|\r|\n/);
+  let end = lines.length - 1;
+  while (end >= 0 && lines[end].trim() !== "}") end -= 1;
+  if (end < 0) return null;
+  for (let start = 0; start < end; start += 1) {
+    if (lines[start].trim() !== "{") continue;
+    const found = gateObject(lines.slice(start, end + 1).join("\n"));
+    if (found) return found;
+  }
+  return null;
 };
 
 // The report crosses back through an agent, which fills a {stdout, stderr} schema. With the

--- a/workflows/code/tests/code.gate.test.js
+++ b/workflows/code/tests/code.gate.test.js
@@ -263,6 +263,28 @@ test("a Green gate whose courier returns unparseable output is a stop, not a pas
   );
 });
 
+// A shim writes to the same stream ahead of the command: inside a worktree, mise prefixed the
+// report with one `mise WARN tracking config` line and the unit stopped as gate_did_not_report
+// (#641 U-002).
+test("a gate report a shell shim printed one line ahead of still carries the unit forward", async () => {
+  const { result } = await runWorkflow(codeJs, {
+    args: { plan, repo: "/abs/repo", verify: true },
+    stubs: {
+      agent: (prompt, opts) => {
+        const key = (opts.label ?? "").split(":")[0];
+        if (key === "gate-green")
+          return {
+            stdout: `mise WARN  tracking config: failed to ln -sf\n${JSON.stringify(gateReport(), null, 2)}\n`,
+            stderr: "",
+          };
+        return stub()(prompt, opts);
+      },
+    },
+  });
+  assert.equal(result.stopped, undefined, "the report behind the warning line was read");
+  assert.deepEqual(result.completed, ["U-1"]);
+});
+
 test("a correction agent that returns nothing stops without re-running the gate", async () => {
   let greenGateCalls = 0;
   const { result } = await runWorkflow(codeJs, {


### PR DESCRIPTION
## What & Why

worktree の中で build を回すと、`mise` が `mise WARN  tracking config: failed to ln -sf ...` の 1 行をコマンド出力の先頭に書く。relay が返す stdout はその行から始まるので、`JSON.parse(stdout)` が全体を拒み、gate は毎回 `gate_did_not_report` を返していた。

#641 U-002 はこれで止まった。gate.ts 自身は同じコマンドを `"verdict": "pass"` と採点しており、Red は成立していた。止めたのは判定でなく読み取りで、`resumeFromRunId` は壊れた読み取り結果をキャッシュから返すので再開でも復旧しない。

## Changes

- `parsedReport` を、stdout 全体の parse に失敗したら文書の開始行から parse し直す形にした
- gate.ts はレポートを pretty-print するので、文書は `{` だけの行で開き `}` だけの最後の行で閉じる。開始行を前から順に試すので、戻るのは最も外側のオブジェクト
- `.ja/workflows/code.js` を canonical として同じ commit でミラーした
- shim の 1 行を前置した stdout で unit が通ることを `code.gate.test.js` に固定した

## Verification

- 新テストは修正前に fail、修正後に pass することを確認済み
- `npx tsc`、CI と同じ scope の `node --test` (914 tests, 0 fail)、`npx oxlint`、`npx knip` すべて green

https://claude.ai/code/session_0124rGJ4dkNsDW9jHdxYsQEF
